### PR TITLE
ci: add pullapprove configuration

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,33 @@
+version: 3
+
+# turn on 'draft' support
+# https://docs.pullapprove.com/config/github-api-version/
+# https://developer.github.com/v3/previews/#draft-pull-requests
+github_api_version: 'shadow-cat-preview'
+
+# https://docs.pullapprove.com/config/overrides/
+# Note that overrides are processed in order.
+overrides:
+  # For PRs which are still being worked on, either still in draft mode or indicated through WIP in
+  # title or label, PullApprove stays in a pending state until its ready for review.
+  - if: "draft or 'WIP' in title or 'PR state: WIP' in labels"
+    status: pending
+    explanation: 'Waiting to send reviews as PR is WIP'
+
+groups:
+  # =========================================================
+  # Require review on all PRs
+  #
+  # All PRs require at least one review.  This rule will not
+  # request any reviewers, however will require that at least
+  # one review is provided before the group is satisfied.
+  # =========================================================
+  required-minimum-review:
+    reviews:
+      request: 0 # Do not request any reviews from the reviewer group
+      required: 1 # Require that all PRs have approval from at least one of the users in the group
+      author_value: 0 # The author of the PR cannot provide an approval for themself
+      reviewed_for: ignored # All reviews apply to this group whether noted via Reviewed-for or not
+    reviewers:
+      teams:
+        - ~dev-infra


### PR DESCRIPTION
Add pullapprove configuration to require at least one review occurs on all PRs.