### PR TITLE
Couple of release notes generator fixes

### DIFF
--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -153,6 +153,13 @@ export class RenderContext {
   replaceCommitHeaderPullRequestNumber(header: string): string {
     return header.replace(/\(#(\d+)\)$/, (_, g) => `(${this.pullRequestToLink(+g)})`);
   }
+
+  /**
+   * Bulletize a paragraph.
+   */
+  bulletizeText(text: string): string {
+    return '- ' + text.replace(/\\n/g, '\\n  ');
+  }
 }
 
 /**

--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -16,6 +16,9 @@ const typesToIncludeInReleaseNotes = Object.values(COMMIT_TYPES)
   .filter((type) => type.releaseNotesLevel === ReleaseNotesLevel.Visible)
   .map((type) => type.name);
 
+/** List of commit authors which are bots. */
+const botsAuthorNames = ['dependabot[bot]', 'Renovate Bot'];
+
 /** Data used for context during rendering. */
 export interface RenderContextData {
   title: string | false;
@@ -162,6 +165,15 @@ export class RenderContext {
    */
   bulletizeText(text: string): string {
     return '- ' + text.replace(/\\n/g, '\\n  ');
+  }
+
+  /**
+   * Returns unique, sorted and filtered commit authors.
+   */
+  commitAuthors(commits: CommitFromGitLog[]): string[] {
+    return [...new Set(commits.map((c) => c.author))]
+      .filter((a) => !botsAuthorNames.includes(a))
+      .sort();
   }
 }
 

--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -68,7 +68,10 @@ export class RenderContext {
      * of the group title.
      */
     const commitGroups = Array.from(groups.entries())
-      .map(([title, commits]) => ({title, commits}))
+      .map(([title, commits]) => ({
+        title,
+        commits: commits.sort((a, b) => (a.type > b.type ? 1 : a.type < b.type ? -1 : 0)),
+      }))
       .sort((a, b) => (a.title > b.title ? 1 : a.title < b.title ? -1 : 0));
 
     // If the configuration provides a sorting order, updated the sorted list of group keys to

--- a/ng-dev/release/notes/templates/changelog.ts
+++ b/ng-dev/release/notes/templates/changelog.ts
@@ -59,12 +59,7 @@ _%>
 _%>
 
 <%_
-const botsAuthorName = ['dependabot[bot]', 'Renovate Bot'];
-const authors = commits
-  .filter(unique('author'))
-  .map(c => c.author)
-  .filter(a => !botsAuthorName.includes(a))
-  .sort();
+const authors = commitAuthors(commits);
 if (authors.length === 1) {
 _%>
 ## Special Thanks:

--- a/ng-dev/release/notes/templates/changelog.ts
+++ b/ng-dev/release/notes/templates/changelog.ts
@@ -20,14 +20,8 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.breakingChanges[0].text %>
-
-<%_
-    }
   }
 }
 _%>
@@ -41,13 +35,8 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.deprecations[0].text %>
-<%_
-    }
   }
 }
 _%>

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -59,13 +59,7 @@ _%>
 _%>
 
 <%_
-const authors = commits.filter(unique('author')).map(c => c.author).sort();
-const botsAuthorName = ['dependabot[bot]', 'Renovate Bot'];
-const authors = commits
-  .filter(unique('author'))
-  .map(c => c.author)
-  .filter(a => !botsAuthorName.includes(a))
-  .sort();
+const authors = commitAuthors(commits);
 if (authors.length === 1) {
 _%>
 ## Special Thanks:

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -20,14 +20,8 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.breakingChanges[0].text %>
-
-<%_
-    }
   }
 }
 _%>
@@ -41,13 +35,8 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-
+<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
-    for (const commit of group.commits) {
-_%>
-<%- commit.deprecations[0].text %>
-<%_
-    }
   }
 }
 _%>
@@ -71,6 +60,12 @@ _%>
 
 <%_
 const authors = commits.filter(unique('author')).map(c => c.author).sort();
