### PR TITLE
build: configuration ng-dev merge tooling for the repo

### DIFF
--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -1,2 +1,3 @@
 export {format} from './format';
 export {github} from './github';
+export {merge} from './merge';

--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -1,0 +1,19 @@
+import {DevInfraMergeConfig} from '../ng-dev/pr/merge/config';
+
+/** Configuration for merging pull requests into the repo. */
+export const merge: DevInfraMergeConfig['merge'] = async (api) => {
+  return {
+    githubApiMerge: false,
+    claSignedLabel: 'cla: yes',
+    mergeReadyLabel: 'action: merge',
+    caretakerNoteLabel: 'merge note',
+    commitMessageFixupLabel: 'needs commit fixup',
+    labels: [
+      {
+        // Since only one branch is merged into for the repository, all patterns are matching.
+        pattern: /.*/,
+        branches: ['master'],
+      },
+    ],
+  };
+};


### PR DESCRIPTION
Configures the ng-dev pr merge command for the repository.

The merge label used is `action: merge` keeping in line with other repositories,
and no target branches are needed as all PRs are merged into the same branch.
We allow fixups commits to be used as we do not use the github API for merging.