### PR TITLE
build: introduce script for updating all generated files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "private": true,
   "scripts": {
     "prepare": "husky install",
-    "ng-dev": "ts-node --transpile-only ./ng-dev/cli.ts"
+    "ng-dev": "ts-node --transpile-only ./ng-dev/cli.ts",
+    "update-generated-files": "ts-node --transpile-only ./tools/update-generated-files.ts"
   },
   "dependencies": {
     "@actions/core": "^1.4.0",

--- a/tools/update-generated-files.ts
+++ b/tools/update-generated-files.ts
@@ -1,0 +1,36 @@
+/**
+ * Script that finds all `generated_file_test` targets and runs their `.update` targets.
+ * This is useful if a dependency that is bundled into all checked-in bundles has been
+ * updated. All of the checked-in bundles would need to be updated and it's cumbersome
+ * to manually run all of these targets.
+ */
+
+import {join} from 'path';
+import {spawnSync, SpawnSyncOptionsWithStringEncoding} from 'child_process';
+
+const projectDir = join(__dirname, '../');
+const bazelPath = process.env.BAZEL ?? join(projectDir, 'node_modules/.bin/bazel');
+const spawnOptions: SpawnSyncOptionsWithStringEncoding = {
+  encoding: 'utf8',
+  cwd: projectDir,
+  shell: true,
+};
+
+const queryProcess = spawnSync(
+  bazelPath,
+  ['query', `"kind(nodejs_binary, //...) intersect attr(name, '.update$', //...)"`],
+  spawnOptions,
+);
+
+if (queryProcess.status !== 0) {
+  throw Error(`Unexpected error: ${queryProcess.error ?? queryProcess.stderr}`);
+}
+
+const updateTargets = queryProcess.stdout.trim().split(/\r?\n/);
+
+for (const targetName of updateTargets) {
+  const proc = spawnSync(bazelPath, ['run', targetName], {...spawnOptions, stdio: 'inherit'});
+  if (proc.status !== 0) {
+    throw Error(`Unexpected error while updating: ${targetName}.`);
+  }
+}


### PR DESCRIPTION
Introduces a script for automatically updating all generated
files in the dev-infra repository. This script can be wired
up in a Github action Slash command, or when Renovate updates
dependencies.