+const botsAuthorName = ['dependabot[bot]', 'Renovate Bot'];
+const authors = commits
+  .filter(unique('author'))
+  .map(c => c.author)
+  .filter(a => !botsAuthorName.includes(a))
+  .sort();
 if (authors.length === 1) {
 _%>
 ## Special Thanks:

--- a/ng-dev/release/publish/test/cut-release-candidate-for-feature-freeze.spec.ts
+++ b/ng-dev/release/publish/test/cut-release-candidate-for-feature-freeze.spec.ts
@@ -89,8 +89,8 @@ describe('cut release candidate for feature-freeze action', () => {
       ### pkg1
       | Commit | Description |
       | -- | -- |
-      | <..> | fix(pkg1): not yet released #2 |
       | <..> | feat(pkg1): not yet released #1 |
+      | <..> | fix(pkg1): not yet released #2 |
       ## Special Thanks:
     `);
   });

--- a/ng-dev/release/publish/test/move-next-into-feature-freeze.spec.ts
+++ b/ng-dev/release/publish/test/move-next-into-feature-freeze.spec.ts
@@ -162,8 +162,8 @@ describe('move next into feature-freeze action', () => {
       ### pkg1
       | Commit | Description |
       | -- | -- |
-      | <..> | fix(pkg1): not yet released #2 |
       | <..> | feat(pkg1): not yet released #1 |
+      | <..> | fix(pkg1): not yet released #2 |
       ## Special Thanks:
     `);
   });

--- a/ng-dev/release/publish/test/move-next-into-release-candidate.spec.ts
+++ b/ng-dev/release/publish/test/move-next-into-release-candidate.spec.ts
@@ -145,8 +145,8 @@ describe('move next into release-candidate action', () => {
       ### pkg1
       | Commit | Description |
       | -- | -- |
-      | <..> | fix(pkg1): not yet released #2 |
       | <..> | feat(pkg1): not yet released #1 |
+      | <..> | fix(pkg1): not yet released #2 |
       ## Special Thanks:
     `);
   });

--- a/ng-dev/release/publish/test/release-notes/generation.spec.ts
+++ b/ng-dev/release/publish/test/release-notes/generation.spec.ts
@@ -54,12 +54,12 @@ describe('release notes generation', () => {
         # 13.0.0 <..>
         ## Breaking Changes
         ### cdk/a11y
-        Description of breaking change.
+        - Description of breaking change.
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
-        | <..> | refactor(cdk/a11y): with breaking change |
         | <..> | fix(cdk/a11y): not yet released #1 |
+        | <..> | refactor(cdk/a11y): with breaking change |
         ## Special Thanks:
       `);
     });
@@ -79,12 +79,12 @@ describe('release notes generation', () => {
         # 13.0.0 <..>
         ## Deprecations
         ### cdk/a11y
-        Description of deprecation.
+        - Description of deprecation.
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
-        | <..> | refactor(cdk/a11y): with deprecation |
         | <..> | fix(cdk/a11y): not yet released #1 |
+        | <..> | refactor(cdk/a11y): with deprecation |
         ## Special Thanks:
       `);
     });
@@ -107,12 +107,12 @@ describe('release notes generation', () => {
         # 13.0.0 <..>
         ## Breaking Changes
         ### cdk/a11y
-        Description of breaking change.
+        - Description of breaking change.
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
-        | <..> | refactor(cdk/a11y): with breaking change |
         | <..> | fix(cdk/a11y): not yet released #1 |
+        | <..> | refactor(cdk/a11y): with breaking change |
         ## Special Thanks:
       `);
     });
