### PR TITLE
fix(ng-dev): remove colon from `Special Thanks` header

### DIFF
--- a/ng-dev/release/notes/templates/changelog.ts
+++ b/ng-dev/release/notes/templates/changelog.ts
@@ -64,13 +64,13 @@ _%>
 const authors = commitAuthors(commits);
 if (authors.length === 1) {
 _%>
-## Special Thanks:
+## Special Thanks
 <%- authors[0]%>
 <%_
 }
 if (authors.length > 1) {
 _%>
-## Special Thanks:
+## Special Thanks
 <%- authors.slice(0, -1).join(', ') %> and <%- authors.slice(-1)[0] %>
 <%_
 }

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -62,13 +62,13 @@ _%>
 const authors = commitAuthors(commits);
 if (authors.length === 1) {
 _%>
-## Special Thanks:
+## Special Thanks
 <%- authors[0]%>
 <%_
 }
 if (authors.length > 1) {
 _%>
-## Special Thanks:
+## Special Thanks
 <%- authors.slice(0, -1).join(', ') %> and <%- authors.slice(-1)[0] %>
 <%_
 }

--- a/ng-dev/release/publish/test/common.spec.ts
+++ b/ng-dev/release/publish/test/common.spec.ts
@@ -134,7 +134,7 @@ describe('common release action logic', () => {
             | -- | -- |
             | <..> | second commit |
             | <..> | first commit |
-            ## Special Thanks:
+            ## Special Thanks
           `,
         );
 

--- a/ng-dev/release/publish/test/cut-lts-patch.spec.ts
+++ b/ng-dev/release/publish/test/cut-lts-patch.spec.ts
@@ -110,7 +110,7 @@ describe('cut an LTS patch action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *2 |
       | <..> | feat | not yet released *1 |
-      ## Special Thanks:
+      ## Special Thanks
     `);
   });
 

--- a/ng-dev/release/publish/test/cut-new-patch.spec.ts
+++ b/ng-dev/release/publish/test/cut-new-patch.spec.ts
@@ -90,7 +90,7 @@ describe('cut new patch action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *2 |
       | <..> | feat | not yet released *1 |
-      ## Special Thanks:
+      ## Special Thanks
     `);
   });
 });

--- a/ng-dev/release/publish/test/cut-next-prerelease.spec.ts
+++ b/ng-dev/release/publish/test/cut-next-prerelease.spec.ts
@@ -103,7 +103,7 @@ describe('cut next pre-release action', () => {
           | <..> | feat | not released yet, but cherry-picked |
           | <..> | feat | only in next, not released yet *2 |
           | <..> | feat | only in next, not released yet *1 |
-          ## Special Thanks:
+          ## Special Thanks
         `);
       },
     );
@@ -152,7 +152,7 @@ describe('cut next pre-release action', () => {
         | -- | -- | -- |
         | <..> | feat | not released yet *2 |
         | <..> | feat | not released yet *1 |
-        ## Special Thanks:
+        ## Special Thanks
       `);
     });
   });
@@ -200,7 +200,7 @@ describe('cut next pre-release action', () => {
         | -- | -- | -- |
         | <..> | feat | not released yet *2 |
         | <..> | feat | not released yet *1 |
-        ## Special Thanks:
+        ## Special Thanks
       `);
     });
   });

--- a/ng-dev/release/publish/test/cut-release-candidate-for-feature-freeze.spec.ts
+++ b/ng-dev/release/publish/test/cut-release-candidate-for-feature-freeze.spec.ts
@@ -91,7 +91,7 @@ describe('cut release candidate for feature-freeze action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *1 |
       | <..> | fix | not yet released *2 |
-      ## Special Thanks:
+      ## Special Thanks
     `);
   });
 });

--- a/ng-dev/release/publish/test/cut-stable.spec.ts
+++ b/ng-dev/release/publish/test/cut-stable.spec.ts
@@ -161,7 +161,7 @@ describe('cut stable action', () => {
       | <..> | fix | released first next pre-release *2 |
       | <..> | fix | released first next pre-release *1 |
       | <..> | fix | landed in patch, not released but cherry-picked *1 |
-      ## Special Thanks:
+      ## Special Thanks
     `);
     },
   );

