### PR TITLE
fix(ng-dev): add `DEPRECATION` to invalid commit message

### DIFF
--- a/ng-dev/commit-message/validate.spec.ts
+++ b/ng-dev/commit-message/validate.spec.ts
@@ -377,6 +377,17 @@ describe('validate-commit-message.js', () => {
         expectValidationResult(validateCommitMessage(incorrectKeyword3), INVALID, [
           'The commit message body contains an invalid deprecation note.',
         ]);
+
+        const incorrectKeyword4 =
+          'feat(compiler): this is just a usual commit message title\n\n' +
+          'This is a normal commit message body which does not exceed the max length\n' +
+          'limit. For more details see the following super long URL:\n\n' +
+          'DEPRECATION:\n' +
+          ' * A to be removed\n' +
+          ' * B to be removed';
+        expectValidationResult(validateCommitMessage(incorrectKeyword4), INVALID, [
+          'The commit message body contains an invalid deprecation note.',
+        ]);
       });
     });
 

--- a/ng-dev/commit-message/validate.ts
+++ b/ng-dev/commit-message/validate.ts
@@ -46,10 +46,11 @@ const INCORRECT_BREAKING_CHANGE_BODY_RE =
  *
  *   - `DEPRECATED <some-content>` | Here we assume the colon is missing by accident.
  *   - `DEPRECATIONS: <some-content>` | The wrong keyword is used here.
+ *   - `DEPRECATION: <some-content>` | The wrong keyword is used here.
  *   - `DEPRECATE: <some-content>` | The wrong keyword is used here.
  *   - `DEPRECATES: <some-content>` | The wrong keyword is used here.
  */
-const INCORRECT_DEPRECATION_BODY_RE = /^(DEPRECATED[^:]|DEPRECATIONS|DEPRECATE:|DEPRECATES)/m;
+const INCORRECT_DEPRECATION_BODY_RE = /^(DEPRECATED[^:]|DEPRECATIONS?|DEPRECATE:|DEPRECATES)/m;
 
 /** Validate a commit message against using the local repo's config. */
 export function validateCommitMessage(


### PR DESCRIPTION
At the moment if `DEPRECATION :` is used to mark deprecations the commit validation will not fail. This PR addresses this.