### PR TITLE
fix(ng-dev/release): prepare-commit-message hook accidentally running when bump commit is created

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -386,6 +386,9 @@ export abstract class ReleaseAction {
     // Note: `git add` would not be needed if the files are already known to
     // Git, but the specified files could also be newly created, and unknown.
     this.git.run(['add', ...files]);
+    // Note: `--no-verify` skips the majority of commit hooks here, but there are hooks
+    // like `prepare-commit-message` which still run. We have set the `HUSKY=0` environment
+    // variable at the start of the publish command to ignore such hooks as well.
     this.git.run(['commit', '-q', '--no-verify', '-m', message, ...files]);
   }
 

--- a/ng-dev/release/publish/index.ts
+++ b/ng-dev/release/publish/index.ts
@@ -60,6 +60,13 @@ export class ReleaseTool {
       return CompletionState.MANUALLY_ABORTED;
     }
 
+    // Set the environment variable to skip all git commit hooks triggered by husky. We are unable to
+    // rely on `--no-verify` as some hooks still run, notably the `prepare-commit-msg` hook.
+    // Running hooks has the downside of potentially running code (like the `ng-dev` tool) when a version
+    // branch is checked out, but the node modules are not re-installed. The tool switches branches
+    // multiple times per execution, and it is not desirable re-running Yarn all the time.
+    process.env['HUSKY'] = '0';
+
     const repo: ReleaseRepoWithApi = {owner, name, api: this._git.github, nextBranchName};
     const releaseTrains = await fetchActiveReleaseTrains(repo);
 


### PR DESCRIPTION
The `prepare-commit-message` hook can still accidentally run when the
changelog / version bump commit is created. This is problematic because
when a version branch is checked out (like the patch branch), the node
modules are not necessarily updated/re-installed, and the node modules
from master remain installed. This can cause runtime errors when Git
hooks accidentally run with a tool from the node modules (like `ng-dev`
itself).

We fix this by also setting the `HUSKY` environment variable, similar to
how the merge tool does. We can assume that Husky is used in all
repositories. This should be our standard for hooks.