### PR TITLE
fix(ng-dev): update github release entry when re-tagging major as latest

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -501,7 +501,7 @@ export abstract class ReleaseAction {
   private async _createGithubReleaseForVersion(
     releaseNotes: ReleaseNotes,
     versionBumpCommitSha: string,
-    prerelease: boolean,
+    isPrerelease: boolean,
   ) {
     const tagName = getReleaseTagForVersion(releaseNotes.version);
     await this.git.github.git.createRef({
@@ -515,7 +515,7 @@ export abstract class ReleaseAction {
       ...this.git.remoteParams,
       name: `v${releaseNotes.version}`,
       tag_name: tagName,
-      prerelease,
+      prerelease: isPrerelease,
       body: await releaseNotes.getGithubReleaseEntry(),
     });
     info(green(`  ✓   Created v${releaseNotes.version} release in Github.`));

--- a/ng-dev/release/publish/test/BUILD.bazel
+++ b/ng-dev/release/publish/test/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "//ng-dev/release/versioning",
         "//ng-dev/utils",
         "//ng-dev/utils/testing",
+        "@npm//@octokit/plugin-rest-endpoint-methods",
         "@npm//@types/jasmine",
         "@npm//@types/node",
         "@npm//@types/semver",

--- a/ng-dev/release/publish/test/test-utils/github-api-testing.ts
+++ b/ng-dev/release/publish/test/test-utils/github-api-testing.ts
@@ -7,6 +7,10 @@
  */
 
 import * as nock from 'nock';
+import {RestEndpointMethodTypes} from '@octokit/plugin-rest-endpoint-methods';
+
+/** Type describing the parameters for a Github release update API request. */
+type ReleaseUpdateParameters = RestEndpointMethodTypes['repos']['updateRelease']['parameters'];
 
 /**
  * Class that represents a Github repository in testing. The class can be
@@ -56,7 +60,19 @@ export class GithubTestingRepo {
   }
 
   expectCommitStatusCheck(sha: string, state: 'success' | 'pending' | 'failure'): this {
-    nock(this.repoApiUrl).get(`/commits/${sha}/status`).reply(200, {state}).activeMocks();
+    nock(this.repoApiUrl).get(`/commits/${sha}/status`).reply(200, {state});
+    return this;
+  }
+
+  expectReleaseByTagRequest(tagName: string, id: number): this {
+    nock(this.repoApiUrl).get(`/releases/tags/${tagName}`).reply(200, {id});
+    return this;
+  }
+
+  expectReleaseUpdateRequest(id: number, updatedFields: Partial<ReleaseUpdateParameters>): this {
+    nock(this.repoApiUrl)
+      .patch(`/releases/${id}`, (body) => JSON.stringify(body) === JSON.stringify(updatedFields))
+      .reply(200, {id});
     return this;
   }
 


### PR DESCRIPTION
Update the Github release entry `isPrerelease` state when re-tagging
a major as `latest` from `next`.