### PR TITLE
feat(ng-dev): remove redundant commit message scope

### DIFF
--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -175,6 +175,27 @@ export class RenderContext {
       .filter((a) => !botsAuthorNames.includes(a))
       .sort();
   }
+
+  /**
+   * Convert a commit object to a Markdown linked badged.
+   */
+  commitToBadge(commit: CommitFromGitLog): string {
+    let color = 'yellow';
+    switch (commit.type) {
+      case 'fix':
+        color = 'green';
+        break;
+      case 'feat':
+        color = 'blue';
+        break;
+      case 'perf':
+        color = 'orange';
+        break;
+    }
+    const url = `https://github.com/${this.data.github.owner}/${this.data.github.name}/commit/${commit.hash}`;
+    const imgSrc = `https://img.shields.io/badge/${commit.shortHash}-${commit.type}-${color}`;
+    return `[![${commit.type} - ${commit.shortHash}](${imgSrc})](${url})`;
+  }
 }
 
 /**

--- a/ng-dev/release/notes/templates/changelog.ts
+++ b/ng-dev/release/notes/templates/changelog.ts
@@ -52,7 +52,7 @@ _%>
 <%_
   for (const commit of group.commits) {
 _%>
-| <%- commitToLink(commit) %> | <%- replaceCommitHeaderPullRequestNumber(commit.header) %> |
+| <%- commitToLink(commit) %> | <%- commit.type %>: <%- replaceCommitHeaderPullRequestNumber(commit.subject) %> |
 <%_
   }
 }

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -52,7 +52,7 @@ _%>
 <%_
   for (const commit of group.commits) {
 _%>
-| <%- commit.shortHash %> | <%- commit.header %> |
+| <%- commitToBadge(commit) %> | <%- commit.subject %> |
 <%_
   }
 }

--- a/ng-dev/release/publish/test/cut-lts-patch.spec.ts
+++ b/ng-dev/release/publish/test/cut-lts-patch.spec.ts
@@ -108,8 +108,8 @@ describe('cut an LTS patch action', () => {
       ### pkg1
       | Commit | Description |
       | -- | -- |
-      | <..> | feat(pkg1): not yet released #2 |
-      | <..> | feat(pkg1): not yet released #1 |
+      | <..> | feat: not yet released #2 |
+      | <..> | feat: not yet released #1 |
       ## Special Thanks:
     `);
   });

--- a/ng-dev/release/publish/test/cut-new-patch.spec.ts
+++ b/ng-dev/release/publish/test/cut-new-patch.spec.ts
@@ -88,8 +88,8 @@ describe('cut new patch action', () => {
       ### pkg1
       | Commit | Description |
       | -- | -- |
-      | <..> | feat(pkg1): not yet released #2 |
-      | <..> | feat(pkg1): not yet released #1 |
+      | <..> | feat: not yet released #2 |
+      | <..> | feat: not yet released #1 |
       ## Special Thanks:
     `);
   });

--- a/ng-dev/release/publish/test/cut-next-prerelease.spec.ts
+++ b/ng-dev/release/publish/test/cut-next-prerelease.spec.ts
@@ -100,9 +100,9 @@ describe('cut next pre-release action', () => {
           ### pkg1
           | Commit | Description |
           | -- | -- |
-          | <..> | feat(pkg1): not released yet, but cherry-picked |
-          | <..> | feat(pkg1): only in next, not released yet #2 |
-          | <..> | feat(pkg1): only in next, not released yet #1 |
+          | <..> | feat: not released yet, but cherry-picked |
+          | <..> | feat: only in next, not released yet #2 |
+          | <..> | feat: only in next, not released yet #1 |
           ## Special Thanks:
         `);
       },
@@ -150,8 +150,8 @@ describe('cut next pre-release action', () => {
         ### pkg1
         | Commit | Description |
         | -- | -- |
-        | <..> | feat(pkg1): not released yet #2 |
-        | <..> | feat(pkg1): not released yet #1 |
+        | <..> | feat: not released yet #2 |
+        | <..> | feat: not released yet #1 |
         ## Special Thanks:
       `);
     });
@@ -198,8 +198,8 @@ describe('cut next pre-release action', () => {
         ### pkg1
         | Commit | Description |
         | -- | -- |
-        | <..> | feat(pkg1): not released yet #2 |
-        | <..> | feat(pkg1): not released yet #1 |
+        | <..> | feat: not released yet #2 |
+        | <..> | feat: not released yet #1 |
         ## Special Thanks:
       `);
     });

--- a/ng-dev/release/publish/test/cut-release-candidate-for-feature-freeze.spec.ts
+++ b/ng-dev/release/publish/test/cut-release-candidate-for-feature-freeze.spec.ts
@@ -89,8 +89,8 @@ describe('cut release candidate for feature-freeze action', () => {
       ### pkg1
       | Commit | Description |
       | -- | -- |
-      | <..> | feat(pkg1): not yet released #1 |
-      | <..> | fix(pkg1): not yet released #2 |
+      | <..> | feat: not yet released #1 |
+      | <..> | fix: not yet released #2 |
       ## Special Thanks:
     `);
   });

--- a/ng-dev/release/publish/test/cut-stable.spec.ts
+++ b/ng-dev/release/publish/test/cut-stable.spec.ts
@@ -152,15 +152,15 @@ describe('cut stable action', () => {
       ### pkg1
       | Commit | Description |
       | -- | -- |
-      | <..> | fix(pkg1): not yet released #2 |
-      | <..> | fix(pkg1): not yet released #1 |
-      | <..> | fix(pkg1): released release-candidate #2 |
-      | <..> | fix(pkg1): released release-candidate #1 |
-      | <..> | fix(pkg1): released feature-freeze pre-release #2 |
-      | <..> | fix(pkg1): released feature-freeze pre-release #1 |
-      | <..> | fix(pkg1): released first next pre-release #2 |
-      | <..> | fix(pkg1): released first next pre-release #1 |
-      | <..> | fix(pkg1): landed in patch, not released but cherry-picked #1 |
+      | <..> | fix: not yet released #2 |
+      | <..> | fix: not yet released #1 |
+      | <..> | fix: released release-candidate #2 |
+      | <..> | fix: released release-candidate #1 |
+      | <..> | fix: released feature-freeze pre-release #2 |
+      | <..> | fix: released feature-freeze pre-release #1 |
+      | <..> | fix: released first next pre-release #2 |
+      | <..> | fix: released first next pre-release #1 |
+      | <..> | fix: landed in patch, not released but cherry-picked #1 |
       ## Special Thanks:
     `);
     },

--- a/ng-dev/release/publish/test/move-next-into-feature-freeze.spec.ts
+++ b/ng-dev/release/publish/test/move-next-into-feature-freeze.spec.ts
@@ -128,9 +128,9 @@ describe('move next into feature-freeze action', () => {
         ### pkg1
         | Commit | Description |
         | -- | -- |
-        | <..> | feat(pkg1): not released yet, but cherry-picked |
-        | <..> | feat(pkg1): only in next, not released yet #2 |
-        | <..> | feat(pkg1): only in next, not released yet #1 |
+        | <..> | feat: not released yet, but cherry-picked |
+        | <..> | feat: only in next, not released yet #2 |
+        | <..> | feat: only in next, not released yet #1 |
       `);
       },
     );
@@ -162,8 +162,8 @@ describe('move next into feature-freeze action', () => {
       ### pkg1
       | Commit | Description |
       | -- | -- |
-      | <..> | feat(pkg1): not yet released #1 |
-      | <..> | fix(pkg1): not yet released #2 |
+      | <..> | feat: not yet released #1 |
+      | <..> | fix: not yet released #2 |
       ## Special Thanks:
     `);
   });

--- a/ng-dev/release/publish/test/move-next-into-release-candidate.spec.ts
+++ b/ng-dev/release/publish/test/move-next-into-release-candidate.spec.ts
@@ -111,9 +111,9 @@ describe('move next into release-candidate action', () => {
         ### pkg1
         | Commit | Description |
         | -- | -- |
-        | <..> | feat(pkg1): not released yet, but cherry-picked |
-        | <..> | feat(pkg1): only in next, not released yet #2 |
-        | <..> | feat(pkg1): only in next, not released yet #1 |
+        | <..> | feat: not released yet, but cherry-picked |
+        | <..> | feat: only in next, not released yet #2 |
+        | <..> | feat: only in next, not released yet #1 |
       `);
       },
     );
@@ -145,8 +145,8 @@ describe('move next into release-candidate action', () => {
       ### pkg1
       | Commit | Description |
       | -- | -- |
-      | <..> | feat(pkg1): not yet released #1 |
-      | <..> | fix(pkg1): not yet released #2 |
+      | <..> | feat: not yet released #1 |
+      | <..> | fix: not yet released #2 |
       ## Special Thanks:
     `);
   });

--- a/ng-dev/release/publish/test/release-notes/generation.spec.ts
+++ b/ng-dev/release/publish/test/release-notes/generation.spec.ts
@@ -58,8 +58,8 @@ describe('release notes generation', () => {
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
-        | <..> | fix(cdk/a11y): not yet released #1 |
-        | <..> | refactor(cdk/a11y): with breaking change |
+        | <..> | fix: not yet released #1 |
+        | <..> | refactor: with breaking change |
         ## Special Thanks:
       `);
     });
@@ -83,8 +83,8 @@ describe('release notes generation', () => {
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
-        | <..> | fix(cdk/a11y): not yet released #1 |
-        | <..> | refactor(cdk/a11y): with deprecation |
+        | <..> | fix: not yet released #1 |
+        | <..> | refactor: with deprecation |
         ## Special Thanks:
       `);
     });
@@ -111,8 +111,8 @@ describe('release notes generation', () => {
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
-        | <..> | fix(cdk/a11y): not yet released #1 |
-        | <..> | refactor(cdk/a11y): with breaking change |
+        | <..> | not yet released #1 |
+        | <..> | with breaking change |
         ## Special Thanks:
       `);
     });
@@ -136,8 +136,8 @@ describe('release notes generation', () => {
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
-        | <..> | fix(cdk/a11y): not yet released #1 |
-        | <..> | refactor(cdk/a11y): with deprecation |
+        | <..> | not yet released #1 |
+        | <..> | with deprecation |
         ## Special Thanks:
       `);
     });


### PR DESCRIPTION
With this change we remove the commit message scope from the list of commits. This is currently redundant since the scope is listed as header.

**Changelog**
**Before**
```md
### @schematics/angular
| Commit | Description |
| -- | -- |
| 268a03b63 | feat(@schematics/angular): add `noImplicitOverride` and `noPropertyAccessFromIndexSignature` to workspace tsconfig |
| 5986befcd | feat(@schematics/angular): update ngsw-config resources extensions |
```

**After**
```md
### @schematics/angular
| Commit | Description |
| -- | -- |
| 3ba13f467| feat: add `noImplicitOverride` and `noPropertyAccessFromIndexSignature` to workspace tsconfig |
| a7b2e6f51| feat: update ngsw-config resources extensions |
```

**Github release**
For GitHub releases we now also add badges. We do this only for GitHub releases since the changelog.md can be quite long and each badge will result in a seperate HTTP call which can end up in hundreds of these.

![Screenshot 2021-08-12 at 14 30 52](https://user-images.githubusercontent.com/17563226/129242111-28a4667f-ac10-4ba3-919d-c98741439f69.png)
