### PR TITLE
build: fix changelog action constructing incorrect version

### DIFF
--- a/tools/local-actions/changelog/lib/main.ts
+++ b/tools/local-actions/changelog/lib/main.ts
@@ -120,7 +120,7 @@ function getLatestRefFromUpstream(branchOrTag: string) {
 /** Create a semver tag based on todays date. */
 function getTodayAsSemver() {
   const today = new Date();
-  return new SemVer(`${today.getFullYear()}.${today.getMonth() + 1}.${today.getDay()}`);
+  return new SemVer(`${today.getFullYear()}.${today.getMonth() + 1}.${today.getDate()}`);
 }
 
 // This action should only be run in the angular/dev-infra repo.

--- a/tools/local-actions/changelog/main.js
+++ b/tools/local-actions/changelog/main.js
@@ -52007,7 +52007,7 @@ function getLatestRefFromUpstream(branchOrTag) {
 }
 function getTodayAsSemver() {
   const today = new Date();
-  return new semver_1.SemVer(`${today.getFullYear()}.${today.getMonth() + 1}.${today.getDay()}`);
+  return new semver_1.SemVer(`${today.getFullYear()}.${today.getMonth() + 1}.${today.getDate()}`);
 }
 if (github_1.context.repo.owner === "angular" && github_1.context.repo.repo === "dev-infra") {
   run().catch((e) => {


### PR DESCRIPTION
We accidentally used `getDay` instead of `getDate` for
constructing the changelog version.