### PR TITLE
feat(bazel): support for terser v5 and 2020 in rollup_bundle rule

### DIFF
--- a/bazel/benchmark/ng_rollup_bundle/ng_rollup_bundle.bzl
+++ b/bazel/benchmark/ng_rollup_bundle/ng_rollup_bundle.bzl
@@ -24,10 +24,10 @@ def ng_rollup_bundle(
 
     Runs [rollup], [terser_minified] and [brotli] to produce a number of output bundles.
 
-    es2015                          : "%{name}.js"
-    es2015 minified                 : "%{name}.min.js"
-    es2015 minified (compressed)    : "%{name}.min.js.br",
-    es2015 minified (debug)         : "%{name}.min_debug.js"
+    JS                          : "%{name}.js"
+    JS minified                 : "%{name}.min.js"
+    JS minified (compressed)    : "%{name}.min.js.br",
+    JS minified (debug)         : "%{name}.min_debug.js"
 
     It registers `@angular-devkit/build-optimizer` as a rollup plugin by default. This helps
     with further optimization. See https://github.com/angular/angular-cli/tree/master/packages/angular_devkit/build_optimizer.

--- a/bazel/benchmark/ng_rollup_bundle/terser_config.json
+++ b/bazel/benchmark/ng_rollup_bundle/terser_config.json
@@ -1,6 +1,6 @@
 {
-  "output": {
-    "ecma": "es2015",
+  "format": {
+    "ecma": "es2020",
     "comments": false,
     "beautify": "bazel_debug"
   },


### PR DESCRIPTION
Supports for terser v5 in the `ng_rollup_bundle` rule. currently
terser fails because there is a conflicting `--beautify` CLI flag
set by `@bazel/terser` and the `output` option we manually control.

Instead of `output`, the new non-conflicting `format` name should be used:

```
ERROR: Please only specify either output or format option, preferrably
format.
```