### PR TITLE
Setup commit message validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,10 @@ jobs:
       - yarn_install
       - run:
           name: Check code format
-          command: yarn ng-dev format changed --check << pipeline.git.base_revision >>
+          command: yarn -s ng-dev format changed --check << pipeline.git.base_revision >>
+      - run:
+          name: Check commit messages
+          command: yarn -s ng-dev commit-message validate-range << pipeline.git.base_revision >> << pipeline.git.revision >>
 
   publish_snapshot_build:
     executor: default-executor

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname $0)/_/husky.sh"
+
+yarn -s ng-dev commit-message pre-commit-validate --file $1 2>/dev/null

--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -1,0 +1,31 @@
+import {CommitMessageConfig} from '../ng-dev/commit-message/config';
+
+/** Build a set of scopes for a package. */
+function buildScopesFor(pkg: string, subpkgs: string[]) {
+  return [pkg, ...subpkgs.map((subpkg: string) => `${pkg}/${subpkg}`)];
+}
+
+export const commitMessage: CommitMessageConfig = {
+  maxLineLength: Infinity,
+  minBodyLength: 0,
+  scopes: [
+    ...buildScopesFor('bazel', ['api-golden', 'benchmark', 'browsers', 'remote-execution']),
+    ...buildScopesFor('github-actions', [
+      'breaking-changes-label',
+      'feature-request',
+      'lock-closed',
+      'rebase',
+      'rerun-circleci',
+    ]),
+    ...buildScopesFor('ng-dev', [
+      'caretaker',
+      'commit-message',
+      'format',
+      'ng-bot',
+      'pr',
+      'pullapprove',
+      'release',
+      'ts-circular-dependencies',
+    ]),
+  ],
+};

--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -1,3 +1,4 @@
 export {format} from './format';
 export {github} from './github';
 export {merge} from './merge';
+export {commitMessage} from './commit-message';


### PR DESCRIPTION
See individual commits


Requiring commit messages to conform to our structure will allow us to create a CHANGELOG file which we can set to automatically generate weekly or something similar.