### PR TITLE
fix(lock-closed): fix broken policy URL

### DIFF
--- a/github-actions/lock-closed/src/main.ts
+++ b/github-actions/lock-closed/src/main.ts
@@ -32,7 +32,7 @@ async function run(): Promise<void> {
     const days = 30;
     // Standardized Angular Team message for locking issues
     const policyUrl =
-      'https://github.com/angular/angular/blob/67d80f/docs/GITHUB_PROCESS.md#conversation-locking';
+      'https://github.com/angular/angular/blob/8f24bc9443b3872fe095d9f7f77b308a361a13b4/docs/GITHUB_PROCESS.md#conversation-locking';
     const message =
       'This issue has been automatically locked due to inactivity.\n' +
       'Please file a new issue if you are encountering a similar or related problem.\n\n' +


### PR DESCRIPTION
Previously, the policy URL used in the automatic conversation locking comment used a shortened SHA (6 our of 40 chars). Such SHAs only work as long as there is no other SHA in the repo starting with the same chars. Since there are now two SHAs starting with the same 6 chars, the link is broken and resulrts in a 404 error. Example: https://github.com/angular/angular-cli/issues/18058#issuecomment-673948687

This commit fixes the broken link by using the full SHA (40 chars).