--- a/ng-dev/release/publish/test/move-next-into-feature-freeze.spec.ts
+++ b/ng-dev/release/publish/test/move-next-into-feature-freeze.spec.ts
@@ -164,7 +164,7 @@ describe('move next into feature-freeze action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *1 |
       | <..> | fix | not yet released *2 |
-      ## Special Thanks:
+      ## Special Thanks
     `);
   });
 });

--- a/ng-dev/release/publish/test/move-next-into-release-candidate.spec.ts
+++ b/ng-dev/release/publish/test/move-next-into-release-candidate.spec.ts
@@ -147,7 +147,7 @@ describe('move next into release-candidate action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *1 |
       | <..> | fix | not yet released *2 |
-      ## Special Thanks:
+      ## Special Thanks
     `);
   });
 

--- a/ng-dev/release/publish/test/release-notes/generation.spec.ts
+++ b/ng-dev/release/publish/test/release-notes/generation.spec.ts
@@ -61,7 +61,7 @@ describe('release notes generation', () => {
           | -- | -- | -- |
           | <..> | fix | commit *4 |
           | <..> | fix | commit *3 |
-          ## Special Thanks:
+          ## Special Thanks
         `);
       });
 
@@ -92,7 +92,7 @@ describe('release notes generation', () => {
           | -- | -- | -- |
           | <..> | fix | commit *4 |
           | <..> | fix | commit *3 |
-          ## Special Thanks:
+          ## Special Thanks
         `);
       });
 
@@ -125,7 +125,7 @@ describe('release notes generation', () => {
           | Commit | Type | Description |
           | -- | -- | -- |
           | <..> | fix | platform: fix detection of chromium |
-          ## Special Thanks:
+          ## Special Thanks
         `);
       });
 
@@ -164,7 +164,7 @@ describe('release notes generation', () => {
           | Commit | Type | Description |
           | -- | -- | -- |
           | <..> | fix | slider/testing: missing stabilization |
-          ## Special Thanks:
+          ## Special Thanks
         `);
       });
     });
@@ -184,7 +184,7 @@ describe('release notes generation', () => {
         | -- | -- | -- |
         | <..> | fix | commit ([#2](<..>/pull/2)) |
         | <..> | fix | commit [#1](<..>/pull/1) |
-        ## Special Thanks:
+        ## Special Thanks
       `);
     });
 
@@ -210,7 +210,7 @@ describe('release notes generation', () => {
         | -- | -- | -- |
         | <..> | fix | not yet released *1 |
         | <..> | refactor | with breaking change |
-        ## Special Thanks:
+        ## Special Thanks
       `);
     });
 
@@ -235,7 +235,7 @@ describe('release notes generation', () => {
         | -- | -- | -- |
         | <..> | fix | not yet released *1 |
         | <..> | refactor | with deprecation |
-        ## Special Thanks:
+        ## Special Thanks
       `);
     });
   });
@@ -264,7 +264,7 @@ describe('release notes generation', () => {
           | -- | -- |
           | <..> | commit *4 |
           | <..> | commit *3 |
-          ## Special Thanks:
+          ## Special Thanks
         `);
       });
 
@@ -295,7 +295,7 @@ describe('release notes generation', () => {
           | -- | -- |
           | <..> | commit *4 |
           | <..> | commit *3 |
-          ## Special Thanks:
+          ## Special Thanks
         `);
       });
 
@@ -328,7 +328,7 @@ describe('release notes generation', () => {
           | Commit | Description |
           | -- | -- |
           | <..> | platform: fix detection of chromium |
-          ## Special Thanks:
+          ## Special Thanks
         `);
       });
 
@@ -367,7 +367,7 @@ describe('release notes generation', () => {
           | Commit | Description |
           | -- | -- |
           | <..> | slider/testing: missing stabilization |
-          ## Special Thanks:
+          ## Special Thanks
         `);
       });
     });
@@ -394,7 +394,7 @@ describe('release notes generation', () => {
         | -- | -- |
         | <..> | not yet released *1 |
         | <..> | with breaking change |
-        ## Special Thanks:
+        ## Special Thanks
       `);
     });
 
@@ -419,7 +419,7 @@ describe('release notes generation', () => {
         | -- | -- |
         | <..> | not yet released *1 |
         | <..> | with deprecation |
-        ## Special Thanks:
+        ## Special Thanks
       `);
     });
   });


### PR DESCRIPTION
This is to align with other headers, which don't have a colon at the end.