### PR TITLE
fix(ng-dev): update default breaking change label to `flag: breaking change`

### DIFF
--- a/github-actions/breaking-changes-label/bundle.js
+++ b/github-actions/breaking-changes-label/bundle.js
@@ -30337,7 +30337,7 @@ var github_1 = require_github();
 var rest_1 = require_dist_node12();
 var parse_1 = require_parse();
 var utils_1 = require_utils4();
-var breakingChangesLabel = "breaking changes";
+var breakingChangesLabel = "flag: breaking change";
 async function run() {
   const token = await utils_1.getAuthTokenForAngularRobotApp();
   const client = new rest_1.Octokit({ auth: token });

--- a/github-actions/breaking-changes-label/main.ts
+++ b/github-actions/breaking-changes-label/main.ts
@@ -4,7 +4,7 @@ import {Octokit} from '@octokit/rest';
 import {parseCommitMessage} from '../../ng-dev/commit-message/parse';
 import {getAuthTokenForAngularRobotApp} from '../utils';
 
-const breakingChangesLabel = 'breaking changes';
+const breakingChangesLabel = 'flag: breaking change';
 
 async function run(): Promise<void> {
   const token = await getAuthTokenForAngularRobotApp();

--- a/ng-dev/pr/merge/pull-request.ts
+++ b/ng-dev/pr/merge/pull-request.ts
@@ -25,7 +25,7 @@ import {
 import {PullRequestMergeTask} from './task';
 
 /** The default label for labeling pull requests containing a breaking change. */
-const BreakingChangeLabel = 'breaking changes';
+const BreakingChangeLabel = 'flag: breaking change';
 
 /** Interface that describes a pull request. */
 export interface PullRequest {


### PR DESCRIPTION


This is to align all repos to use the same label