### PR TITLE
Update browsers provided by dev-infra and introduce fallback mirror URLs to reduce flakiness

### DIFF
--- a/bazel/browsers/README.md
+++ b/bazel/browsers/README.md
@@ -14,35 +14,40 @@ The process of updating the Chrome or Firefox version is not straightforward, bu
 
 ## Updating Chromium
 
-1. Visit https://chromium.woolyss.com/ and note the version (commit position) of the latest stable version.
+1. Run `yarn ts-node dev-infra/bazel/browsers/chromium/find-stable-revision-for-all-platforms.ts`
 
-   For example, "Google Chrome 83.0.4103.97 (756066) • Wednesday, 3 Jun 2020".
-   Alternatively, you can look in https://omahaproxy.appspot.com/.
+2. Inspect the console output which looks like the followed:
 
-2. Find the closest commit position number available for each platform in chromium-browser-snapshots: https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html
+```
+Release Info: https://storage.googleapis.com/chromium-find-releases-static/index.html#r885453
+Click on the link above to determine the Chromium version number.
 
-   For example:
+MAC:       https://storage.googleapis.com/chromium-browser-snapshots/Mac/885453/chrome-mac.zip
+                0c7ed37b2128c992d5563a5b54d2c2790ce4872d2004b298ca073c7db4cc3f58
+           https://storage.googleapis.com/chromium-browser-snapshots/Mac/885453/chromedriver_mac64.zip
+                fc5150742c045b12ec0a138365b87be3d4216a52bf6b65c914325e941a3c8af7
 
-   - https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Linux_x64/756066/
-   - https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Mac/756053/
-   - https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Win/756065/
+WINDOWS:   https://storage.googleapis.com/chromium-browser-snapshots/Win/885453/chrome-win.zip
+                2a78bc9331a9fd7d1153e9e87cad85948853d4e37427d053dc88887ac9774a69
+           https://storage.googleapis.com/chromium-browser-snapshots/Win/885453/chromedriver_win32.zip
+                bdde7e7aa6349dd0e6e185c07c2fdef4a8f60739eacd79ee49c175390231be20
 
-   You can download Chromium for your local platform and double check that the `--version` matches up with what you expect.
+LINUX:     https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/885453/chrome-linux.zip
+                ac5d11ff66698cb29ece33f8a38de011d2384c609123f421b771aafeea87f679
+           https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/885453/chromedriver_linux64.zip
+                aa38374059252bb7896d79ac7bb4b3ee3eca84cfa5641f432e05bba5f04c01a2
 
-   For example:
+```
 
-   ```bash
-   $ ~/Downloads/chrome-mac/Chromium.app/Contents/MacOS/Chromium --version
-   Chromium 83.0.4103.0
-   ```
+3. Click on the `Release Info` URL and update version number comments in the `chromium.bzl` file so
+   that it is easier to figure out which version of Chromium is configured.
 
-3. Update the chrome & chrome driver build numbers in `bazel/browsers/chromium/chromium.bzl` and either run `bazel query @org_chromium_chromium_amd64//...` to prompt Bazel to calculate the new `sha256` for each platform binary or determine the new `sha256` values manually.
+4. Update the `chromium` and `chromedriver` repository URLs for all platforms to use the
+   new URLs printed out by the tool. Also make sure to update the SHA256 checksums. The tool prints the
+   new checksums for convenient copy & paste.
 
