### PR TITLE
fix(bazel): no browsers matching for windows x86_64 cpu

### DIFF
--- a/bazel/browsers/chromium/BUILD.bazel
+++ b/bazel/browsers/chromium/BUILD.bazel
@@ -20,7 +20,7 @@ browser(
             "@org_chromium_chromedriver_macos_arm64//:metadata",
             "@org_chromium_chromium_macos_arm64//:metadata",
         ],
-        "//bazel/constraints:windows_x32": [
+        "//bazel/constraints:windows_x64": [
             "@org_chromium_chromedriver_windows//:metadata",
             "@org_chromium_chromium_windows//:metadata",
         ],

--- a/bazel/browsers/firefox/BUILD.bazel
+++ b/bazel/browsers/firefox/BUILD.bazel
@@ -7,7 +7,6 @@ browser(
     disabled = select({
         # TODO: Consider adding support for Windows. Requires a portable version of
         # Firefox. Official distribution only ships with installers.
-        "//bazel/constraints:windows_x32": "Firefox is not disabled on Windows but always passing",
         "//bazel/constraints:windows_x64": "Firefox is not disabled on Windows but always passing",
         # Note: We keep always keep others enabled. This will result in proper errors if e.g. a
         # linux arm64 machine intends to run tests with Firefox but we miss binaries for the platform.

--- a/bazel/constraints/BUILD.bazel
+++ b/bazel/constraints/BUILD.bazel
@@ -32,14 +32,6 @@ config_setting(
     ],
 )
 
-config_setting(
-    name = "windows_x32",
-    constraint_values = [
-        "@platforms//os:windows",
-        "@platforms//cpu:x86_32",
-    ],
-)
-
 # Make source files available for distribution via pkg_npm
 filegroup(
     name = "files",


### PR DESCRIPTION
With the recent refactorings for supporting M1 browsers, we
added our own constraints/config settings. An incorrect assumption
was made that the x64 CPU constraint would also match the x32 constraint
given that Windows x64 can always run x32 programs. This seems to be
not the case (and makes sense in retrospective).

This commit fixes the browser configurations by always using x64
instead. The x32 constraint is removed because `rules_webtesting`
and other parts of the tooling seem to use x64 windows only, and
at this point supporting 32 bit windows seems not wort maintaining/
the additional maintenance.