### PR TITLE
ci: enable renovate bot

### DIFF
--- a/renovte.json
+++ b/renovte.json
@@ -1,0 +1,40 @@
+{
+  "pinVersions": false,
+  "semanticCommits": true,
+  "semanticPrefix": "build",
+  "separateMajorMinor": false,
+  "prHourlyLimit": 2,
+  "labels": ["comp: build", "dependencies"],
+  "timezone": "America/Tijuana",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "schedule": ["after 10pm every weekday", "before 4am every weekday", "every weekend"],
+  "baseBranches": ["main"],
+  "ignoreDeps": ["@types/node", "@types/selenium-webdriver", "selenium-webdriver"],
+  "packageFiles": ["WORKSPACE", "package.json"],
+  "packageRules": [
+    {
+      "packagePatterns": ["^@bazel/.*", "^build_bazel.*"],
+      "groupName": "bazel",
+      "pinVersions": false
+    },
+    {
+      "packageNames": ["typescript"],
+      "updateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchCurrentVersion": "0.0.0-PLACEHOLDER",
+      "enabled": false
+    },
+    {
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": ">=1",
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "schedule": ["after 1am on Thursday"]
+    }
+  ]
+}


### PR DESCRIPTION
With this change dependencies are now managed via Renovate bot.

- Major updates are scheduled after 10pm and before 4am every weekday and unscheduled during weekends
- lock file maintenance, every Monday
- minor and patch updates are grouped and scheduled after 1am every Thursday