### PR TITLE
fix: remove husky install from `scripts` section of package json for published npm package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,6 +26,7 @@ pkg_npm(
         "//bazel:static_files",
     ],
     substitutions = {
+        "    \"prepare\": \"husky install\",\n": "",
         "@dev-infra//bazel/": "@npm//@angular/dev-infra-private/bazel/",
         "//bazel/": "@npm//@angular/dev-infra-private/bazel/",
         "//bazel:": "@npm//@angular/dev-infra-private/bazel:",


### PR DESCRIPTION
This is a temporary fix to ensure that the husky install is not included in the package.json for the published npm package.