### PR TITLE
fix the warning: Warning: Unexpected input(s) 'lock-bot-key'

### DIFF
--- a/github-actions/lock-closed/action.yml
+++ b/github-actions/lock-closed/action.yml
@@ -2,7 +2,7 @@ name: 'Lock Closed Issues'
 description: 'Locks issues that are both closed and inactive'
 author: 'Angular'
 inputs:
-  lock-bot-token:
+  lock-bot-key:
     description: 'A private key for the Lock Bot GitHub app'
     required: true
   locks-per-execution:


### PR DESCRIPTION
**Why**:

To remove this warning from the Github Action:
`Warning: Unexpected input(s) 'lock-bot-key', valid inputs are ['lock-bot-token', 'locks-per-execution']`

(see it happening [here](https://github.com/angular/angular/runs/1614331849?check_suite_focus=true))

**But in the end, it is lock-bot-token or lock-bot-key?**

It is *lock-bot-key* for sure as it shows [here](https://github.com/angular/angular/blob/master/.github/workflows/lock-closed.yml#L15) and [here](https://github.com/gkalpak/dev-infra/blob/master/github-actions/lock-closed/src/main.ts#L47).

**TODO after merging:**

To update the commit hash [here](https://github.com/angular/angular/blob/master/.github/workflows/lock-closed.yml#L13)