### PR TITLE
build: update tsconfig.json to allow editor to properly follow typings/deps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "moduleResolution": "node",
-    "outDir": "dist/tsc-output"
+    "noEmit": false
   },
   "include": [
     "bazel/",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,18 @@
   "compilerOptions": {
     "module": "CommonJS",
     "target": "es2020",
-    "lib": ["es2020"],
+    "lib": ["DOM", "es2020"],
     "strict": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
-    "moduleResolution": "node"
-  }
+    "moduleResolution": "node",
+    "outDir": "dist/tsc-output"
+  },
+  "include": [
+    "bazel/",
+    "github-actions/",
+    "ng-dev/",
+    "tools/",
+    "tslint-rules/",
+  ]
 }


### PR DESCRIPTION
Update `tsconfig.json` to only include the directories which contain source code in the repository to prevent editors from discovering code in `bazel-out/` and `dist/` as source code.