### PR TITLE
refactor(ng-dev/pr): move pr configuration out of the merge directory

### DIFF
--- a/ng-dev/pr/BUILD.bazel
+++ b/ng-dev/pr/BUILD.bazel
@@ -13,3 +13,12 @@ ts_library(
         "@npm//@types/yargs",
     ],
 )
+
+ts_library(
+    name = "config",
+    srcs = ["config.ts"],
+    visibility = ["//ng-dev:__subpackages__"],
+    deps = [
+        "//ng-dev/utils",
+    ],
+)

--- a/ng-dev/pr/check-target-branches/BUILD.bazel
+++ b/ng-dev/pr/check-target-branches/BUILD.bazel
@@ -5,6 +5,7 @@ ts_library(
     srcs = glob(["*.ts"]),
     visibility = ["//ng-dev:__subpackages__"],
     deps = [
+        "//ng-dev/pr:config",
         "//ng-dev/pr/merge",
         "//ng-dev/utils",
         "@npm//@types/yargs",

--- a/ng-dev/pr/check-target-branches/check-target-branches.ts
+++ b/ng-dev/pr/check-target-branches/check-target-branches.ts
@@ -9,7 +9,7 @@
 import {assertValidGithubConfig, getConfig, GithubConfig} from '../../utils/config';
 import {info} from '../../utils/console';
 import {GitClient} from '../../utils/git/git-client';
-import {assertValidMergeConfig, MergeConfig} from '../merge/config';
+import {assertValidMergeConfig, MergeConfig} from '../config';
 import {getTargetBranchesForPullRequest} from '../merge/target-label';
 
 async function getTargetBranchesForPr(

--- a/ng-dev/pr/config.ts
+++ b/ng-dev/pr/config.ts
@@ -6,15 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ConfigValidationError, GithubConfig} from '../../utils/config';
-
-import {GithubApiMergeStrategyConfig} from './strategies/api-merge';
+import {ConfigValidationError, GithubConfig} from '../utils/config';
 
 /**
  * Possible merge methods supported by the Github API.
  * https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button.
  */
 export type GithubApiMergeMethod = 'merge' | 'squash' | 'rebase';
+
+/** Configuration for the Github API merge strategy. */
+export interface GithubApiMergeStrategyConfig {
+  /** Default method used for merging pull requests */
+  default: GithubApiMergeMethod;
+  /** Labels which specify a different merge method than the default. */
+  labels?: {pattern: string; method: GithubApiMergeMethod}[];
+}
 
 /**
  * Configuration for the merge script with all remote options specified. The

--- a/ng-dev/pr/merge/BUILD.bazel
+++ b/ng-dev/pr/merge/BUILD.bazel
@@ -16,6 +16,7 @@ ts_library(
     ],
     deps = [
         "//ng-dev/commit-message",
+        "//ng-dev/pr:config",
         "//ng-dev/pr/common",
         "//ng-dev/release/config",
         "//ng-dev/release/versioning",

--- a/ng-dev/pr/merge/index.ts
+++ b/ng-dev/pr/merge/index.ts
@@ -12,7 +12,7 @@ import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client';
 import {GithubApiRequestError} from '../../utils/git/github';
 import {GITHUB_TOKEN_GENERATE_URL} from '../../utils/git/github-urls';
 
-import {assertValidMergeConfig} from './config';
+import {assertValidMergeConfig} from '../config';
 import {MergeResult, MergeStatus, PullRequestMergeTask, PullRequestMergeTaskFlags} from './task';
 
 /**

--- a/ng-dev/pr/merge/strategies/api-merge.ts
+++ b/ng-dev/pr/merge/strategies/api-merge.ts
@@ -11,7 +11,7 @@ import {prompt} from 'inquirer';
 
 import {parseCommitMessage} from '../../../commit-message/parse';
 import {AuthenticatedGitClient} from '../../../utils/git/authenticated-git-client';
-import {GithubApiMergeMethod} from '../config';
+import {GithubApiMergeMethod, GithubApiMergeStrategyConfig} from '../../config';
 import {PullRequestFailure} from '../failures';
 import {PullRequest} from '../pull-request';
 import {matchesPattern} from '../string-pattern';
@@ -21,14 +21,6 @@ import {GithubApiRequestError} from '../../../utils/git/github';
 
 /** Type describing the parameters for the Octokit `merge` API endpoint. */
 type OctokitMergeParams = RestEndpointMethodTypes['pulls']['merge']['parameters'];
-
-/** Configuration for the Github API merge strategy. */
-export interface GithubApiMergeStrategyConfig {
-  /** Default method used for merging pull requests */
-  default: GithubApiMergeMethod;
-  /** Labels which specify a different merge method than the default. */
-  labels?: {pattern: string; method: GithubApiMergeMethod}[];
-}
 
 /** Separator between commit message header and body. */
 const COMMIT_HEADER_SEPARATOR = '\n\n';

--- a/ng-dev/pr/merge/target-label.ts
+++ b/ng-dev/pr/merge/target-label.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {MergeConfig} from './config';
+import {MergeConfig} from '../config';
 import {getTargetLabelsForActiveReleaseTrains} from './defaults';
 import {GithubConfig} from '../../utils/config';
 import {Commit} from '../../commit-message/parse';

--- a/ng-dev/pr/merge/task.ts
+++ b/ng-dev/pr/merge/task.ts
@@ -10,7 +10,7 @@ import {promptConfirm} from '../../utils/console';
 import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client';
 import {GitCommandError} from '../../utils/git/git-client';
 
-import {MergeConfigWithRemote} from './config';
+import {MergeConfigWithRemote} from '../config';
 import {PullRequestFailure} from './failures';
 import {
   getCaretakerNotePromptMessage,

--- a/ng-dev/pr/merge/validations.ts
+++ b/ng-dev/pr/merge/validations.ts
@@ -8,7 +8,7 @@
 
 import {Commit} from '../../commit-message/parse';
 import {TargetLabel, TargetLabelName} from './target-label';
-import {MergeConfig} from './config';
+import {MergeConfig} from '../config';
 import {PullRequestFailure} from './failures';
 import {red, warn} from '../../utils/console';
 import {breakingChangeLabel} from './constants';


### PR DESCRIPTION
As part of #203, refactoring the pr directory into more reusable pieces.