### PR TITLE
ci: upload test result XML files to CircleCI after tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,16 @@ commands:
       - run: echo "import %workspace%/.circleci/bazel.rc" >> ./.bazelrc
       - run: ./.circleci/setup-bazel.sh
 
+  prepare_and_store_test_results:
+    description: "Prepare and upload test results"
+    steps:
+      - run:
+          name: Copy JUnit test reports to central folder for upload
+          command: node .circleci/copy-junit-reports.js
+          when: always
+      - store_test_results:
+          path: ./test-results
+
   checkout_and_rebase:
     description: Checkout and rebase the repository
     steps:
@@ -98,6 +108,7 @@ jobs:
       - run:
           name: Run bazel tests
           command: yarn bazel test //...
+      - prepare_and_store_test_results
       - *save_cache
 
   lint:

--- a/.circleci/copy-junit-reports.js
+++ b/.circleci/copy-junit-reports.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+const {execSync} = require('child_process');
+const {join} = require('path');
+const {mkdirSync, rmSync, statSync, readdirSync, copyFileSync} = require('fs');
+
+/**
+ * Discover all test results, which @bazel/jasmine stores as `test.xml` files, in the directory and
+ * return back the list of absolute file paths.
+ */
+const findTestResultsInDir = function (dirPath, files) {
+  for (const file of readdirSync(dirPath)) {
+    const filePath = join(dirPath, file);
+    if (statSync(filePath).isDirectory()) {
+      files = findTestResultsInDir(filePath, files);
+    } else {
+      if (file === 'test.xml') {
+        files.push(filePath);
+      }
+    }
+  }
+  return files;
+};
+
+/** StdOut result from the bazel info command. */
+const bazelInfoOutput = execSync('yarn bazel info', {stdio: 'pipe', encoding: 'utf8'});
+/** Absolute path to the bazel instance's testlog directory.  */
+const testLogPath = bazelInfoOutput.match(/bazel\-testlogs: (.*)/)[1];
+/** List of test result files. */
+const testResultPaths = findTestResultsInDir(testLogPath, []);
+/**
+ * Absolute path to a directory to contain the JUnit test result files.
+ *
+ * Note: The directory created needs to contain a subdirectory which contains the test results in
+ * order for CircleCI to properly discover the test results.
+ */
+const destDirPath = join(__dirname, '../test-results/jasmine');
+
+// Ensure that an empty directory exists to contain the test results reports for upload.
+rmSync(destDirPath, {recursive: true, force: true});
+mkdirSync(destDirPath, {recursive: true});
+
+// Copy each of the test result files to the central test result directory which CircleCI discovers
+// test results in.
+testResultPaths.forEach((filePath, i) => {
+  const destFilePath = join(destDirPath, `results-${i}.xml`);
+  copyFileSync(filePath, destFilePath);
+});

--- a/.circleci/copy-junit-reports.js
+++ b/.circleci/copy-junit-reports.js
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 const {execSync} = require('child_process');
-const {join} = require('path');
+const {join, extname} = require('path');
 const {mkdirSync, rmSync, statSync, readdirSync, copyFileSync} = require('fs');
 
 /**
@@ -19,7 +19,8 @@ const findTestResultsInDir = function (dirPath, files) {
     if (statSync(filePath).isDirectory()) {
       files = findTestResultsInDir(filePath, files);
     } else {
-      if (file === 'test.xml') {
+      // Only the test result files, which are XML with the .xml extension, should be discovered.
+      if (extname(file) === '.xml') {
         files.push(filePath);
       }
     }
@@ -27,10 +28,11 @@ const findTestResultsInDir = function (dirPath, files) {
   return files;
 };
 
-/** StdOut result from the bazel info command. */
-const bazelInfoOutput = execSync('yarn bazel info', {stdio: 'pipe', encoding: 'utf8'});
 /** Absolute path to the bazel instance's testlog directory.  */
-const testLogPath = bazelInfoOutput.match(/bazel\-testlogs: (.*)/)[1];
+const testLogPath = execSync('yarn -s bazel info bazel-testlogs', {
+  stdio: 'pipe',
+  encoding: 'utf8',
+}).trim();
 /** List of test result files. */
 const testResultPaths = findTestResultsInDir(testLogPath, []);
 /**

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log
 .ng-dev.err*
 .ng-dev.log
 .ng-dev.user*
+
+# Don't check in junit test results.
+test-results/*


### PR DESCRIPTION
Uploading test results to CircleCI will provide both the test failure information in the CircleCI UI
as well as allowing CircleCI to provide insights information about test success rates on an individual
test level.

This is useful both in this repository, but will also act as a proving ground for making this kind of
information available in other repositories we manage to gather better metrics.


[Here](https://app.circleci.com/pipelines/github/angular/dev-infra/415/workflows/abe37406-8cb7-43db-8974-feda2aab5323/jobs/841/tests) is an example of what failing tests look like in the CircleCI UI.