### PR TITLE
Improve comment content and comment mechanism

### DIFF
--- a/github-actions/feature-request/action.yml
+++ b/github-actions/feature-request/action.yml
@@ -44,14 +44,16 @@ inputs:
       Thank you for submitting your feature request! Looks like during the polling
       process it didn't collect a sufficient number of votes to move to the next stage.
 
+
       We want to keep Angular rich and ergonomic and at the same time be mindful about
       its scope and learning journey. If you think your request could live outside
       Angular's scope, we'd encourage you to collaborate with the
       [community](https://angular.io/resources?category=community) on publishing it
-      as an open source [package](https://angular.io/guide/creating-libraries)!
+      as an open source [package](https://angular.io/guide/creating-libraries).
+
 
       You can find more details about the feature request process in our
-      [documentation](https://github.com/angular/angular/blob/automation-docs/docs/GITHUB_PROCESS.md#feature-request-process).
+      [documentation](https://github.com/angular/angular/blob/ce8e011a9f7c6bac94292d632b0cc8822f710a66/docs/GITHUB_PROCESS.md#feature-request-process).
   start-voting-comment:
     description: 'Comment to kick voting off.'
     default: >
@@ -59,11 +61,16 @@ inputs:
       upvote. If the request receives more than 20 upvotes, we'll move it
       to our consideration list.
 
+
       You can find more details about the feature request process in our
-      [documentation](https://github.com/angular/angular/blob/automation-docs/docs/GITHUB_PROCESS.md#feature-request-process).
+      [documentation](https://github.com/angular/angular/blob/ce8e011a9f7c6bac94292d632b0cc8822f710a66/docs/GITHUB_PROCESS.md#feature-request-process).
   warn-comment:
     description: 'A warning that the end of voting is approaching.'
-    default: Just a heads up that there are 20 days until the voting process ends.
+    default: >
+      Just a heads up that we kicked off a community voting process for your feature request. There are 20 days until the voting process ends.
+
+      
+      Find more details about Angular's feature request process in our [documentation](https://github.com/angular/angular/blob/ce8e011a9f7c6bac94292d632b0cc8822f710a66/docs/GITHUB_PROCESS.md#feature-request-process).
 runs:
   using: 'node12'
   main: 'lib/bundle.js'

--- a/github-actions/feature-request/action.yml
+++ b/github-actions/feature-request/action.yml
@@ -38,6 +38,9 @@ inputs:
   insufficient-votes-label:
     description: 'Label to add when the `close-when-no-sufficient-votes` is set to false and there are no sufficient number of votes or comments from unique authors.'
     default: 'insufficient votes'
+  limit:
+    description: 'Limits the number of issues we are going to run the action over.'
+    default: -1
   close-comment:
     description: 'Comment to post when closing the issue.'
     default: >

--- a/github-actions/feature-request/lib/bundle.js
+++ b/github-actions/feature-request/lib/bundle.js
@@ -14995,7 +14995,7 @@ var CommentMarkers;
 })(CommentMarkers || (CommentMarkers = {}));
 const run = async (api, config) => {
     const issues = api.query({
-        q: `is:open is:issue label:"${config.featureRequestLabel}" -label:"${config.inBacklogLabel}" -label:"${config.underConsiderationLabel}" sort:created-asc`,
+        q: `is:open is:issue label:"${config.featureRequestLabel}" -label:"${config.inBacklogLabel}" -label:"${config.underConsiderationLabel}" -label:"${config.insufficientVotesLabel}" sort:created-asc`,
     });
     for await (const issue of issues) {
         await processIssue(api, issue, config);
@@ -15021,6 +15021,7 @@ const processIssue = async (githubAPI, githubIssue, config) => {
     // An extra assurance we will not get into a situation where we
     // have issues under consideration / backlog which require votes.
     if (issue.labels.includes(config.inBacklogLabel) ||
+        issue.labels.includes(config.insufficientVotesLabel) ||
         issue.labels.includes(config.underConsiderationLabel) ||
         !issue.labels.includes(config.featureRequestLabel) ||
         !issue.open) {

--- a/github-actions/feature-request/lib/bundle.js
+++ b/github-actions/feature-request/lib/bundle.js
@@ -14997,7 +14997,12 @@ const run = async (api, config) => {
     const issues = api.query({
         q: `is:open is:issue label:"${config.featureRequestLabel}" -label:"${config.inBacklogLabel}" -label:"${config.underConsiderationLabel}" -label:"${config.insufficientVotesLabel}" sort:created-asc`,
     });
+    let limit = config.limit === -1 ? Infinity : config.limit;
     for await (const issue of issues) {
+        if (limit <= 0) {
+            break;
+        }
+        limit--;
         await processIssue(api, issue, config);
     }
 };
@@ -15380,5 +15385,6 @@ run(octokit, {
     warnComment: getInputValue('warn-comment'),
     warnDaysDuration: getInputValue('warn-days-duration'),
     closeWhenNoSufficientVotes: getInputValue('close-when-no-sufficient-votes'),
-    insufficientVotesLabel: getInputValue('insufficient-votes-label')
+    insufficientVotesLabel: getInputValue('insufficient-votes-label'),
+    limit: getInputValue('limit'),
 });

--- a/github-actions/feature-request/src/action.spec.ts
+++ b/github-actions/feature-request/src/action.spec.ts
@@ -201,4 +201,23 @@ describe('feature request action', () => {
     expect(first.labels.indexOf(basicConfig.requiresVotesLabel)).toBe(-1);
     expect(first.comments.length).toBe(0);
   });
+
+  it('should not process (comment, close, or label) issues which are already marked as having insufficient number of votes', async () => {
+    const [first] = basic.issues;
+    first.labels = [basicConfig.featureRequestLabel, basicConfig.insufficientVotesLabel];
+    first.comments.push({
+      author: {
+        name: ''
+      },
+      body: action.comment(action.CommentMarkers.Warn, basicConfig.warnComment),
+      id: 1,
+      timestamp: Date.now() - (basicConfig.closeAfterWarnDaysDuration * 24 * 60 * 60 * 1000)
+    });
+
+    await action.run(basic, basicConfig);
+
+    expect(first.labels.indexOf(basicConfig.requiresVotesLabel)).toBe(-1);
+    expect(first.comments.length).toBe(1);
+    expect(first.open).toBeTrue();
+  });
 });

--- a/github-actions/feature-request/src/action.ts
+++ b/github-actions/feature-request/src/action.ts
@@ -52,7 +52,7 @@ export interface Config {
 
 export const run = async (api: GitHubAPI, config: Config) => {
   const issues = api.query({
-    q: `is:open is:issue label:"${config.featureRequestLabel}" -label:"${config.inBacklogLabel}" -label:"${config.underConsiderationLabel}" sort:created-asc`,
+    q: `is:open is:issue label:"${config.featureRequestLabel}" -label:"${config.inBacklogLabel}" -label:"${config.underConsiderationLabel}" -label:"${config.insufficientVotesLabel}" sort:created-asc`,
   });
 
   for await (const issue of issues) {
@@ -83,6 +83,7 @@ const processIssue = async (githubAPI: GitHubAPI, githubIssue: GitHubIssueAPI, c
   // have issues under consideration / backlog which require votes.
   if (
     issue.labels.includes(config.inBacklogLabel) ||
+    issue.labels.includes(config.insufficientVotesLabel) ||
     issue.labels.includes(config.underConsiderationLabel) ||
     !issue.labels.includes(config.featureRequestLabel) ||
     !issue.open

--- a/github-actions/feature-request/src/action.ts
+++ b/github-actions/feature-request/src/action.ts
@@ -48,6 +48,10 @@ export interface Config {
   // Alternatively, the bot will just add a `votingFinishedLabel`.
   closeWhenNoSufficientVotes: boolean;
   insufficientVotesLabel: string;
+
+  // Sets the number of issues we want to perform the action over.
+  // Use -1 for all the issues in the repository.
+  limit: number;
 }
 
 export const run = async (api: GitHubAPI, config: Config) => {
@@ -55,7 +59,12 @@ export const run = async (api: GitHubAPI, config: Config) => {
     q: `is:open is:issue label:"${config.featureRequestLabel}" -label:"${config.inBacklogLabel}" -label:"${config.underConsiderationLabel}" -label:"${config.insufficientVotesLabel}" sort:created-asc`,
   });
 
+  let limit = config.limit === -1 ? Infinity : config.limit;
   for await (const issue of issues) {
+    if (limit <= 0) {
+      break;
+    }
+    limit--;
     await processIssue(api, issue, config);
   }
 };

--- a/github-actions/feature-request/src/main.ts
+++ b/github-actions/feature-request/src/main.ts
@@ -44,5 +44,6 @@ run(octokit, {
   warnComment: getInputValue('warn-comment'),
   warnDaysDuration: getInputValue('warn-days-duration'),
   closeWhenNoSufficientVotes: getInputValue('close-when-no-sufficient-votes'),
-  insufficientVotesLabel: getInputValue('insufficient-votes-label')
+  insufficientVotesLabel: getInputValue('insufficient-votes-label'),
+  limit: getInputValue('limit'),
 })


### PR DESCRIPTION
- Add more context in the heads up comment for old issues
- Make sure we don't comment twice on issues with insufficient number of votes
- Set a limit configuration property to allow us go through only a limited number of issues