### PR TITLE
feat(ng-dev): support using no targeting labels for merge

### DIFF
--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -1,7 +1,7 @@
-import {DevInfraMergeConfig} from '../ng-dev/pr/merge/config';
+import {MergeConfig} from '../ng-dev/pr/merge/config';
 
 /** Configuration for merging pull requests into the repo. */
-export const merge: DevInfraMergeConfig['merge'] = {
+export const merge: MergeConfig = {
   githubApiMerge: false,
   claSignedLabel: 'cla: yes',
   mergeReadyLabel: 'action: merge',

--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -1,19 +1,11 @@
 import {DevInfraMergeConfig} from '../ng-dev/pr/merge/config';
 
 /** Configuration for merging pull requests into the repo. */
-export const merge: DevInfraMergeConfig['merge'] = async (api) => {
-  return {
-    githubApiMerge: false,
-    claSignedLabel: 'cla: yes',
-    mergeReadyLabel: 'action: merge',
-    caretakerNoteLabel: 'merge note',
-    commitMessageFixupLabel: 'needs commit fixup',
-    labels: [
-      {
-        // Since only one branch is merged into for the repository, we use our merge label as a marker.
-        pattern: 'action: merge',
-        branches: ['main'],
-      },
-    ],
-  };
+export const merge: DevInfraMergeConfig['merge'] = {
+  githubApiMerge: false,
+  claSignedLabel: 'cla: yes',
+  mergeReadyLabel: 'action: merge',
+  caretakerNoteLabel: 'merge note',
+  commitMessageFixupLabel: 'needs commit fixup',
+  noTargetLabeling: true,
 };

--- a/ng-dev/pr/merge/config.ts
+++ b/ng-dev/pr/merge/config.ts
@@ -77,20 +77,10 @@ export interface MergeConfig {
   targetLabelExemptScopes?: string[];
 }
 
-/**
- * Configuration of the merge script in the dev-infra configuration. Note that the
- * merge configuration is retrieved lazily as usually these configurations rely
- * on branch name computations. We don't want to run these immediately whenever
- * the dev-infra configuration is loaded as that could slow-down other commands.
- */
-export type DevInfraMergeConfig = {
-  merge: MergeConfig;
-};
-
 /** Loads and validates the merge configuration. */
 export function assertValidMergeConfig<T>(
-  config: T & Partial<DevInfraMergeConfig>,
-): asserts config is T & DevInfraMergeConfig {
+  config: T & Partial<{merge: MergeConfig}>,
+): asserts config is T & {merge: MergeConfig} {
   const errors: string[] = [];
   if (config.merge === undefined) {
     throw new ConfigValidationError('No merge configuration found. Set the `merge` configuration.');

--- a/ng-dev/pr/merge/config.ts
+++ b/ng-dev/pr/merge/config.ts
@@ -52,7 +52,7 @@ export interface MergeConfig {
    */
   remote?: GithubConfig;
   /** List of target labels. */
-  labels: TargetLabel[];
+  noTargetLabeling?: boolean;
   /** Required base commits for given branches. */
   requiredBaseCommits?: {[branchName: string]: string};
   /** Pattern that matches labels which imply a signed CLA. */
@@ -96,11 +96,6 @@ export function assertValidMergeConfig<T>(
     throw new ConfigValidationError('No merge configuration found. Set the `merge` configuration.');
   }
 
-  if (!config.merge.labels) {
-    errors.push('No label configuration.');
-  } else if (!Array.isArray(config.merge.labels)) {
-    errors.push('Label configuration needs to be an array.');
-  }
   if (!config.merge.claSignedLabel) {
     errors.push('No CLA signed label configured.');
   }

--- a/ng-dev/pr/merge/defaults/integration.spec.ts
+++ b/ng-dev/pr/merge/defaults/integration.spec.ts
@@ -31,7 +31,6 @@ describe('default target labels', () => {
     api = new GithubClient();
     githubConfig = {owner: 'angular', name: 'dev-infra-test', mainBranchName: 'master'};
     releaseConfig = {
-      releaseNotes: {},
       npmPackages: ['@angular/dev-infra-test-pkg'],
       buildPackages: async () => [],
     };
@@ -113,10 +112,6 @@ describe('default target labels', () => {
     try {
       label = await getTargetLabelFromPullRequest({}, [name]);
     } catch (error) {
-      console.log(error);
-      if (error.message === 'This repository does not use target labels') {
-        return [githubTargetBranch];
-      }
       return null;
     }
     return await getBranchesFromTargetLabel(label, githubTargetBranch);

--- a/ng-dev/pr/merge/defaults/integration.spec.ts
+++ b/ng-dev/pr/merge/defaults/integration.spec.ts
@@ -15,8 +15,9 @@ import * as console from '../../../utils/console';
 import {GithubClient} from '../../../utils/git/github';
 import {TargetLabel} from '../config';
 import {getBranchesFromTargetLabel, getTargetLabelFromPullRequest} from '../target-label';
+import * as labelDefaults from './labels';
 
-import {getDefaultTargetLabelConfiguration} from './index';
+import {getTargetLabels} from './index';
 import {fakeGithubPaginationResponse} from '../../../utils/testing/github-interception';
 
 const API_ENDPOINT = `https://api.github.com`;
@@ -30,6 +31,7 @@ describe('default target labels', () => {
     api = new GithubClient();
     githubConfig = {owner: 'angular', name: 'dev-infra-test', mainBranchName: 'master'};
     releaseConfig = {
+      releaseNotes: {},
       npmPackages: ['@angular/dev-infra-test-pkg'],
       buildPackages: async () => [],
     };
@@ -42,7 +44,7 @@ describe('default target labels', () => {
   afterEach(() => nock.cleanAll());
 
   async function computeTargetLabels(): Promise<TargetLabel[]> {
-    return getDefaultTargetLabelConfiguration(api, githubConfig, releaseConfig);
+    return getTargetLabels(api, {github: githubConfig, release: releaseConfig});
   }
 
   function getRepoApiRequestUrl(): string {
@@ -104,15 +106,17 @@ describe('default target labels', () => {
   async function getBranchesForLabel(
     name: string,
     githubTargetBranch = 'master',
-    labels?: TargetLabel[],
   ): Promise<string[] | null> {
-    if (labels === undefined) {
-      labels = await computeTargetLabels();
-    }
+    const labels = await computeTargetLabels();
+    spyOn(labelDefaults, 'getTargetLabels').and.resolveTo(labels);
     let label: TargetLabel;
     try {
-      label = getTargetLabelFromPullRequest({labels}, [name]);
+      label = await getTargetLabelFromPullRequest({}, [name]);
     } catch (error) {
+      console.log(error);
+      if (error.message === 'This repository does not use target labels') {
+        return [githubTargetBranch];
+      }
       return null;
     }
     return await getBranchesFromTargetLabel(label, githubTargetBranch);

--- a/ng-dev/pr/merge/defaults/labels.ts
+++ b/ng-dev/pr/merge/defaults/labels.ts
@@ -33,11 +33,6 @@ import {assertActiveLtsBranch} from './lts-branch';
  * @param releaseConfig Configuration for the release packages. Used to fetch
  *   NPM version data when LTS version branches are validated.
  */
-export async function getTargetLabels(): Promise<TargetLabel[]>;
-export async function getTargetLabels(
-  api?: GithubClient,
-  config?: Partial<{github: GithubConfig; release: ReleaseConfig}>,
-): Promise<TargetLabel[]>;
 export async function getTargetLabels(
   api = GitClient.get().github,
   config = getConfig() as Partial<{github: GithubConfig; release: ReleaseConfig}>,

--- a/ng-dev/pr/merge/defaults/labels.ts
+++ b/ng-dev/pr/merge/defaults/labels.ts
@@ -35,16 +35,13 @@ import {assertActiveLtsBranch} from './lts-branch';
  */
 export async function getTargetLabels(): Promise<TargetLabel[]>;
 export async function getTargetLabels(
-  _api?: GithubClient,
-  _config?: Partial<{github: GithubConfig; release: ReleaseConfig}>,
+  api?: GithubClient,
+  config?: Partial<{github: GithubConfig; release: ReleaseConfig}>,
 ): Promise<TargetLabel[]>;
 export async function getTargetLabels(
-  _api?: GithubClient,
-  _config?: Partial<{github: GithubConfig; release: ReleaseConfig}>,
+  api = GitClient.get().github,
+  config = getConfig() as Partial<{github: GithubConfig; release: ReleaseConfig}>,
 ): Promise<TargetLabel[]> {
-  const api = _api || GitClient.get().github;
-
-  const config = _config || (getConfig() as any);
   assertValidReleaseConfig(config);
   assertValidGithubConfig(config);
 

--- a/ng-dev/pr/merge/defaults/labels.ts
+++ b/ng-dev/pr/merge/defaults/labels.ts
@@ -6,14 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ReleaseConfig} from '../../../release/config/index';
+import {assertValidReleaseConfig, ReleaseConfig} from '../../../release/config/index';
 import {
   fetchActiveReleaseTrains,
   getNextBranchName,
   isVersionBranch,
   ReleaseRepoWithApi,
 } from '../../../release/versioning';
-import {GithubConfig} from '../../../utils/config';
+import {assertValidGithubConfig, getConfig, GithubConfig} from '../../../utils/config';
+import {GitClient} from '../../../utils/git/git-client';
 import {GithubClient} from '../../../utils/git/github';
 import {TargetLabel} from '../config';
 import {InvalidTargetBranchError, InvalidTargetLabelError} from '../target-label';
@@ -32,15 +33,25 @@ import {assertActiveLtsBranch} from './lts-branch';
  * @param releaseConfig Configuration for the release packages. Used to fetch
  *   NPM version data when LTS version branches are validated.
  */
-export async function getDefaultTargetLabelConfiguration(
-  api: GithubClient,
-  githubConfig: GithubConfig,
-  releaseConfig: ReleaseConfig,
+export async function getTargetLabels(): Promise<TargetLabel[]>;
+export async function getTargetLabels(
+  _api?: GithubClient,
+  _config?: Partial<{github: GithubConfig; release: ReleaseConfig}>,
+): Promise<TargetLabel[]>;
+export async function getTargetLabels(
+  _api?: GithubClient,
+  _config?: Partial<{github: GithubConfig; release: ReleaseConfig}>,
 ): Promise<TargetLabel[]> {
-  const nextBranchName = getNextBranchName(githubConfig);
+  const api = _api || GitClient.get().github;
+
+  const config = _config || (getConfig() as any);
+  assertValidReleaseConfig(config);
+  assertValidGithubConfig(config);
+
+  const nextBranchName = getNextBranchName(config.github);
   const repo: ReleaseRepoWithApi = {
-    owner: githubConfig.owner,
-    name: githubConfig.name,
+    owner: config.github.owner,
+    name: config.github.name,
     nextBranchName,
     api,
   };
@@ -139,7 +150,7 @@ export async function getDefaultTargetLabelConfiguration(
           );
         }
         // Assert that the selected branch is an active LTS branch.
-        await assertActiveLtsBranch(repo, releaseConfig, githubTargetBranch);
+        await assertActiveLtsBranch(repo, config.release, githubTargetBranch);
         return [githubTargetBranch];
       },
     },

--- a/ng-dev/pr/merge/index.ts
+++ b/ng-dev/pr/merge/index.ts
@@ -154,5 +154,6 @@ async function createPullRequestMergeTask(flags: PullRequestMergeTaskFlags) {
       }
       process.exit(1);
     }
+    throw e;
   }
 }

--- a/ng-dev/pr/merge/pull-request.ts
+++ b/ng-dev/pr/merge/pull-request.ts
@@ -24,6 +24,7 @@ import {
 } from './target-label';
 import {PullRequestMergeTask} from './task';
 import {breakingChangeLabel} from './constants';
+import {GithubConfig} from '../../utils/config';
 
 /** Interface that describes a pull request. */
 export interface PullRequest {
@@ -75,32 +76,14 @@ export async function loadAndValidatePullRequest(
 
   /** List of parsed commits for all of the commits in the pull request. */
   const commitsInPr = prData.commits.nodes.map((n) => parseCommitMessage(n.commit.message));
-
   const githubTargetBranch = prData.baseRefName;
-  let targetLabel: TargetLabel;
-  let targetBranches: string[];
-  if (!config.noTargetLabeling) {
-    try {
-      targetLabel = await getTargetLabelFromPullRequest(config, labels);
-      // If branches are determined for a given target label, capture errors that are
-      // thrown as part of branch computation. This is expected because a merge configuration
-      // can lazily compute branches for a target label and throw. e.g. if an invalid target
-      // label is applied, we want to exit the script gracefully with an error message.
 
-      targetBranches = await getBranchesFromTargetLabel(targetLabel, githubTargetBranch);
-      assertChangesAllowForTargetLabel(commitsInPr, targetLabel, config);
-    } catch (error) {
-      if (error instanceof PullRequestFailure) {
-        return error;
-      }
-      if (error instanceof InvalidTargetBranchError || error instanceof InvalidTargetLabelError) {
-        return new PullRequestFailure(error.failureMessage);
-      }
-      throw error;
-    }
-  } else {
-    targetBranches = [git.config.github.mainBranchName];
-  }
+  const targetBranches = await getTargetBranches(
+    {github: git.config.github, merge: config},
+    labels,
+    githubTargetBranch,
+    commitsInPr,
+  );
 
   try {
     assertPendingState(prData);
@@ -288,5 +271,34 @@ function assertPendingState(pr: RawPullRequest) {
       throw PullRequestFailure.isClosed();
     case 'MERGED':
       throw PullRequestFailure.isMerged();
+  }
+}
+
+/** Get the branches the pull request will be merged into.  */
+async function getTargetBranches(
+  config: {merge: MergeConfig; github: GithubConfig},
+  labels: string[],
+  targetBranch: string,
+  commits: Commit[],
+) {
+  if (config.merge.noTargetLabeling) {
+    return [config.github.mainBranchName];
+  } else {
+    try {
+      let targetLabel = await getTargetLabelFromPullRequest(config.merge, labels);
+      // If branches are determined for a given target label, capture errors that are
+      // thrown as part of branch computation. This is expected because a merge configuration
+      // can lazily compute branches for a target label and throw. e.g. if an invalid target
+      // label is applied, we want to exit the script gracefully with an error message.
+
+      let targetBranches = await getBranchesFromTargetLabel(targetLabel, targetBranch);
+      assertChangesAllowForTargetLabel(commits, targetLabel, config.merge);
+      return targetBranches;
+    } catch (error) {
+      if (error instanceof InvalidTargetBranchError || error instanceof InvalidTargetLabelError) {
+        throw new PullRequestFailure(error.failureMessage);
+      }
+      throw error;
+    }
   }
 }

--- a/ng-dev/pr/merge/pull-request.ts
+++ b/ng-dev/pr/merge/pull-request.ts
@@ -278,7 +278,7 @@ function assertPendingState(pr: RawPullRequest) {
 async function getTargetBranches(
   config: {merge: MergeConfig; github: GithubConfig},
   labels: string[],
-  targetBranch: string,
+  githubTargetBranch: string,
   commits: Commit[],
 ) {
   if (config.merge.noTargetLabeling) {
@@ -291,7 +291,7 @@ async function getTargetBranches(
       // can lazily compute branches for a target label and throw. e.g. if an invalid target
       // label is applied, we want to exit the script gracefully with an error message.
 
-      let targetBranches = await getBranchesFromTargetLabel(targetLabel, targetBranch);
+      let targetBranches = await getBranchesFromTargetLabel(targetLabel, githubTargetBranch);
       assertChangesAllowForTargetLabel(commits, targetLabel, config.merge);
       return targetBranches;
     } catch (error) {

--- a/ng-dev/pr/merge/target-label.ts
+++ b/ng-dev/pr/merge/target-label.ts
@@ -7,6 +7,7 @@
  */
 
 import {MergeConfig, TargetLabel} from './config';
+import {getTargetLabels} from './defaults/labels';
 import {matchesPattern} from './string-pattern';
 
 /**
@@ -26,14 +27,19 @@ export class InvalidTargetLabelError {
 }
 
 /** Gets the target label from the specified pull request labels. */
-export function getTargetLabelFromPullRequest(
-  config: Pick<MergeConfig, 'labels'>,
+export async function getTargetLabelFromPullRequest(
+  config: Pick<MergeConfig, 'noTargetLabeling'>,
   labels: string[],
-): TargetLabel {
+): Promise<TargetLabel> {
+  if (config.noTargetLabeling) {
+    throw Error('This repository does not use target labels');
+  }
+
+  const targetLabels = await getTargetLabels();
   /** List of discovered target labels for the PR. */
   const matches = [];
   for (const label of labels) {
-    const match = config.labels.find(({pattern}) => matchesPattern(label, pattern));
+    const match = targetLabels.find(({pattern}) => matchesPattern(label, pattern));
     if (match !== undefined) {
       matches.push(match);
     }


### PR DESCRIPTION
Allow the configuration of no target labels instead always merging into the main branch provided in the `GithubConfig`.