### PR TITLE
ci: rename `breaking-changes-label` workflow to `commit_message_based_labels`

### DIFF
--- a/.github/workflows/commit-message-based-labels.yml
+++ b/.github/workflows/commit-message-based-labels.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  breaking_changes_label:
+  commit_message_based_labels:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION


This is to match the action action performed by the GH action.