### PR TITLE
test(ng-dev): incorrectly uses hardcoded date that breaks tests

### DIFF
--- a/ng-dev/release/publish/test/common.spec.ts
+++ b/ng-dev/release/publish/test/common.spec.ts
@@ -128,7 +128,7 @@ describe('common release action logic', () => {
           `v${version}`,
           tagName,
           changelogPattern`
-            # 10.1.0-next.0 (2021-08-17)
+            # 10.1.0-next.0 <..>
             ### test
             | Commit | Description |
             | -- | -- |


### PR DESCRIPTION
No longer use a hard-coded test in the changelog pattern test.