### PR TITLE
build: ship integration rule to NPM package

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -8,6 +8,7 @@ filegroup(
         "//bazel/benchmark:files",
         "//bazel/browsers:files",
         "//bazel/constraints:files",
+        "//bazel/integration:files",
         "//bazel/remote-execution:files",
     ],
     visibility = ["//:npm"],


### PR DESCRIPTION
This commit fixes that integration rule is not shipped
to the NPM package.