### PR TITLE
fix(ng-dev/release): fix description for TagRecentMajorAsLatest action

### DIFF
--- a/ng-dev/release/publish/actions/tag-recent-major-as-latest.ts
+++ b/ng-dev/release/publish/actions/tag-recent-major-as-latest.ts
@@ -28,7 +28,7 @@ import {getReleaseTagForVersion} from '../../versioning/version-tags';
  */
 export class TagRecentMajorAsLatest extends ReleaseAction {
   override async getDescription() {
-    return `Tag recently published major v${this.active.latest.version} as "next" in NPM.`;
+    return `Retag recently published major v${this.active.latest.version} as "latest" in NPM.`;
   }
 
   override async perform() {


### PR DESCRIPTION
The `TagRecentMajorAsLatest` action errantly said it was tagging the version as `next` when it tags it as `latest`.