-   Here is an example with `curl` & `shasum`:
+5. [Upload artifacts to our Google Cloud Storage mirror.](#uploading-mirror-artifacts)
 
-   ```bash
-   curl -L https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/756066/chrome-linux.zip | shasum -a 256
-   ```
 
 ## Puppeteer
 
@@ -88,6 +93,9 @@ platform_http_file(
    curl -L <BROWSER_URL> | shasum -a 256
    ```
 
+3. [Upload artifacts to our Google Cloud Storage mirror.](#uploading-mirror-artifacts)
+
+
 In the same file, you can also update the version of gecko driver (the WebDriver implementation for Firefox browsers).
 
 1. Go to https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html and find a version that is compatible with the used version of Firefox.
@@ -107,7 +115,25 @@ In the same file, you can also update the version of gecko driver (the WebDriver
    For example, replace all occurrences of `0.26.0` with the newer version.
 
 3. Update the `sha256` checksum of the driver archives.
-   You can do this by downloading the artifacts from the URLs you just updated, and then running `shasum` on those files:
-   ```sh
-   curl -L <DRIVER_URL> | shasum -a 256
-   ```
+    You can do this by downloading the artifacts from the URLs you just updated, and then running `shasum` on those files:
+    ```sh
+    curl -L <DRIVER_URL> | shasum -a 256
+    ```
+
+4. [Upload artifacts to our Google Cloud Storage mirror.](#uploading-mirror-artifacts)
+
+
+## Uploading mirror artifacts
+
+1. Download all the artifacts you want to mirror, and upload the artifacts to the
+   `dev-infra-mirror` cloud storage bucket (which serves as a fallback mirror to help with reducing flakiness).
+
+   Note: The `dev-infra-mirror` bucket is part of the team-internal `internal-200822` GCP instance. If you do not
+   have permission to update, please contact a member of the Angular dev-infra team
+
+2. Update the permissions for all uploaded artifacts so that they can be accessed publicly. This can be
+   done by clicking on an uploaded file, then going to `Edit Permissions`. Within the permission dialog
+   you can then add another entity for `Public` with the `allUsers` name, and `Reader` access.
+
+3. Update the fallback `dev-infra-mirror` URLs for your browser archives to point to the newly
+   uploaded files.

--- a/bazel/browsers/README.md
+++ b/bazel/browsers/README.md
@@ -14,7 +14,7 @@ The process of updating the Chrome or Firefox version is not straightforward, bu
 
 ## Updating Chromium
 
-1. Run `yarn ts-node dev-infra/bazel/browsers/chromium/find-stable-revision-for-all-platforms.ts`
+1. Run `yarn ts-node bazel/browsers/chromium/find-stable-revision-for-all-platforms.ts`
 
 2. Inspect the console output which looks like the followed:
 
@@ -129,7 +129,7 @@ In the same file, you can also update the version of gecko driver (the WebDriver
    `dev-infra-mirror` cloud storage bucket (which serves as a fallback mirror to help with reducing flakiness).
 
    Note: The `dev-infra-mirror` bucket is part of the team-internal `internal-200822` GCP instance. If you do not
-   have permission to update, please contact a member of the Angular dev-infra team
+   have permission to update, please contact a member of the Angular dev-infra team.
 
 2. Update the permissions for all uploaded artifacts so that they can be accessed publicly. This can be
    done by clicking on an uploaded file, then going to `Edit Permissions`. Within the permission dialog

--- a/bazel/browsers/chromium/chromium.bzl
+++ b/bazel/browsers/chromium/chromium.bzl
@@ -12,9 +12,12 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromium_amd64",
         licenses = ["notice"],  # BSD 3-clause (maybe more?)
-        sha256 = "36759ed6d151645d00a3a015200334edc70188b422eec51bcaa5790c8e906e27",
-        # 87.0.4280
-        url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/812847/chrome-linux.zip",
+        sha256 = "e2ce3260ad798151b88ee6ce53027533f0a596c311d960a514e82bf87c217ab3",
+        # 93.0.4532.0
+        urls = [
+            "https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/888689/chrome-linux.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/888689/chrome-linux.zip",
+        ],
         named_files = {
             "CHROMIUM": "chrome-linux/chrome",
         },
@@ -23,9 +26,12 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromium_macos",
         licenses = ["notice"],  # BSD 3-clause (maybe more?)
-        sha256 = "e10533c84ef57232975d6bde9cd28fd0354371e9556dda85e01178e6dcd56b93",
-        # 87.0.4280
-        url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/812851/chrome-mac.zip",
+        sha256 = "46093b750f1efe5575bdb0a4dc8a229fbfaf5e1801f19c9480232c6ad3b35330",
+        # 93.0.4532.0
+        urls = [
+            "https://storage.googleapis.com/chromium-browser-snapshots/Mac/888689/chrome-mac.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/888689/chrome-mac.zip",
+        ],
         named_files = {
             "CHROMIUM": "chrome-mac/Chromium.app/Contents/MacOS/chromium",
         },
@@ -34,9 +40,12 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromium_windows",
         licenses = ["notice"],  # BSD 3-clause (maybe more?)
-        sha256 = "40d0dec1892d729db2f7d8f27feff762b070a02f04d4e14f4e37b97d6b7c3c8f",
-        # 87.0.4280
-        url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win/812822/chrome-win.zip",
+        sha256 = "27398cdf31bcb070e60f0339330c4ebd9ff44f62c76b55b39c2b329e0ce63f58",
+        # 93.0.4532.0
+        urls = [
+            "https://storage.googleapis.com/chromium-browser-snapshots/Win/888689/chrome-win.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/888689/chrome-win.zip",
+        ],
         named_files = {
             "CHROMIUM": "chrome-win/chrome.exe",
         },
@@ -45,9 +54,11 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromedriver_amd64",
         licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-        sha256 = "d859f8ecb21e26d3ddaf3f229da695bc86512f4e6c9fe32533af7a8b36783ec5",
-        # 87.0.4280
-        url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/812847/chromedriver_linux64.zip",
+        sha256 = "f898364b4e237101748ef9bb6a44715b3840422270bdca25f0a98eba2eb8d732",
+        urls = [
+            "https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/888689/chromedriver_linux64.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/888689/chromedriver_linux64.zip",
+        ],
         named_files = {
             "CHROMEDRIVER": "chromedriver_linux64/chromedriver",
         },
@@ -56,9 +67,11 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromedriver_macos",
         licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-        sha256 = "aa7a99fa23287725d7108cc07baa94e6f0ef4171ff7b134018387a939a67d93d",
-        # 87.0.4280
-        url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/812851/chromedriver_mac64.zip",
+        sha256 = "c297fa1a3dccdf40cf4c7b67ca302eca135aac09a67dfddc57f25b93cea0835c",
+        urls = [
+            "https://storage.googleapis.com/chromium-browser-snapshots/Mac/888689/chromedriver_mac64.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/888689/chromedriver_mac64.zip",
+        ],
         named_files = {
             "CHROMEDRIVER": "chromedriver_mac64/chromedriver",
         },
@@ -67,9 +80,11 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromedriver_windows",
         licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-        sha256 = "826f2bd0c50b823e7642860ed08cacf69d3756002a71ac30cdd77c68f31d2d24",
-        # 87.0.4280
-        url = "https://commondatastorage.googleapis.com/chromium-browser-snapshots/Win/812822/chromedriver_win32.zip",
+        sha256 = "2f2bd5f090f605797d81a50684daf9e84ffc5d049ca1341c3b9c3801daf37e86",
+        urls = [
+            "https://storage.googleapis.com/chromium-browser-snapshots/Win/888689/chromedriver_win32.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/888689/chromedriver_win32.zip",
+        ],
         named_files = {
             "CHROMEDRIVER": "chromedriver_win32/chromedriver.exe",
         },

--- a/bazel/browsers/chromium/find-stable-revision-for-all-platforms.ts
+++ b/bazel/browsers/chromium/find-stable-revision-for-all-platforms.ts
@@ -1,0 +1,239 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @fileoverview
+ * Script that fetches the latest revision currently in the "stable" channel of Chromium.
+ * It then checks if build artifacts on the CDN exist for that revision. If there are missing
+ * build artifacts, it looks for more recent revisions, starting from the determined revision
+ * in the stable channel, and checks if those have build artifacts. This allows us to determine
+ * a Chromium revision that is as close as possible to the "stable" channel and we have CDN
+ * artifacts available for each supported platform.
+ *
+ * This is needed because Chromium does not build artifacts for every revision. See:
+ * https://github.com/puppeteer/puppeteer/issues/2567#issuecomment-393436282
+ *
+ * Note: An explicit revision can be specified as command line argument. This allows
+ * for finding snapshot builds if a revision is already known. e.g. consider a case
+ * where a specific Chromium bug (needed for the Angular org) is fixed but is ahead
+ * of the current revision in the stable channel. We still may want to update Chromium
+ * to a revision ahead of the specified revision for which snapshot builds exist.
+ */
+
+import {createHash} from 'crypto';
+import fetch from 'node-fetch';
+import * as Ora from 'ora';
+
+/**
+ * Enum describing browser platforms this script considers. The
+ * value for each browser maps to the key being used by the Chromium buildbot.
+ * See: https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html.
+ */
+enum BrowserPlatform {
+  LINUX = 'Linux_x64',
+  MAC = 'Mac',
+  WINDOWS = 'Win',
+}
+
+/** Maps a browser platform to the archive file containing the browser binary. */
+const PlatformBrowserArchiveMap = {
+  [BrowserPlatform.LINUX]: 'chrome-linux.zip',
+  [BrowserPlatform.MAC]: 'chrome-mac.zip',
+  [BrowserPlatform.WINDOWS]: 'chrome-win.zip',
+};
+
+/** Maps a browser platform to the archive file containing the driver. */
+const PlatformDriverArchiveMap = {
+  [BrowserPlatform.LINUX]: 'chromedriver_linux64.zip',
+  [BrowserPlatform.MAC]: 'chromedriver_mac64.zip',
+  [BrowserPlatform.WINDOWS]: 'chromedriver_win32.zip',
+};
+
+const cloudStorageHeadRevisionUrl = `https://storage.googleapis.com/chromium-browser-snapshots/{platform}/LAST_CHANGE`;
+const cloudStorageArchiveUrl =
+  'https://storage.googleapis.com/chromium-browser-snapshots/{platform}/{revision}/{file}';
+
+if (require.main === module) {
+  const explicitStartRevision = Number(process.argv[2]) || null;
+  main(explicitStartRevision).catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}
+
+/**
+ * Entry-point for the script, finding a revision which has snapshot builds for all platforms.
+ * If an explicit start revision has been specified, this function looks for a closest
+ * revision that is available for all platforms. If none has been specified, we look for
+ * a revision that is as close as possible to the revision in the stable release channel.
+ */
+async function main(explicitStartRevision: number | null): Promise<void> {
+  const availableRevision =
+    explicitStartRevision !== null
+      ? await findClosestAscendingRevisionForAllPlatforms(explicitStartRevision)
+      : await findClosestStableRevisionForAllPlatforms();
+
+  if (availableRevision === null) {
+    console.error('Could not find a revision for which builds are available for all platforms.');
+    process.exit(1);
+  }
+
+  console.info('Found a revision for which builds are available for all platforms.');
+  console.info('Printing the URLs and archive checksums:');
+  console.info();
+  // Note: We cannot extract the Chromium version and commit automatically because
+  // this requires an actual browser resolving a manual `window.open` redirect.
+  console.info('Release Info:', await getReleaseInfoUrlForRevision(availableRevision));
+  console.info('Click on the link above to determine the Chromium version number.');
+  console.info();
+
+  for (const platformName of Object.keys(BrowserPlatform)) {
+    const platform = BrowserPlatform[platformName as keyof typeof BrowserPlatform];
+
+    console.info(
+      `${platformName}: `.padEnd(10),
+      getRevisionArchiveUrl(availableRevision, platform, 'browser'),
+    );
+    console.info(
+      ' '.repeat(15),
+      await getSha256ChecksumForPlatform(availableRevision, platform, 'browser'),
+    );
+    console.info(
+      ' '.repeat(10),
+      await getRevisionArchiveUrl(availableRevision, platform, 'driver'),
+    );
+    console.info(
+      ' '.repeat(15),
+      await getSha256ChecksumForPlatform(availableRevision, platform, 'driver'),
+    );
+    console.info();
+  }
+}
+
+/**
+ * Finds a Chromium revision which is as close as possible to the revision currently
+ * in the stable release channel, and for which snapshot builds exist for all platforms.
+ */
+async function findClosestStableRevisionForAllPlatforms(): Promise<number | null> {
+  const stableBaseRevision = await getStableChromiumRevision();
+
+  // Note: We look for revisions with snapshot builds for every platform by searching in
+  // ascending order because going back to older revisions would mean that we use a revision
+  // which might miss fixes that have landed before the determined "stable" revision has been
+  // released. Note that searching for a revision is ascending order is technically also not
+  // ideal because it may contain new regressions, or new APIs, but either way is not ideal here.
+  // It seems better to use a more up-to-date revision, rather than relying on code that has
+  // already been fixed, but we'd accidentally use it then.
+  return findClosestAscendingRevisionForAllPlatforms(stableBaseRevision);
+}
+
+/**
+ * Finds a Chromium revision in ascending order which is as close as possible to
+ * the specified revision and has snapshot builds for all platforms.
+ */
+async function findClosestAscendingRevisionForAllPlatforms(
+  startRevision: number,
+): Promise<number | null> {
+  return lookForRevisionWithBuildsForAllPlatforms(startRevision, await getHeadChromiumRevision());
+}
+
+/**
+ * Looks for revision within the specified revision range for which builds exist for
+ * every platform. This is needed because there are no builds available for every
+ * revision that lands within Chromium. More details can be found here:
+ * https://github.com/puppeteer/puppeteer/issues/2567#issuecomment-393436282.
+ */
+async function lookForRevisionWithBuildsForAllPlatforms(
+  startRevision: number,
+  toRevision: number,
+): Promise<number | null> {
+  const spinner = Ora({}).start('Looking for revision build.');
+  const increment = toRevision >= startRevision ? 1 : -1;
+
+  for (let i = startRevision; i !== toRevision; i += increment) {
+    spinner.text = `Checking: r${i}`;
+
+    const checks = await Promise.all(
+      Object.values(BrowserPlatform).map((p) => isRevisionAvailableForPlatform(i, p)),
+    );
+
+    // If the current revision is available for all platforms, stop
+    // searching and return the current revision.
+    if (checks.every((isAvailable) => isAvailable === true)) {
+      spinner.succeed(`Found revision: r${i}`);
+      return i;
+    }
+  }
+  spinner.fail('No revision found.');
+  return null;
+}
+
+/** Checks if the specified revision is available for the given platform. */
+async function isRevisionAvailableForPlatform(
+  revision: number,
+  platform: BrowserPlatform,
+): Promise<boolean> {
+  // Look for the `driver` archive as this is smaller and faster to check.
+  const response = await fetch(getRevisionArchiveUrl(revision, platform, 'driver'));
+  return response.ok && response.status === 200;
+}
+
+/** Gets the latest revision currently in the `stable` release channel of Chromium. */
+async function getStableChromiumRevision(): Promise<number> {
+  // Omahaproxy is maintained by the Chromium team and can be consulted for determining
+  // the current latest revision in stable channel.
+  // https://chromium.googlesource.com/chromium/chromium/+/refs/heads/trunk/tools/omahaproxy.py.
+  const response = await fetch(`https://omahaproxy.appspot.com/all.json?channel=stable&os=linux`);
+  const revisionStr = (await response.json())[0].versions[0].branch_base_position;
+  return Number(revisionStr);
+}
+
+/** Gets the Chromium release information page URL for a given revision. */
+async function getReleaseInfoUrlForRevision(revision: number): Promise<string | null> {
+  // This is a site used and maintained by Omahaproxy which is owned by the Chromium team.
+  // https://chromium.googlesource.com/chromium/chromium/+/refs/heads/trunk/tools/omahaproxy.py.
+  return `https://storage.googleapis.com/chromium-find-releases-static/index.html#r${revision}`;
+}
+
+/** Determines the latest Chromium revision available in the CDN. */
+async function getHeadChromiumRevision(): Promise<number> {
+  const responses = await Promise.all(
+    Object.values(BrowserPlatform).map((p) => fetch(getPlatformLastChangeFileUrl(p))),
+  );
+  const revisions = await Promise.all(responses.map(async (r) => Number(await r.text())));
+  return Math.max(...revisions);
+}
+
+/** Gets the SHA256 checksum for the platform archive of a specified revision. */
+async function getSha256ChecksumForPlatform(
+  revision: number,
+  platform: BrowserPlatform,
+  archive: 'driver' | 'browser',
+): Promise<string> {
+  const response = await fetch(getRevisionArchiveUrl(revision, platform, archive));
+  const binaryContent = await response.buffer();
+  return createHash('sha256').update(binaryContent).digest('hex');
+}
+
+/** Gets an URL to the `LAST_CHANGE` file for a given platform. */
+function getPlatformLastChangeFileUrl(platform: BrowserPlatform) {
+  return cloudStorageHeadRevisionUrl.replace('{platform}', platform);
+}
+
+/** Gets the CDN archive URL for the given revision and platform. */
+function getRevisionArchiveUrl(
+  revision: number,
+  platform: BrowserPlatform,
+  archive: 'driver' | 'browser',
+): string {
+  const archiveMap = archive === 'driver' ? PlatformDriverArchiveMap : PlatformBrowserArchiveMap;
+  return cloudStorageArchiveUrl
+    .replace('{platform}', platform)
+    .replace('{revision}', `${revision}`)
+    .replace('{file}', archiveMap[platform]);
+}

--- a/bazel/browsers/chromium/find-stable-revision-for-all-platforms.ts
+++ b/bazel/browsers/chromium/find-stable-revision-for-all-platforms.ts
@@ -74,9 +74,9 @@ if (require.main === module) {
  */
 async function main(explicitStartRevision: number | null): Promise<void> {
   const availableRevision =
-    explicitStartRevision !== null
-      ? await findClosestAscendingRevisionForAllPlatforms(explicitStartRevision)
-      : await findClosestStableRevisionForAllPlatforms();
+    explicitStartRevision === null
+      ? await findClosestStableRevisionForAllPlatforms()
+      : await findClosestAscendingRevisionForAllPlatforms(explicitStartRevision);
 
   if (availableRevision === null) {
     console.error('Could not find a revision for which builds are available for all platforms.');
@@ -101,15 +101,12 @@ async function main(explicitStartRevision: number | null): Promise<void> {
     );
     console.info(
       ' '.repeat(15),
-      await getSha256ChecksumForPlatform(availableRevision, platform, 'browser'),
+      getSha256ChecksumForPlatform(availableRevision, platform, 'browser'),
     );
-    console.info(
-      ' '.repeat(10),
-      await getRevisionArchiveUrl(availableRevision, platform, 'driver'),
-    );
+    console.info(' '.repeat(10), getRevisionArchiveUrl(availableRevision, platform, 'driver'));
     console.info(
       ' '.repeat(15),
-      await getSha256ChecksumForPlatform(availableRevision, platform, 'driver'),
+      getSha256ChecksumForPlatform(availableRevision, platform, 'driver'),
     );
     console.info();
   }

--- a/bazel/browsers/firefox/firefox.bzl
+++ b/bazel/browsers/firefox/firefox.bzl
@@ -12,9 +12,12 @@ def define_firefox_repositories():
     browser_archive(
         name = "org_mozilla_firefox_amd64",
         licenses = ["reciprocal"],  # MPL 2.0
-        sha256 = "601e5a9a12ce680ecd82177c7887dae008d8f33690da43be1a690b76563cd992",
-        # Firefox v84.0
-        url = "https://ftp.mozilla.org/pub/firefox/releases/84.0/linux-x86_64/en-US/firefox-84.0.tar.bz2",
+        sha256 = "998607f028043b3780f296eee03027279ef059acab5b50f9754df2bd69ca42b3",
+        # Firefox v90.0.1
+        urls = [
+            "https://ftp.mozilla.org/pub/firefox/releases/90.0.1/linux-x86_64/en-US/firefox-90.0.1.tar.bz2",
+            "https://storage.googleapis.com/dev-infra-mirror/mozilla/firefox/firefox-90.0.1.tar.bz2",
+        ],
         named_files = {
             "FIREFOX": "firefox/firefox",
         },
@@ -23,9 +26,12 @@ def define_firefox_repositories():
     browser_archive(
         name = "org_mozilla_firefox_macos",
         licenses = ["reciprocal"],  # MPL 2.0
-        sha256 = "4c7bca050eb228f4f6f93a9895af0a87473e03c67401d1d2f1ba907faf87fefd",
-        # Firefox v84.0
-        url = "https://ftp.mozilla.org/pub/firefox/releases/84.0/mac/en-US/Firefox%2084.0.dmg",
+        sha256 = "76c1b9c42b52c7e5be4c112a98b7d3762a18841367f778a179679ac0de751f05",
+        # Firefox v90.0.1
+        urls = [
+            "https://ftp.mozilla.org/pub/firefox/releases/90.0.1/mac/en-US/Firefox%2090.0.1.dmg",
+            "https://storage.googleapis.com/dev-infra-mirror/mozilla/firefox/Firefox%2090.0.1.dmg",
+        ],
         named_files = {
             "FIREFOX": "Firefox.app/Contents/MacOS/firefox",
         },
@@ -34,9 +40,12 @@ def define_firefox_repositories():
     browser_archive(
         name = "org_mozilla_geckodriver_amd64",
         licenses = ["reciprocal"],  # MPL 2.0
-        sha256 = "61bfc547a623d7305256611a81ecd24e6bf9dac555529ed6baeafcf8160900da",
-        # Geckodriver v0.28.0
-        url = "https://github.com/mozilla/geckodriver/releases/download/v0.28.0/geckodriver-v0.28.0-linux64.tar.gz",
+        sha256 = "ec164910a3de7eec71e596bd2a1814ae27ba4c9d112b611680a6470dbe2ce27b",
+        # Geckodriver v0.29.1
+        urls = [
+            "https://github.com/mozilla/geckodriver/releases/download/v0.29.1/geckodriver-v0.29.1-linux64.tar.gz",
+            "https://storage.googleapis.com/dev-infra-mirror/mozilla/geckodriver/0.29.1/geckodriver-v0.29.1-linux64.tar.gz",
+        ],
         named_files = {
             "GECKODRIVER": "geckodriver",
         },
@@ -45,9 +54,12 @@ def define_firefox_repositories():
     browser_archive(
         name = "org_mozilla_geckodriver_macos",
         licenses = ["reciprocal"],  # MPL 2.0
-        sha256 = "c288ff6db39adfd5eea0e25b4c3e71bfd9fb383eccf521cdd65f67ea78eb1761",
-        # Geckodriver v0.28.0
-        url = "https://github.com/mozilla/geckodriver/releases/download/v0.28.0/geckodriver-v0.28.0-macos.tar.gz",
+        sha256 = "9929c804ad0157ca13fdafca808866c88815b658e7059280a9f08f7e70364963",
+        # Geckodriver v0.29.1
+        urls = [
+            "https://github.com/mozilla/geckodriver/releases/download/v0.29.1/geckodriver-v0.29.1-macos.tar.gz",
+            "https://storage.googleapis.com/dev-infra-mirror/mozilla/geckodriver/0.29.1/geckodriver-v0.29.1-macos.tar.gz",
+        ],
         named_files = {
             "GECKODRIVER": "geckodriver",
         },


### PR DESCRIPTION
See individual commits.

Port of https://github.com/angular/angular/pull/42932