### PR TITLE
build: automatically set the action: merge label for renovate changes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "semanticPrefix": "build",
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
-  "labels": ["comp: build", "dependencies"],
+  "labels": ["comp: build", "dependencies", "action: merge"],
   "timezone": "America/Tijuana",
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
Since any change renovate makes is intended to be merged as soon as it passes, it
should have the `action: merge` label as the PR author is ready for its merge.