### PR TITLE
build: use nvmrc version to set node version in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,7 +26,7 @@ http_archive(
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 
 node_repositories(
-    node_version = "16.10.0",
+    use_nvmrc = "//:.nvmrc",
 )
 
 yarn_install(


### PR DESCRIPTION
Use the nvmrc version to set the version of node used in WORKSPACE to more centrally manage the version of node being used.