@@ -132,12 +132,12 @@ describe('release notes generation', () => {
         # 13.0.0 <..>
         ## Deprecations
         ### cdk/a11y
-        Description of deprecation.
+        - Description of deprecation.
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
-        | <..> | refactor(cdk/a11y): with deprecation |
         | <..> | fix(cdk/a11y): not yet released #1 |
+        | <..> | refactor(cdk/a11y): with deprecation |
         ## Special Thanks:
       `);
     });


### PR DESCRIPTION
**fix(ng-dev): add breaklines and bullets to deprecation and breaking changes messages**

Previously, various breaking changes and deprecation messages were being displayed as single entry due to the lack of new lines., because EJS is trimming them due to https://github.com/angular/angular/blob/9fb79d38aade67f6f3bcdac0ffa93b8806baa215/dev-infra/release/notes/release-notes.ts#L49

Even with the whitespace however, when having multiple breaking changes, it was hard to distinguish each one, hence we added bullets.

**Before**
```md
## Breaking Changes
### @angular/cli
We drop support for Node.js versions prior to `12.20`.
### @angular-devkit/build-angular
Support for `karma-coverage-instanbul-reporter` has been dropped in favor of the official karma coverage plugin `karma-coverage`.
With this change we removed several deprecated builder options
- `extractCss` has been removed from the browser builder. CSS is now always extracted.
- `servePathDefaultWarning` and `hmrWarning` have been removed from the dev-server builder. These options had no effect.
The automatic inclusion of Angular-required ES2015 polyfills to support ES5 browsers has been removed. Previously when targetting ES5 within the application's TypeScript configuration or listing an ES5 requiring browser in the browserslist file, Angular-required polyfills were included in the built application. However, with Angular no longer supporting IE11, there are now no browsers officially supported by Angular that would require these polyfills. As a result, the automatic inclusion of these ES2015 polyfills has been removed. Any polyfills manually added to an application's code are not affected by this change.
Differential loading support has been removed. With Angular no longer supporting IE11, there are now no browsers officially supported by Angular that require ES5 code. As a result, differential loading's functionality for creating and conditionally loading ES5 and ES2015+ variants of an application is no longer required.
Deprecated `@angular-devkit/build-angular:tslint` builder has been removed. Use https://github.com/angular-eslint/angular-eslint instead.
We remove inlining of Google fonts in WOFF format since IE 11 is no longer supported. Other supported browsers use WOFF2.
Support for `node-sass` has been removed. `sass` will be used by default to compile SASS and SCSS files.
### @angular-devkit/schematics
With this change we remove the following deprecated APIs
- `TslintFixTask`
- `TslintFixTaskOptions`

**Note:** this only effects schematics developers.
```

**After**
```md
## Breaking Changess
### @angular-devkit/build-angular
- Support for `karma-coverage-instanbul-reporter` has been dropped in favor of the official karma coverage plugin `karma-coverage`.

- With this change we removed several deprecated builder options
  - `extractCss` has been removed from the browser builder. CSS is now always extracted.
  - `servePathDefaultWarning` and `hmrWarning` have been removed from the dev-server builder. These options had no effect.

- The automatic inclusion of Angular-required ES2015 polyfills to support ES5 browsers has been removed. Previously when targetting ES5 within the application's TypeScript configuration or listing an ES5 requiring browser in the browserslist file, Angular-required polyfills were included in the built application. However, with Angular no longer supporting IE11, there are now no browsers officially supported by Angular that would require these polyfills. As a result, the automatic inclusion of these ES2015 polyfills has been removed. Any polyfills manually added to an application's code are not affected by this change.

- Differential loading support has been removed. With Angular no longer supporting IE11, there are now no browsers officially supported by Angular that require ES5 code. As a result, differential loading's functionality for creating and conditionally loading ES5 and ES2015+ variants of an application is no longer required.

- Deprecated `@angular-devkit/build-angular:tslint` builder has been removed. Use https://github.com/angular-eslint/angular-eslint instead.

- We remove inlining of Google fonts in WOFF format since IE 11 is no longer supported. Other supported browsers use WOFF2.

- Support for `node-sass` has been removed. `sass` will be used by default to compile SASS and SCSS files.
### @angular-devkit/schematics
- With this change we remove the following deprecated APIs
  - `TslintFixTask`
  - `TslintFixTaskOptions`
```

Live example of this change can be viewed https://github.com/angular/angular-cli/releases/tag/13.0.0-next.0

---

**fix(dev-infra): sort commits by type in release notes**

Currently, the commit messages are not sorted by type which makes it harder to looks for a specific commit type, such as fixes, perf improvements or features.

**Before**
```md

| [cdfaeee08](https://github.com/angular/angular-cli/commit/cdfaeee089f3458b1924eb516a2b4275e662b079) | fix(@angular-devkit/build-angular): support both pure annotation forms for static properties |
| [2aa6f579d](https://github.com/angular/angular-cli/commit/2aa6f579d7b5af13eeb5bbf35f78d5411738b98a) | fix(@angular-devkit/build-angular): do not consume inline sourcemaps when vendor sourcemaps is disabled. |
| [167eed465](https://github.com/angular/angular-cli/commit/167eed4654be4480c45d7fdfe7a0b9f160170289) | fix(@angular-devkit/build-angular): update Angular peer dependencies to v13.0 prerelease |
| [7dcfffaff](https://github.com/angular/angular-cli/commit/7dcfffafff6f3d29bbe679a90cdf77b1292fec0b) | feat(@angular-devkit/build-angular): drop support for `karma-coverage-instanbul-reporter` |
| [f5d019f9d](https://github.com/angular/angular-cli/commit/f5d019f9d6ad6d8fdea37836564d9ee190deb23c) | fix(@angular-devkit/build-angular): avoid attempting to optimize copied JavaScript assets |
| [8758e4415](https://github.com/angular/angular-cli/commit/8758e4415d7ef6301c4441db0014e24f1cc8d146) | fix(@angular-devkit/build-angular): handle null maps in JavaScript optimizer worker |
| [f53bf9dc2](https://github.com/angular/angular-cli/commit/f53bf9dc21ee9aa8a682b8a82ee8a9870fa859e1) | feat(@angular-devkit/build-angular): add `type=module` to all scripts tags |
| [20e48a33c](https://github.com/angular/angular-cli/commit/20e48a33c14a1b0b959ba0a45018df53a3e129c8) | feat(@angular-devkit/build-angular): remove deprecated options |
| [7576136b2](https://github.com/angular/angular-cli/commit/7576136b2fc8a9173b0a92e2ab14c9bc2559081e) | feat(@angular-devkit/build-angular): remove automatic inclusion of ES5 browser polyfills |
| [701214d17](https://github.com/angular/angular-cli/commit/701214d174586fe7373b6155024c9b6e97b26377) | feat(@angular-devkit/build-angular): remove differential loading support |
| [e78f6ab5d](https://github.com/angular/angular-cli/commit/e78f6ab5d8f00338d826c8407ce5c8fca40cf097) | feat(@angular-devkit/build-angular): remove deprecated tslint builder |
| [ac3fc2752](https://github.com/angular/angular-cli/commit/ac3fc2752f28761e1cd42157b59dcf2364ae5567) | feat(@angular-devkit/build-angular): drop support for `node-sass` |
| [c1efaa17f](https://github.com/angular/angular-cli/commit/c1efaa17feb1d2911dcdea12688d75086d410bf1) | fix(@angular-devkit/build-angular): calculate valid Angular versions from peerDependencies |
| [d750c686f](https://github.com/angular/angular-cli/commit/d750c686fd26f3ccfccb039027bd816a91279497) | fix(@angular-devkit/build-angular): add priority to copy-webpack-plugin patterns |
```

**After**
```md
| [7dcfffaff](https://github.com/angular/angular-cli/commit/7dcfffafff6f3d29bbe679a90cdf77b1292fec0b) | feat(@angular-devkit/build-angular): drop support for `karma-coverage-instanbul-reporter` |
| [f53bf9dc2](https://github.com/angular/angular-cli/commit/f53bf9dc21ee9aa8a682b8a82ee8a9870fa859e1) | feat(@angular-devkit/build-angular): add `type=module` to all scripts tags |
| [20e48a33c](https://github.com/angular/angular-cli/commit/20e48a33c14a1b0b959ba0a45018df53a3e129c8) | feat(@angular-devkit/build-angular): remove deprecated options |
| [7576136b2](https://github.com/angular/angular-cli/commit/7576136b2fc8a9173b0a92e2ab14c9bc2559081e) | feat(@angular-devkit/build-angular): remove automatic inclusion of ES5 browser polyfills |
| [701214d17](https://github.com/angular/angular-cli/commit/701214d174586fe7373b6155024c9b6e97b26377) | feat(@angular-devkit/build-angular): remove differential loading support |
| [e78f6ab5d](https://github.com/angular/angular-cli/commit/e78f6ab5d8f00338d826c8407ce5c8fca40cf097) | feat(@angular-devkit/build-angular): remove deprecated tslint builder |
| [ac3fc2752](https://github.com/angular/angular-cli/commit/ac3fc2752f28761e1cd42157b59dcf2364ae5567) | feat(@angular-devkit/build-angular): drop support for `node-sass` |
| [cdfaeee08](https://github.com/angular/angular-cli/commit/cdfaeee089f3458b1924eb516a2b4275e662b079) | fix(@angular-devkit/build-angular): support both pure annotation forms for static properties |
| [2aa6f579d](https://github.com/angular/angular-cli/commit/2aa6f579d7b5af13eeb5bbf35f78d5411738b98a) | fix(@angular-devkit/build-angular): do not consume inline sourcemaps when vendor sourcemaps is disabled. |
| [167eed465](https://github.com/angular/angular-cli/commit/167eed4654be4480c45d7fdfe7a0b9f160170289) | fix(@angular-devkit/build-angular): update Angular peer dependencies to v13.0 prerelease |
| [f5d019f9d](https://github.com/angular/angular-cli/commit/f5d019f9d6ad6d8fdea37836564d9ee190deb23c) | fix(@angular-devkit/build-angular): avoid attempting to optimize copied JavaScript assets |
| [8758e4415](https://github.com/angular/angular-cli/commit/8758e4415d7ef6301c4441db0014e24f1cc8d146) | fix(@angular-devkit/build-angular): handle null maps in JavaScript optimizer worker |
| [c1efaa17f](https://github.com/angular/angular-cli/commit/c1efaa17feb1d2911dcdea12688d75086d410bf1) | fix(@angular-devkit/build-angular): calculate valid Angular versions from peerDependencies |
| [d750c686f](https://github.com/angular/angular-cli/commit/d750c686fd26f3ccfccb039027bd816a91279497) | fix(@angular-devkit/build-angular): add priority to copy-webpack-plugin patterns |
```