### PR TITLE
fix: use --deepen in place of --depth during fetches

### DIFF
--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -49860,10 +49860,10 @@ var require_rebase = __commonJS({
       }
       try {
         (0, console_1.info)(`Checking out PR #${prNumber} from ${fullHeadRef}`);
-        git.run(["fetch", "-q", headRefUrl, headRefName, "--depth=500"]);
+        git.run(["fetch", "-q", headRefUrl, headRefName, "--deepen=500"]);
         git.run(["checkout", "-q", "--detach", "FETCH_HEAD"]);
         (0, console_1.info)(`Fetching ${fullBaseRef} to rebase #${prNumber} on`);
-        git.run(["fetch", "-q", baseRefUrl, baseRefName, "--depth=500"]);
+        git.run(["fetch", "-q", baseRefUrl, baseRefName, "--deepen=500"]);
         const commonAncestorSha = git.run(["merge-base", "HEAD", "FETCH_HEAD"]).stdout.trim();
         const commits = await (0, utils_12.getCommitsInRange)(commonAncestorSha, "HEAD");
         let squashFixups = process.env["CI"] !== void 0 || commits.filter((commit) => commit.isFixup).length === 0 ? false : await (0, console_1.promptConfirm)(`PR #${prNumber} contains fixup commits, would you like to squash them during rebase?`, true);

--- a/ng-dev/pr/rebase/index.ts
+++ b/ng-dev/pr/rebase/index.ts
@@ -90,16 +90,16 @@ export async function rebasePr(prNumber: number, githubToken: string): Promise<n
   }
 
   try {
-    // Fetches are done with --depth=500 increase the likelihood of finding a common ancestor when
+    // Fetches are done with --deepen=500 increase the likelihood of finding a common ancestor when
     // a shallow clone is being used.
 
     // Fetch the branch at the commit of the PR, and check it out in a detached state.
     info(`Checking out PR #${prNumber} from ${fullHeadRef}`);
-    git.run(['fetch', '-q', headRefUrl, headRefName, '--depth=500']);
+    git.run(['fetch', '-q', headRefUrl, headRefName, '--deepen=500']);
     git.run(['checkout', '-q', '--detach', 'FETCH_HEAD']);
     // Fetch the PRs target branch and rebase onto it.
     info(`Fetching ${fullBaseRef} to rebase #${prNumber} on`);
-    git.run(['fetch', '-q', baseRefUrl, baseRefName, '--depth=500']);
+    git.run(['fetch', '-q', baseRefUrl, baseRefName, '--deepen=500']);
 
     const commonAncestorSha = git.run(['merge-base', 'HEAD', 'FETCH_HEAD']).stdout.trim();
 

--- a/tools/local-actions/changelog/lib/main.ts
+++ b/tools/local-actions/changelog/lib/main.ts
@@ -110,7 +110,7 @@ function writeAndAddToGit(filePath: string, contents: string) {
 function getLatestRefFromUpstream(branchOrTag: string) {
   try {
     const git = AuthenticatedGitClient.get();
-    git.runGraceful(['fetch', git.getRepoGitUrl(), branchOrTag, '--depth=250']);
+    git.runGraceful(['fetch', git.getRepoGitUrl(), branchOrTag, '--deepen=250']);
     return git.runGraceful(['rev-parse', 'FETCH_HEAD']).stdout.trim();
   } catch {
     core.error(`Unable to retrieve '${branchOrTag}' from upstream`);

--- a/tools/local-actions/changelog/main.js
+++ b/tools/local-actions/changelog/main.js
@@ -54772,7 +54772,7 @@ function writeAndAddToGit(filePath, contents) {
 function getLatestRefFromUpstream(branchOrTag) {
   try {
     const git = authenticated_git_client_1.AuthenticatedGitClient.get();
-    git.runGraceful(["fetch", git.getRepoGitUrl(), branchOrTag, "--depth=250"]);
+    git.runGraceful(["fetch", git.getRepoGitUrl(), branchOrTag, "--deepen=250"]);
     return git.runGraceful(["rev-parse", "FETCH_HEAD"]).stdout.trim();
   } catch {
     core.error(`Unable to retrieve '${branchOrTag}' from upstream`);


### PR DESCRIPTION
Previously we used `--depth` to ensure that enough commits were included in the repository to effectively
 perform actions.  However, using `--depth` sets the depth of the repository, and if the repository previously
was unshallow, it because a shallow repository.  Instead by using deepen, the depth will be increased by the
provided value.  This will ensure that the enough commits are included and will be a noop if an unshallow
repo is deepened further.