### PR TITLE
fix(ng-dev): release fails if release notes are too long

### DIFF
--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -44,6 +44,8 @@ export class RenderContext {
   readonly version = this.data.version;
   /** The date stamp string for use in the release notes entry. */
   readonly dateStamp = buildDateStamp(this.data.date);
+  /** URL fragment that is used to create an anchor for the release. */
+  readonly urlFragmentForRelease = this.data.version;
 
   constructor(private readonly data: RenderContextData) {}
 

--- a/ng-dev/release/notes/release-notes.ts
+++ b/ng-dev/release/notes/release-notes.ts
@@ -50,6 +50,14 @@ export class ReleaseNotes {
   }
 
   /**
+   * Gets the URL fragment for the release notes. The URL fragment identifier
+   * can be used to point to a specific changelog entry through an URL.
+   */
+  async getUrlFragmentForRelease() {
+    return (await this.generateRenderContext()).urlFragmentForRelease;
+  }
+
+  /**
    * Prompt the user for a title for the release, if the project's configuration is defined to use a
    * title.
    */

--- a/ng-dev/release/notes/templates/changelog.ts
+++ b/ng-dev/release/notes/templates/changelog.ts
@@ -7,7 +7,7 @@
  */
 
 export default `
-<a name="<%- version %>"></a>
+<a name="<%- urlFragmentForRelease %>"></a>
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
 
 <%_

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -7,7 +7,7 @@
  */
 
 export default `
-<a name="<%- version %>"></a>
+<a name="<%- urlFragmentForRelease %>"></a>
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
 
 <%_

--- a/ng-dev/release/publish/constants.ts
+++ b/ng-dev/release/publish/constants.ts
@@ -14,3 +14,12 @@ export const changelogPath = 'CHANGELOG.md';
 
 /** Default interval in milliseconds to check whether a pull request has been merged. */
 export const waitForPullRequestInterval = 10000;
+
+/**
+ * Maximum number of characters a Github release entry can use for its body.
+ *
+ * Note: Github does not specify an official limit for this, but based on local testing,
+ * Github limits switch between 25000 and 125000 characters. We use the lowest limit we have
+ * seen so far, as otherwise the limit can potentially be wrong and result in errors.
+ */
+export const githubReleaseBodyLimit = 25000;

--- a/ng-dev/release/publish/test/test-utils/github-api-testing.ts
+++ b/ng-dev/release/publish/test/test-utils/github-api-testing.ts
@@ -95,9 +95,16 @@ export class GithubTestingRepo {
     return this;
   }
 
-  expectReleaseToBeCreated(name: string, tagName: string): this {
+  expectReleaseToBeCreated(name: string, tagName: string, bodyRegex?: RegExp): this {
     nock(this.repoApiUrl)
-      .post('/releases', (b) => b.name === name && b['tag_name'] === tagName)
+      .post('/releases', (requestBody) => {
+        if (bodyRegex && !bodyRegex.test(requestBody.body)) {
+          return false;
+        } else if (requestBody.name !== name) {
+          return false;
+        }
+        return requestBody['tag_name'] === tagName;
+      })
       .reply(200, {});
     return this;
   }

--- a/ng-dev/utils/git/github-urls.ts
+++ b/ng-dev/utils/git/github-urls.ts
@@ -40,6 +40,13 @@ export function getRepositoryGitUrl(
 }
 
 /** Gets a Github URL that refers to a list of recent commits within a specified branch. */
-export function getListCommitsInBranchUrl({remoteParams}: GitClient, branchName: string) {
-  return `https://github.com/${remoteParams.owner}/${remoteParams.repo}/commits/${branchName}`;
+export function getListCommitsInBranchUrl(client: GitClient, branchName: string) {
+  const {owner, repo} = client.remoteParams;
+  return `https://github.com/${owner}/${repo}/commits/${branchName}`;
+}
+
+/** Gets a Github URL for viewing the file contents of a specified file for the given ref. */
+export function getFileContentsUrl(client: GitClient, ref: string, relativeFilePath: string) {
+  const {owner, repo} = client.remoteParams;
+  return `https://github.com/${owner}/${repo}/blob/${ref}/${relativeFilePath}`;
 }


### PR DESCRIPTION
While manually testing the release tool a couple of times
for the COMP and FW repos, the script sometimes failed
based on the release notes comparison range. i.e. if
there were too many changes in the release notes, the
Github API errored out when we send the `POST` http
request for creating the Github release entry.

Github does not seem to give official details about
the limits on the release body property. The limit
seems to be between 25k and 125k. This is surprising
but based on actual testing. Initially I was seeing failures
with 25k characters limit, but today (8/17/2021) the limit
seems to be (for all my forks; also organization repos) set
to 125k. I think it's best to stay with the lowest we have
seen. If we exceed, we just link to the changelog, assuming it
still exists in the next branch.

![image](https://user-images.githubusercontent.com/4987015/129768313-ffcc1930-f19a-4cfc-9d31-f3bc4843100c.png)
