### PR TITLE
test: enable sharding for publish release test

### DIFF
--- a/ng-dev/release/publish/test/BUILD.bazel
+++ b/ng-dev/release/publish/test/BUILD.bazel
@@ -30,6 +30,7 @@ ts_library(
 jasmine_node_test(
     name = "test",
     args = ["'$(GIT_BIN_PATH)'"],
+    shard_count = 6,
     specs = [":test_lib"],
     toolchains = ["//tools/git-toolchain:current_git_toolchain"],
 )


### PR DESCRIPTION
Enables sharding for the publish release test as it became
slower over time, most likely the actual Sandbox git client
testing had an effect on this as well.

The test currently took ~20sec with RBE on CI which is rather
slow compared to other tests.