### PR TITLE
test(ng-dev): fix usage of TEST_TMPDIR

### DIFF
--- a/ng-dev/release/publish/test/test-utils/action-mocks.ts
+++ b/ng-dev/release/publish/test/test-utils/action-mocks.ts
@@ -23,10 +23,11 @@ import {ReleaseNotes} from '../../../notes/release-notes';
 import {getMockGitClient} from './git-client-mock';
 
 /**
- * Temporary directory which will be used as project directory in tests. Note that
- * this environment variable is automatically set by Bazel for tests.
+ * Temporary directory which will be used as project directory in tests. Note that this environment
+ * variable is automatically set by Bazel for tests. Bazel expects tests "not attempt to remove,
+ * chmod, or otherwise alter [TEST_TMPDIR]," so a subdirectory path is used to be created/destroyed.
  */
-export const testTmpDir: string = process.env['TEST_TMPDIR']!;
+export const testTmpDir: string = join(process.env['TEST_TMPDIR']!, 'dev-infra');
 
 /** List of NPM packages which are configured for release action tests. */
 export const testReleasePackages = ['@angular/pkg1', '@angular/pkg2'];


### PR DESCRIPTION
Bazel expects tests "not attempt to remove, chmod, or otherwise alter [TEST_TMPDIR]," so instead a subdirectory
should be used to be created/destroyed throughout tests.  If the TEST_TMPDIR is directly used the first usage
works as expected but removing the directory is not successful causing failure on the next creation.  This
failure does not occur on windows due to Bazel's lack of sandboxing and therefore lack of control over the
interactions with the TEST_TMPDIR.