### PR TITLE
build: include generated javascript files for ng-dev tooling to allow for importing

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,11 +7,6 @@ ts_config(
     src = "tsconfig.json",
     visibility = ["//visibility:public"],
 )
-# END-INTERNAL
-
-exports_files(["tsconfig.json"])
-
-# BEGIN-INTERNAL
 
 package_group(
     name = "npm",
@@ -42,8 +37,11 @@ pkg_npm(
     },
     deps = [
         "//bazel:lib",
+        "//ng-dev",
         "//ng-dev:lib",
         "//tslint-rules:lib",
     ],
 )
 # END-INTERNAL
+
+exports_files(["tsconfig.json"])

--- a/ng-dev/BUILD.bazel
+++ b/ng-dev/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "cli.ts",
     ],
     visibility = [
+        "//:npm",
         "//ng-dev:__subpackages__",
     ],
     deps = [

--- a/package.json
+++ b/package.json
@@ -2,10 +2,9 @@
   "name": "@angular/dev-infra-private",
   "version": "0.0.0",
   "bin": {
-    "ng-dev": "./ng-dev/cli.ts"
+    "ng-dev": "./ng-dev/cli-bundle.js"
   },
   "private": true,
-  "main": "./ng-dev/cli-bundle.js",
   "scripts": {
     "prepare": "husky install",
     "ng-dev": "ts-node --transpile-only ./ng-dev/cli.ts"


### PR DESCRIPTION
Including the generated javascript files for the `ng-dev` toolset allows for downstream repos to import the exported items from the code.  When only including the bundled executables, we don't provide proper entry points for accessing the utils/config typings.


Additionally, we update the `bin` to note we would like to run the `-bundle` file rather than the unbundled version.