### PR TITLE
fix(ng-dev/release): fetch release notes compare tag and store it locally

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -415,7 +415,14 @@ export abstract class ReleaseAction {
     const releaseNotesCompareTag = getReleaseTagForVersion(compareVersionForReleaseNotes);
 
     // Fetch the compare tag so that commits for the release notes can be determined.
-    this.git.run(['fetch', this.git.getRepoGitUrl(), `refs/tags/${releaseNotesCompareTag}`]);
+    // We forcibly override existing local tags that are named similar as we will fetch
+    // the correct tag for release notes comparison from the upstream remote.
+    this.git.run([
+      'fetch',
+      '--force',
+      this.git.getRepoGitUrl(),
+      `refs/tags/${releaseNotesCompareTag}:refs/tags/${releaseNotesCompareTag}`,
+    ]);
 
     // Build release notes for commits from `<releaseNotesCompareTag>..HEAD`.
     const releaseNotes = await ReleaseNotes.forRange(newVersion, releaseNotesCompareTag, 'HEAD');


### PR DESCRIPTION
The release notes compare tag might not exist locally if the local
repository has not been synced with upstream. We fetch the release
notes compare tag in order to be able to build the changelog. Our
current fetch logic incorrectly stores the tag reference in
`FETCH_HEAD`, while we want it to be stored locally. This commit
fixes that.