### PR TITLE
ci: set up OSS abuse orb to monitor usage on the angular/angular repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@
 
 version: 2.1
 
+orbs:
+  buildalert: oss-tools/buildalert@0.1.0
+
 # **Note**: When updating the beginning of the cache key, also update the cache key to match
 # the new cache key prefix. This allows us to take advantage of CircleCI's fallback caching.
 # Read more here: https://circleci.com/docs/2.0/caching/#restoring-cache.
@@ -141,6 +144,20 @@ jobs:
 
 workflows:
   version: 2
+  oss_abuse_monitoring:
+    triggers:
+      - schedule:
+          cron: "* * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - buildalert/monitor-builds:
+          circle-project-org: 'angular'
+          circle-project-reponame: 'angular'
+          circle-token-envvar: 'OSS_ABUSE_CIRCLECI_TOKEN'
+          slack-app-url-envvar: 'OSS_ABUSE_SLACK_URL'
   default_workflow:
     jobs:
       - test


### PR DESCRIPTION
Set up the OSS abuse orb provided to use by CircleCI to monitor build frequency on angular/angular.

Orb information can be found at: https://circleci.com/developer/orbs/orb/oss-tools/buildalert