### PR TITLE
refactor(ng-dev): move breaking change and deprecations to beginning of release notes

### DIFF
--- a/ng-dev/pr/merge/defaults/integration.spec.ts
+++ b/ng-dev/pr/merge/defaults/integration.spec.ts
@@ -34,7 +34,6 @@ describe('default target labels', () => {
     releaseConfig = {
       npmPackages: ['@angular/dev-infra-test-pkg'],
       buildPackages: async () => [],
-      releaseNotes: {},
     };
 
     // The label determination will print warn messages. These should not be

--- a/ng-dev/release/build/build.spec.ts
+++ b/ng-dev/release/build/build.spec.ts
@@ -34,7 +34,6 @@ describe('ng-dev release build', () => {
     spyOn(releaseConfig, 'getReleaseConfig').and.returnValue({
       npmPackages,
       buildPackages,
-      releaseNotes: {},
     });
     await ReleaseBuildCommandModule.handler({json: !!json, stampForRelease: true, $0: '', _: []});
   }

--- a/ng-dev/release/config/index.ts
+++ b/ng-dev/release/config/index.ts
@@ -27,7 +27,7 @@ export interface ReleaseConfig {
   /** The list of github labels to add to the release PRs. */
   releasePrLabels?: string[];
   /** Configuration for creating release notes during publishing. */
-  releaseNotes: ReleaseNotesConfig;
+  releaseNotes?: ReleaseNotesConfig;
 }
 
 /** Configuration for creating release notes during publishing. */

--- a/ng-dev/release/notes/release-notes.ts
+++ b/ng-dev/release/notes/release-notes.ts
@@ -33,7 +33,7 @@ export class ReleaseNotes {
   /** The title to use for the release. */
   private title: string | false | undefined;
   /** The configuration for release notes. */
-  private config: ReleaseNotesConfig = this.getReleaseConfig().releaseNotes;
+  private config: ReleaseNotesConfig = this.getReleaseConfig().releaseNotes ?? {};
 
   protected constructor(public version: semver.SemVer, private commits: CommitFromGitLog[]) {}
 

--- a/ng-dev/release/notes/templates/changelog.ts
+++ b/ng-dev/release/notes/templates/changelog.ts
@@ -11,7 +11,7 @@ export default `
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
 
 <%_
-const breakingChanges = commits.filter(contains('breakingChanges'));
+const breakingChanges = commits.filter(hasBreakingChanges);
 if (breakingChanges.length) {
 _%>
 ## Breaking Changes
@@ -33,7 +33,7 @@ _%>
 _%>
 
 <%_
-const deprecations = commits.filter(contains('deprecations'));
+const deprecations = commits.filter(hasDeprecations);
 if (deprecations.length) {
 _%>
 ## Deprecations

--- a/ng-dev/release/notes/templates/changelog.ts
+++ b/ng-dev/release/notes/templates/changelog.ts
@@ -11,23 +11,6 @@ export default `
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
 
 <%_
-const commitsInChangelog = commits.filter(includeInReleaseNotes());
-for (const group of asCommitGroups(commitsInChangelog)) {
-_%>
-
-### <%- group.title %>
-| Commit | Description |
-| -- | -- |
-<%_
-  for (const commit of group.commits) {
-_%>
-| <%- commitToLink(commit) %> | <%- replaceCommitHeaderPullRequestNumber(commit.header) %> |
-<%_
-  }
-}
-_%>
-
-<%_
 const breakingChanges = commits.filter(contains('breakingChanges'));
 if (breakingChanges.length) {
 _%>
@@ -65,6 +48,23 @@ _%>
 <%- commit.deprecations[0].text %>
 <%_
     }
+  }
+}
+_%>
+
+<%_
+const commitsInChangelog = commits.filter(includeInReleaseNotes());
+for (const group of asCommitGroups(commitsInChangelog)) {
+_%>
+
+### <%- group.title %>
+| Commit | Description |
+| -- | -- |
+<%_
+  for (const commit of group.commits) {
+_%>
+| <%- commitToLink(commit) %> | <%- replaceCommitHeaderPullRequestNumber(commit.header) %> |
+<%_
   }
 }
 _%>

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -11,23 +11,6 @@ export default `
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
 
 <%_
-const commitsInChangelog = commits.filter(includeInReleaseNotes());
-for (const group of asCommitGroups(commitsInChangelog)) {
-_%>
-
-### <%- group.title %>
-| Commit | Description |
-| -- | -- |
-<%_
-  for (const commit of group.commits) {
-_%>
-| <%- commit.shortHash %> | <%- commit.header %> |
-<%_
-  }
-}
-_%>
-
-<%_
 const breakingChanges = commits.filter(contains('breakingChanges'));
 if (breakingChanges.length) {
 _%>
@@ -65,6 +48,23 @@ _%>
 <%- commit.deprecations[0].text %>
 <%_
     }
+  }
+}
+_%>
+
+<%_
+const commitsInChangelog = commits.filter(includeInReleaseNotes());
+for (const group of asCommitGroups(commitsInChangelog)) {
+_%>
+
+### <%- group.title %>
+| Commit | Description |
+| -- | -- |
+<%_
+  for (const commit of group.commits) {
+_%>
+| <%- commit.shortHash %> | <%- commit.header %> |
+<%_
   }
 }
 _%>

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -11,7 +11,7 @@ export default `
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
 
 <%_
-const breakingChanges = commits.filter(contains('breakingChanges'));
+const breakingChanges = commits.filter(hasBreakingChanges);
 if (breakingChanges.length) {
 _%>
 ## Breaking Changes
@@ -33,7 +33,7 @@ _%>
 _%>
 
 <%_
-const deprecations = commits.filter(contains('deprecations'));
+const deprecations = commits.filter(hasDeprecations);
 if (deprecations.length) {
 _%>
 ## Deprecations

--- a/ng-dev/release/publish/test/common.spec.ts
+++ b/ng-dev/release/publish/test/common.spec.ts
@@ -26,11 +26,11 @@ import {
   setupReleaseActionForTesting,
 } from './test-utils/test-utils';
 import {
-  getMockGitClient,
   getTestConfigurationsForAction,
   testReleasePackages,
   testTmpDir,
 } from './test-utils/action-mocks';
+import {getMockGitClient} from './test-utils/git-client-mock';
 
 describe('common release action logic', () => {
   const baseReleaseTrains: ActiveReleaseTrains = {

--- a/ng-dev/release/publish/test/cut-lts-patch.spec.ts
+++ b/ng-dev/release/publish/test/cut-lts-patch.spec.ts
@@ -20,13 +20,10 @@ import {
   expectGithubApiRequestsForStaging,
   expectStagingAndPublishWithCherryPick,
 } from './test-utils/staging-test';
-import {
-  getMockGitClient,
-  getTestConfigurationsForAction,
-  testTmpDir,
-} from './test-utils/action-mocks';
+import {getTestConfigurationsForAction, testTmpDir} from './test-utils/action-mocks';
 import {SandboxGitRepo} from './test-utils/sandbox-testing';
 import {readFileSync} from 'fs';
+import {getMockGitClient} from './test-utils/git-client-mock';
 
 describe('cut an LTS patch action', () => {
   it('should be active', async () => {

--- a/ng-dev/release/publish/test/release-notes/generation.spec.ts
+++ b/ng-dev/release/publish/test/release-notes/generation.spec.ts
@@ -58,6 +58,7 @@ describe('release notes generation', () => {
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
+        | <..> | refactor(cdk/a11y): with breaking change |
         | <..> | fix(cdk/a11y): not yet released #1 |
         ## Special Thanks:
       `);
@@ -82,6 +83,7 @@ describe('release notes generation', () => {
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
+        | <..> | refactor(cdk/a11y): with deprecation |
         | <..> | fix(cdk/a11y): not yet released #1 |
         ## Special Thanks:
       `);
@@ -109,6 +111,7 @@ describe('release notes generation', () => {
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
+        | <..> | refactor(cdk/a11y): with breaking change |
         | <..> | fix(cdk/a11y): not yet released #1 |
         ## Special Thanks:
       `);
@@ -133,6 +136,7 @@ describe('release notes generation', () => {
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
+        | <..> | refactor(cdk/a11y): with deprecation |
         | <..> | fix(cdk/a11y): not yet released #1 |
         ## Special Thanks:
       `);

--- a/ng-dev/release/publish/test/release-notes/generation.spec.ts
+++ b/ng-dev/release/publish/test/release-notes/generation.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {installSandboxGitClient, SandboxGitClient} from '../test-utils/sandbox-git-client';
+import {mkdirSync, rmdirSync} from 'fs';
+import {testTmpDir} from '../test-utils/action-mocks';
+import {getMockGitClient} from '../test-utils/git-client-mock';
+import {GithubConfig} from '../../../../utils/config';
+import {SandboxGitRepo} from '../test-utils/sandbox-testing';
+import {ReleaseNotes} from '../../../notes/release-notes';
+import {ReleaseConfig} from '../../../config';
+import {changelogPattern, parse} from '../test-utils/test-utils';
+
+describe('release notes generation', () => {
+  let releaseConfig: ReleaseConfig;
+  let githubConfig: GithubConfig;
+  let client: SandboxGitClient;
+
+  beforeEach(() => {
+    // Clear the temporary directory used by the sandbox git client. We do not want
+    // the repo state to persist between tests.
+    rmdirSync(testTmpDir, {recursive: true});
+    mkdirSync(testTmpDir);
+
+    releaseConfig = {npmPackages: [], buildPackages: async () => []};
+    githubConfig = {owner: 'angular', name: 'dev-infra-test', mainBranchName: 'main'};
+    client = getMockGitClient(githubConfig, /* useSandboxGitClient */ true);
+
+    installSandboxGitClient(client);
+
+    // Ensure the `ReleaseNotes` class picks up the fake release config for testing.
+    spyOn(ReleaseNotes.prototype as any, 'getReleaseConfig').and.callFake(() => releaseConfig);
+  });
+
+  describe('changelog', () => {
+    it('should capture breaking changes', async () => {
+      SandboxGitRepo.withInitialCommit(githubConfig)
+        .commit('fix(cdk/a11y): already released #1')
+        .createTagForHead('13.0.0-next.0')
+        .commit('fix(cdk/a11y): not yet released #1')
+        .commit(
+          'refactor(cdk/a11y): with breaking change\n\n' +
+            'BREAKING CHANGE: Description of breaking change.',
+        );
+
+      const releaseNotes = await ReleaseNotes.forRange(parse('13.0.0'), '13.0.0-next.0', 'HEAD');
+
+      expect(await releaseNotes.getChangelogEntry()).toMatch(changelogPattern`
+        # 13.0.0 <..>
+        ## Breaking Changes
+        ### cdk/a11y
+        Description of breaking change.
+        ### cdk/a11y
+        | Commit | Description |
+        | -- | -- |
+        | <..> | fix(cdk/a11y): not yet released #1 |
+        ## Special Thanks:
+      `);
+    });
+
+    it('should capture deprecations', async () => {
+      SandboxGitRepo.withInitialCommit(githubConfig)
+        .commit('fix(cdk/a11y): already released #1')
+        .createTagForHead('13.0.0-next.0')
+        .commit('fix(cdk/a11y): not yet released #1')
+        .commit(
+          'refactor(cdk/a11y): with deprecation\n\n' + 'DEPRECATED: Description of deprecation.',
+        );
+
+      const releaseNotes = await ReleaseNotes.forRange(parse('13.0.0'), '13.0.0-next.0', 'HEAD');
+
+      expect(await releaseNotes.getChangelogEntry()).toMatch(changelogPattern`
+        # 13.0.0 <..>
+        ## Deprecations
+        ### cdk/a11y
+        Description of deprecation.
+        ### cdk/a11y
+        | Commit | Description |
+        | -- | -- |
+        | <..> | fix(cdk/a11y): not yet released #1 |
+        ## Special Thanks:
+      `);
+    });
+  });
+
+  describe('github release notes', () => {
+    it('should capture breaking changes', async () => {
+      SandboxGitRepo.withInitialCommit(githubConfig)
+        .commit('fix(cdk/a11y): already released #1')
+        .createTagForHead('13.0.0-next.0')
+        .commit('fix(cdk/a11y): not yet released #1')
+        .commit(
+          'refactor(cdk/a11y): with breaking change\n\n' +
+            'BREAKING CHANGE: Description of breaking change.',
+        );
+
+      const releaseNotes = await ReleaseNotes.forRange(parse('13.0.0'), '13.0.0-next.0', 'HEAD');
+
+      expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
+        # 13.0.0 <..>
+        ## Breaking Changes
+        ### cdk/a11y
+        Description of breaking change.
+        ### cdk/a11y
+        | Commit | Description |
+        | -- | -- |
+        | <..> | fix(cdk/a11y): not yet released #1 |
+        ## Special Thanks:
+      `);
+    });
+
+    it('should capture deprecations', async () => {
+      SandboxGitRepo.withInitialCommit(githubConfig)
+        .commit('fix(cdk/a11y): already released #1')
+        .createTagForHead('13.0.0-next.0')
+        .commit('fix(cdk/a11y): not yet released #1')
+        .commit(
+          'refactor(cdk/a11y): with deprecation\n\n' + 'DEPRECATED: Description of deprecation.',
+        );
+
+      const releaseNotes = await ReleaseNotes.forRange(parse('13.0.0'), '13.0.0-next.0', 'HEAD');
+
+      expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
+        # 13.0.0 <..>
+        ## Deprecations
+        ### cdk/a11y
+        Description of deprecation.
+        ### cdk/a11y
+        | Commit | Description |
+        | -- | -- |
+        | <..> | fix(cdk/a11y): not yet released #1 |
+        ## Special Thanks:
+      `);
+    });
+  });
+});

--- a/ng-dev/release/publish/test/test-utils/action-mocks.ts
+++ b/ng-dev/release/publish/test/test-utils/action-mocks.ts
@@ -1,6 +1,3 @@
-import {mkdirSync, rmdirSync, writeFileSync} from 'fs';
-import {join} from 'path';
-
 /**
  * @license
  * Copyright Google LLC All Rights Reserved.
@@ -8,6 +5,9 @@ import {join} from 'path';
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
+import {mkdirSync, rmdirSync, writeFileSync} from 'fs';
+import {join} from 'path';
 
 import * as npm from '../../../versioning/npm-publish';
 import * as constants from '../../constants';
@@ -18,8 +18,9 @@ import {ReleaseAction} from '../../actions';
 import {GithubConfig} from '../../../../utils/config';
 import {ReleaseConfig} from '../../../config';
 import {installVirtualGitClientSpies, VirtualGitClient} from '../../../../utils/testing';
-import {installSandboxGitClient, SandboxGitClient} from './sandbox-git-client';
+import {installSandboxGitClient} from './sandbox-git-client';
 import {ReleaseNotes} from '../../../notes/release-notes';
+import {getMockGitClient} from './git-client-mock';
 
 /**
  * Temporary directory which will be used as project directory in tests. Note that
@@ -39,7 +40,6 @@ export function getTestConfigurationsForAction() {
   };
   const releaseConfig: ReleaseConfig = {
     npmPackages: testReleasePackages,
-    releaseNotes: {},
     buildPackages: () => {
       throw Error('Not implemented');
     },
@@ -101,21 +101,4 @@ export function setupMocksForReleaseAction<T extends boolean>(
   }
 
   return {gitClient};
-}
-
-/** Gets a mock instance for the `GitClient` instance. */
-export function getMockGitClient<T extends boolean>(
-  github: GithubConfig,
-  useSandboxGitClient: T,
-): T extends true ? SandboxGitClient : VirtualGitClient {
-  if (useSandboxGitClient) {
-    // TypeScript does not infer the return type for the implementation, so we cast
-    // to any. The function signature will have the proper conditional return type.
-    // The Git binary path will be passed to this test process as command line argument.
-    // See `ng-dev/release/publish/test/BUILD.bazel` and the `GIT_BIN_PATH` variable
-    // that is exposed from the Git bazel toolchain.
-    return SandboxGitClient.createInstance(process.argv[2], {github}, testTmpDir) as any;
-  } else {
-    return VirtualGitClient.createInstance({github});
-  }
 }

--- a/ng-dev/release/publish/test/test-utils/git-client-mock.ts
+++ b/ng-dev/release/publish/test/test-utils/git-client-mock.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {GithubConfig} from '../../../../utils/config';
+import {SandboxGitClient} from './sandbox-git-client';
+import {VirtualGitClient} from '../../../../utils/testing';
+import {testTmpDir} from './action-mocks';
+
+/** Gets a mock instance for the `GitClient` instance. */
+export function getMockGitClient<T extends boolean>(
+  github: GithubConfig,
+  useSandboxGitClient: T,
+): T extends true ? SandboxGitClient : VirtualGitClient {
+  if (useSandboxGitClient) {
+    // TypeScript does not infer the return type for the implementation, so we cast
+    // to any. The function signature will have the proper conditional return type.
+    // The Git binary path will be passed to this test process as command line argument.
+    // See `ng-dev/release/publish/test/BUILD.bazel` and the `GIT_BIN_PATH` variable
+    // that is exposed from the Git bazel toolchain.
+    return SandboxGitClient.createInstance(process.argv[2], {github}, testTmpDir) as any;
+  } else {
+    return VirtualGitClient.createInstance({github});
+  }
+}

--- a/ng-dev/release/set-dist-tag/set-dist-tag.spec.ts
+++ b/ng-dev/release/set-dist-tag/set-dist-tag.spec.ts
@@ -32,7 +32,6 @@ describe('ng-dev release set-dist-tag', () => {
       npmPackages,
       publishRegistry,
       buildPackages: async () => [],
-      releaseNotes: {},
     });
     await ReleaseSetDistTagCommand.handler({tagName, targetVersion, $0: '', _: []});
   }


### PR DESCRIPTION
Various improvements for release notes. See individual commits.