### PR TITLE
refactor(ng-dev): create enum for target label names

### DIFF
--- a/ng-dev/pr/check-target-branches/check-target-branches.ts
+++ b/ng-dev/pr/check-target-branches/check-target-branches.ts
@@ -11,8 +11,11 @@ import {error, info, red} from '../../utils/console';
 import {GitClient} from '../../utils/git/git-client';
 import {assertValidMergeConfig, MergeConfig} from '../merge/config';
 import {
-  getBranchesFromTargetLabel, getMatchingTargetLabelForPullRequest, getTargetBranchesForPullRequest,
-  InvalidTargetLabelError, TargetLabel,
+  getBranchesFromTargetLabel,
+  getMatchingTargetLabelForPullRequest,
+  getTargetBranchesForPullRequest,
+  InvalidTargetLabelError,
+  TargetLabel,
 } from '../merge/target-label';
 
 async function getTargetBranchesForPr(

--- a/ng-dev/pr/merge/config.ts
+++ b/ng-dev/pr/merge/config.ts
@@ -10,16 +10,11 @@ import {ConfigValidationError, GithubConfig} from '../../utils/config';
 
 import {GithubApiMergeStrategyConfig} from './strategies/api-merge';
 
-/** Describes possible values that can be returned for `branches` of a target label. */
-export type TargetLabelBranchResult = string[] | Promise<string[]>;
-
 /**
  * Possible merge methods supported by the Github API.
  * https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button.
  */
 export type GithubApiMergeMethod = 'merge' | 'squash' | 'rebase';
-
-
 
 /**
  * Configuration for the merge script with all remote options specified. The

--- a/ng-dev/pr/merge/config.ts
+++ b/ng-dev/pr/merge/config.ts
@@ -19,23 +19,7 @@ export type TargetLabelBranchResult = string[] | Promise<string[]>;
  */
 export type GithubApiMergeMethod = 'merge' | 'squash' | 'rebase';
 
-/**
- * Target labels represent Github pull requests labels. These labels instruct the merge
- * script into which branches a given pull request should be merged to.
- */
-export interface TargetLabel {
-  /** Pattern that matches the given target label. */
-  pattern: RegExp | string;
-  /**
-   * List of branches a pull request with this target label should be merged into.
-   * Can also be wrapped in a function that accepts the target branch specified in the
-   * Github Web UI. This is useful for supporting labels like `target: development-branch`.
-   *
-   * @throws {InvalidTargetLabelError} Invalid label has been applied to pull request.
-   * @throws {InvalidTargetBranchError} Invalid Github target branch has been selected.
-   */
-  branches: TargetLabelBranchResult | ((githubTargetBranch: string) => TargetLabelBranchResult);
-}
+
 
 /**
  * Configuration for the merge script with all remote options specified. The

--- a/ng-dev/pr/merge/defaults/integration.spec.ts
+++ b/ng-dev/pr/merge/defaults/integration.spec.ts
@@ -13,7 +13,11 @@ import {_npmPackageInfoCache, NpmPackageInfo} from '../../../release/versioning/
 import {GithubConfig} from '../../../utils/config';
 import * as console from '../../../utils/console';
 import {GithubClient} from '../../../utils/git/github';
-import {getBranchesFromTargetLabel, getMatchingTargetLabelForPullRequest, TargetLabel} from '../target-label';
+import {
+  getBranchesFromTargetLabel,
+  getMatchingTargetLabelForPullRequest,
+  TargetLabel,
+} from '../target-label';
 import * as labelDefaults from './labels';
 
 import {fakeGithubPaginationResponse} from '../../../utils/testing/github-interception';
@@ -101,8 +105,10 @@ describe('default target labels', () => {
     name: string,
     githubTargetBranch = 'master',
   ): Promise<string[] | null> {
-    const targetLabels = await getTargetLabelsForActiveReleaseTrains(
-      api, {github: githubConfig, release: releaseConfig});
+    const targetLabels = await getTargetLabelsForActiveReleaseTrains(api, {
+      github: githubConfig,
+      release: releaseConfig,
+    });
     let label: TargetLabel;
     try {
       label = await getMatchingTargetLabelForPullRequest({}, [name], targetLabels);

--- a/ng-dev/pr/merge/defaults/labels.ts
+++ b/ng-dev/pr/merge/defaults/labels.ts
@@ -15,25 +15,40 @@ import {
 } from '../../../release/versioning';
 import {assertValidGithubConfig, getConfig, GithubConfig} from '../../../utils/config';
 import {GitClient} from '../../../utils/git/git-client';
-import {GithubClient} from '../../../utils/git/github';
-import {TargetLabel} from '../config';
-import {InvalidTargetBranchError, InvalidTargetLabelError} from '../target-label';
+import {InvalidTargetBranchError, InvalidTargetLabelError, TargetLabel} from '../target-label';
 
 import {assertActiveLtsBranch} from './lts-branch';
 
 /**
- * Gets a label configuration for the merge tooling that reflects the default Angular
- * organization-wide labeling and branching semantics as outlined in the specification.
+ * Enum capturing available target label names in the Angular organization. A target
+ * label is set on a pull request to specify where its changes should land.
  *
+ * More details can be found here:
+ * https://docs.google.com/document/d/197kVillDwx-RZtSVOBtPb4BBIAw0E9RT3q3v6DZkykU#heading=h.lkuypj38h15d
+ */
+export enum TargetLabelName {
+  MAJOR = 'target: major',
+  MINOR = 'target: minor',
+  PATCH = 'target: patch',
+  RELEASE_CANDIDATE = 'target: rc',
+  LONG_TERM_SUPPORT = 'target: lts',
+}
+
+
+/**
+ * Gets a list of target labels which should be considered by the merge
+ * tooling when a pull request is processed to be merged.
+ *
+ * The target labels are implemented according to the design document which
+ * specifies versioning, branching and releasing for the Angular organization:
  * https://docs.google.com/document/d/197kVillDwx-RZtSVOBtPb4BBIAw0E9RT3q3v6DZkykU
  *
  * @param api Instance of an authenticated Github client.
- * @param githubConfig Configuration for the Github remote. Used as Git remote
  *   for the release train branches.
- * @param releaseConfig Configuration for the release packages. Used to fetch
+ * @param config Configuration for the Github remote and release packages. Used to fetch
  *   NPM version data when LTS version branches are validated.
  */
-export async function getTargetLabels(
+export async function getTargetLabelsForActiveReleaseTrains(
   api = GitClient.get().github,
   config = getConfig() as Partial<{github: GithubConfig; release: ReleaseConfig}>,
 ): Promise<TargetLabel[]> {
@@ -51,7 +66,7 @@ export async function getTargetLabels(
 
   return [
     {
-      pattern: 'target: major',
+      pattern: TargetLabelName.MAJOR,
       branches: () => {
         // If `next` is currently not designated to be a major version, we do not
         // allow merging of PRs with `target: major`.
@@ -65,7 +80,7 @@ export async function getTargetLabels(
       },
     },
     {
-      pattern: 'target: minor',
+      pattern: TargetLabelName.MINOR,
       // Changes labeled with `target: minor` are merged most commonly into the next branch
       // (i.e. `main`). In rare cases of an exceptional minor version while being
       // already on a major release train, this would need to be overridden manually.
@@ -75,7 +90,7 @@ export async function getTargetLabels(
       branches: [nextBranchName],
     },
     {
-      pattern: 'target: patch',
+      pattern: TargetLabelName.PATCH,
       branches: (githubTargetBranch) => {
         // If a PR is targeting the latest active version-branch through the Github UI,
         // and is also labeled with `target: patch`, then we merge it directly into the
@@ -95,7 +110,7 @@ export async function getTargetLabels(
       },
     },
     {
-      pattern: 'target: rc',
+      pattern: TargetLabelName.RELEASE_CANDIDATE,
       branches: (githubTargetBranch) => {
         // The `target: rc` label cannot be applied if there is no active feature-freeze
         // or release-candidate release train.
@@ -121,7 +136,7 @@ export async function getTargetLabels(
       // active LTS branches for PRs created against any other branch. Instead, PR authors need
       // to manually create separate PRs for desired LTS branches. Additionally, active LT branches
       // commonly diverge quickly. This makes cherry-picking not an option for LTS changes.
-      pattern: 'target: lts',
+      pattern: TargetLabelName.LONG_TERM_SUPPORT,
       branches: async (githubTargetBranch) => {
         if (!isVersionBranch(githubTargetBranch)) {
           throw new InvalidTargetBranchError(

--- a/ng-dev/pr/merge/failures.ts
+++ b/ng-dev/pr/merge/failures.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TargetLabel} from './config';
 import {breakingChangeLabel} from './constants';
+import {TargetLabel} from './target-label';
 
 /**
  * Class that can be used to describe pull request failures. A failure

--- a/ng-dev/pr/merge/failures.ts
+++ b/ng-dev/pr/merge/failures.ts
@@ -95,14 +95,14 @@ export class PullRequestFailure {
 
   static hasBreakingChanges(label: TargetLabel) {
     const message =
-      `Cannot merge into branch for "${label.pattern}" as the pull request has ` +
+      `Cannot merge into branch for "${label.name}" as the pull request has ` +
       `breaking changes. Breaking changes can only be merged with the "target: major" label.`;
     return new this(message);
   }
 
   static hasDeprecations(label: TargetLabel) {
     const message =
-      `Cannot merge into branch for "${label.pattern}" as the pull request ` +
+      `Cannot merge into branch for "${label.name}" as the pull request ` +
       `contains deprecations. Deprecations can only be merged with the "target: minor" or ` +
       `"target: major" label.`;
     return new this(message);
@@ -110,7 +110,7 @@ export class PullRequestFailure {
 
   static hasFeatureCommits(label: TargetLabel) {
     const message =
-      `Cannot merge into branch for "${label.pattern}" as the pull request has ` +
+      `Cannot merge into branch for "${label.name}" as the pull request has ` +
       'commits with the "feat" type. New features can only be merged with the "target: minor" ' +
       'or "target: major" label.';
     return new this(message);

--- a/ng-dev/pr/merge/fetch-pull-request.ts
+++ b/ng-dev/pr/merge/fetch-pull-request.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {params, types as graphqlTypes} from 'typed-graphqlify';
+import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client';
+import {getPr} from '../../utils/github';
+
+/** Graphql schema for the response body the requested pull request. */
+const PR_SCHEMA = {
+  url: graphqlTypes.string,
+  isDraft: graphqlTypes.boolean,
+  state: graphqlTypes.oneOf(['OPEN', 'MERGED', 'CLOSED'] as const),
+  number: graphqlTypes.number,
+  // Only the last 100 commits from a pull request are obtained as we likely will never see a pull
+  // requests with more than 100 commits.
+  commits: params(
+    {last: 100},
+    {
+      totalCount: graphqlTypes.number,
+      nodes: [
+        {
+          commit: {
+            status: {
+              state: graphqlTypes.oneOf(['FAILURE', 'PENDING', 'SUCCESS'] as const),
+            },
+            message: graphqlTypes.string,
+          },
+        },
+      ],
+    },
+  ),
+  baseRefName: graphqlTypes.string,
+  title: graphqlTypes.string,
+  labels: params(
+    {first: 100},
+    {
+      nodes: [
+        {
+          name: graphqlTypes.string,
+        },
+      ],
+    },
+  ),
+};
+
+/** A pull request retrieved from github via the graphql API. */
+export type RawPullRequest = typeof PR_SCHEMA;
+
+/** Fetches a pull request from Github. Returns null if an error occurred. */
+export async function fetchPullRequestFromGithub(
+  git: AuthenticatedGitClient,
+  prNumber: number,
+): Promise<RawPullRequest | null> {
+  return await getPr(PR_SCHEMA, prNumber, git);
+}

--- a/ng-dev/pr/merge/pull-request.ts
+++ b/ng-dev/pr/merge/pull-request.ts
@@ -125,4 +125,3 @@ export async function loadAndValidatePullRequest(
 export function isPullRequest(v: PullRequestFailure | PullRequest): v is PullRequest {
   return (v as PullRequest).targetBranches !== undefined;
 }
-

--- a/ng-dev/pr/merge/target-label.ts
+++ b/ng-dev/pr/merge/target-label.ts
@@ -6,9 +6,34 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MergeConfig, TargetLabel} from './config';
-import {getTargetLabels} from './defaults/labels';
+import {MergeConfig} from './config';
 import {matchesPattern} from './string-pattern';
+import {getTargetLabelsForActiveReleaseTrains} from './defaults';
+import {GithubConfig} from '../../utils/config';
+import {Commit} from '../../commit-message/parse';
+import {assertChangesAllowForTargetLabel} from './validations';
+import {PullRequestFailure} from './failures';
+
+/** Describes possible values that can be returned for `branches` of a target label. */
+export type TargetLabelBranchResult = string[] | Promise<string[]>;
+
+/**
+ * Matcher that can resolve a Github label to a list of branches into which a pull
+ * request should be merged into..
+ */
+export interface TargetLabel {
+  /** Pattern that matches the given target label. */
+  pattern: RegExp | string;
+  /**
+   * List of branches a pull request with this target label should be merged into.
+   * Can also be wrapped in a function that accepts the target branch specified in the
+   * Github Web UI. This is useful for supporting labels like `target: development-branch`.
+   *
+   * @throws {InvalidTargetLabelError} Invalid label has been applied to pull request.
+   * @throws {InvalidTargetBranchError} Invalid Github target branch has been selected.
+   */
+  branches: TargetLabelBranchResult | ((githubTargetBranch: string) => TargetLabelBranchResult);
+}
 
 /**
  * Unique error that can be thrown in the merge configuration if an
@@ -27,19 +52,19 @@ export class InvalidTargetLabelError {
 }
 
 /** Gets the target label from the specified pull request labels. */
-export async function getTargetLabelFromPullRequest(
+export async function getMatchingTargetLabelForPullRequest(
   config: Pick<MergeConfig, 'noTargetLabeling'>,
-  labels: string[],
+  labelsOnPullRequest: string[],
+  allTargetLabels: TargetLabel[],
 ): Promise<TargetLabel> {
   if (config.noTargetLabeling) {
     throw Error('This repository does not use target labels');
   }
 
-  const targetLabels = await getTargetLabels();
-  /** List of discovered target labels for the PR. */
-  const matches = [];
-  for (const label of labels) {
-    const match = targetLabels.find(({pattern}) => matchesPattern(label, pattern));
+  const matches: TargetLabel[] = [];
+
+  for (const label of labelsOnPullRequest) {
+    const match = allTargetLabels.find(({pattern}) => matchesPattern(label, pattern));
     if (match !== undefined) {
       matches.push(match);
     }
@@ -55,6 +80,38 @@ export async function getTargetLabelFromPullRequest(
   throw new InvalidTargetLabelError(
     'Unable to determine target for the PR as it has multiple target labels.',
   );
+}
+
+/** Get the branches the pull request should be merged into. */
+export async function getTargetBranchesForPullRequest(
+  config: {merge: MergeConfig; github: GithubConfig},
+  labelsOnPullRequest: string[],
+  githubTargetBranch: string,
+  commits: Commit[],
+): Promise<string[]> {
+  if (config.merge.noTargetLabeling) {
+    return [config.github.mainBranchName];
+  }
+
+  // If branches are determined for a given target label, capture errors that are
+  // thrown as part of branch computation. This is expected because a merge configuration
+  // can lazily compute branches for a target label and throw. e.g. if an invalid target
+  // label is applied, we want to exit the script gracefully with an error message.
+  try {
+    const targetLabels = await getTargetLabelsForActiveReleaseTrains();
+    const matchingLabel = await getMatchingTargetLabelForPullRequest(
+        config.merge, labelsOnPullRequest, targetLabels);
+    const targetBranches = await getBranchesFromTargetLabel(matchingLabel, githubTargetBranch);
+
+    assertChangesAllowForTargetLabel(commits, matchingLabel, config.merge);
+
+    return targetBranches;
+  } catch (error) {
+    if (error instanceof InvalidTargetBranchError || error instanceof InvalidTargetLabelError) {
+      throw new PullRequestFailure(error.failureMessage);
+    }
+    throw error;
+  }
 }
 
 /**

--- a/ng-dev/pr/merge/validations.ts
+++ b/ng-dev/pr/merge/validations.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Commit} from '../../commit-message/parse';
+import {TargetLabel} from './target-label';
+import {MergeConfig} from './config';
+import {PullRequestFailure} from './failures';
+import {red, warn} from '../../utils/console';
+import {breakingChangeLabel} from './constants';
+import {TargetLabelName} from './defaults';
+import {RawPullRequest} from './fetch-pull-request';
+
+/**
+ * Assert the commits provided are allowed to merge to the provided target label,
+ * throwing an error otherwise.
+ * @throws {PullRequestFailure}
+ */
+export function assertChangesAllowForTargetLabel(
+  commits: Commit[],
+  label: TargetLabel,
+  config: MergeConfig,
+) {
+  /**
+   * List of commit scopes which are exempted from target label content requirements. i.e. no `feat`
+   * scopes in patch branches, no breaking changes in minor or patch changes.
+   */
+  const exemptedScopes = config.targetLabelExemptScopes || [];
+  /** List of commits which are subject to content requirements for the target label. */
+  commits = commits.filter((commit) => !exemptedScopes.includes(commit.scope));
+  const hasBreakingChanges = commits.some((commit) => commit.breakingChanges.length !== 0);
+  const hasDeprecations = commits.some((commit) => commit.deprecations.length !== 0);
+  const hasFeatureCommits = commits.some((commit) => commit.type === 'feat');
+  switch (label.pattern) {
+    case TargetLabelName.MAJOR:
+      break;
+    case TargetLabelName.MINOR:
+      if (hasBreakingChanges) {
+        throw PullRequestFailure.hasBreakingChanges(label);
+      }
+      break;
+    case TargetLabelName.RELEASE_CANDIDATE:
+    case TargetLabelName.LONG_TERM_SUPPORT:
+    case TargetLabelName.PATCH:
+      if (hasBreakingChanges) {
+        throw PullRequestFailure.hasBreakingChanges(label);
+      }
+      if (hasFeatureCommits) {
+        throw PullRequestFailure.hasFeatureCommits(label);
+      }
+      // Deprecations should not be merged into RC, patch or LTS branches.
+      // https://semver.org/#spec-item-7. Deprecations should be part of
+      // minor releases, or major releases according to SemVer.
+      if (hasDeprecations) {
+        throw PullRequestFailure.hasDeprecations(label);
+      }
+      break;
+    default:
+      warn(red('WARNING: Unable to confirm all commits in the pull request are eligible to be'));
+      warn(red(`merged into the target branch: ${label.pattern}`));
+      break;
+  }
+}
+
+/**
+ * Assert the pull request has the proper label for breaking changes if there are breaking change
+ * commits, and only has the label if there are breaking change commits.
+ * @throws {PullRequestFailure}
+ */
+export function assertCorrectBreakingChangeLabeling(commits: Commit[], pullRequestLabels: string[]) {
+  /** Whether the PR has a label noting a breaking change. */
+  const hasLabel = pullRequestLabels.includes(breakingChangeLabel);
+  //** Whether the PR has at least one commit which notes a breaking change. */
+  const hasCommit = commits.some((commit) => commit.breakingChanges.length !== 0);
+
+  if (!hasLabel && hasCommit) {
+    throw PullRequestFailure.missingBreakingChangeLabel();
+  }
+
+  if (hasLabel && !hasCommit) {
+    throw PullRequestFailure.missingBreakingChangeCommit();
+  }
+}
+
+/**
+ * Assert the pull request is pending, not closed, merged or in draft.
+ * @throws {PullRequestFailure} if the pull request is not pending.
+ */
+export function assertPendingState(pullRequest: RawPullRequest) {
+  if (pullRequest.isDraft) {
+    throw PullRequestFailure.isDraft();
+  }
+  switch (pullRequest.state) {
+    case 'CLOSED':
+      throw PullRequestFailure.isClosed();
+    case 'MERGED':
+      throw PullRequestFailure.isMerged();
+  }
+}

--- a/ng-dev/pr/merge/validations.ts
+++ b/ng-dev/pr/merge/validations.ts
@@ -7,12 +7,11 @@
  */
 
 import {Commit} from '../../commit-message/parse';
-import {TargetLabel} from './target-label';
+import {TargetLabel, TargetLabelName} from './target-label';
 import {MergeConfig} from './config';
 import {PullRequestFailure} from './failures';
 import {red, warn} from '../../utils/console';
 import {breakingChangeLabel} from './constants';
-import {TargetLabelName} from './defaults';
 import {RawPullRequest} from './fetch-pull-request';
 
 /**
@@ -35,7 +34,7 @@ export function assertChangesAllowForTargetLabel(
   const hasBreakingChanges = commits.some((commit) => commit.breakingChanges.length !== 0);
   const hasDeprecations = commits.some((commit) => commit.deprecations.length !== 0);
   const hasFeatureCommits = commits.some((commit) => commit.type === 'feat');
-  switch (label.pattern) {
+  switch (label.name) {
     case TargetLabelName.MAJOR:
       break;
     case TargetLabelName.MINOR:
@@ -61,7 +60,7 @@ export function assertChangesAllowForTargetLabel(
       break;
     default:
       warn(red('WARNING: Unable to confirm all commits in the pull request are eligible to be'));
-      warn(red(`merged into the target branch: ${label.pattern}`));
+      warn(red(`merged into the target branch: ${label.name}`));
       break;
   }
 }
@@ -71,7 +70,10 @@ export function assertChangesAllowForTargetLabel(
  * commits, and only has the label if there are breaking change commits.
  * @throws {PullRequestFailure}
  */
-export function assertCorrectBreakingChangeLabeling(commits: Commit[], pullRequestLabels: string[]) {
+export function assertCorrectBreakingChangeLabeling(
+  commits: Commit[],
+  pullRequestLabels: string[],
+) {
   /** Whether the PR has a label noting a breaking change. */
   const hasLabel = pullRequestLabels.includes(breakingChangeLabel);
   //** Whether the PR has at least one commit which notes a breaking change. */


### PR DESCRIPTION
Instead of hard-coding the label names for the target labels
the whole Angular organization uses, we now have an enum for
these names, allowing for consistent use of the labels.

This is in preparation for adding the proper target labels
automatically to staging and cherry-pick release PRs. Previously
this was not possible because we still had a possible way to configure
custom target labels, and missed such an enum.

This new enum came together with some refactorings that cleaned up
some of the validation and target label extraction logic. Mostly code
has been split up into individual files, allowing for more readable code
and less convuluted files.

**Note**: This also fixes `yarn ng-dev pr check-target-branches` if target labels are disabled.