### PR TITLE
fix(github-actions): properly set the authentication token for feature request action

### DIFF
--- a/github-actions/feature-request/main.js
+++ b/github-actions/feature-request/main.js
@@ -11762,7 +11762,7 @@ var require_octokit = __commonJS({
         this.options = options;
         this._orgMembers = new Set();
         this.mockLabels = new Set();
-        this._octokit = new rest_1.Octokit({ token });
+        this._octokit = new rest_1.Octokit({ auth: token });
       }
       get octokit() {
         return this._octokit;

--- a/github-actions/feature-request/src/octokit.ts
+++ b/github-actions/feature-request/src/octokit.ts
@@ -34,7 +34,7 @@ export class OctoKit implements GitHubAPI {
     protected params: {repo: string; owner: string},
     protected options: {readonly: boolean} = {readonly: false},
   ) {
-    this._octokit = new Octokit({token});
+    this._octokit = new Octokit({auth: token});
   }
 
   async *query(query: Query): AsyncIterableIterator<GitHubIssueAPI> {


### PR DESCRIPTION
The `Octokit` constructor was initially created with an older version of `Octokit` which supported
providing the token as a property `token`, the property is now expected to be `auth` to properly
use the token for authentication.