### PR TITLE
refactor: ship `BUILD.bazel` files for shared scripts

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -15,8 +15,9 @@ basePackageSubstitutions = {
     "//ng-dev:": "@npm//@angular/dev-infra-private/ng-dev:",
     "//tslint-rules/": "@npm//@angular/dev-infra-private/tslint-rules/",
     "//tslint-rules:": "@npm//@angular/dev-infra-private/tslint-rules:",
+    "//shared-scripts/": "@npm//@angular/dev-infra-private/shared-scripts/",
+    "//shared-scripts:": "@npm//@angular/dev-infra-private/shared-scripts:",
     "//:tsconfig.json": "@npm//@angular/dev-infra-private:tsconfig.json",
-    "//shared-scripts[:/][^\"]+": "@npm//@angular/dev-infra-private",
 }
 
 NPM_PACKAGE_SUBSTITUTIONS = select({

--- a/shared-scripts/BUILD.bazel
+++ b/shared-scripts/BUILD.bazel
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "static_files",
-    srcs = [
+    srcs = glob(["*"]) + [
         "//shared-scripts/angular-linker:static_files",
     ],
 )

--- a/shared-scripts/README.md
+++ b/shared-scripts/README.md
@@ -1,0 +1,10 @@
+## shared-scripts
+
+This is a Directory containing scripts that are commonly used in consumer Angular projects or
+Bazel actions.
+
+#### Important Note for authors:
+
+We also expose the `BUILD.bazel` files here as this allows for fine-grained dependencies when
+scripts are used within Bazel actions, and it helps with using these shared scripts directly
+in the `angular/dev-infra` repository itself.


### PR DESCRIPTION
In order to simplify the use of the shared scripts within the dev-infra
repo itself, and within consumer projects, while also improving the
dependency managment and runfile tree creation, we start shipping the
actual `BUILD.bazel` files for the shared scripts.

This allows us to just continue using the shared-scripts Bazel targets
within Bazel tools, without needing any substitutions. And it also
ensures that the scripts will have the proper dependencies within Bazel
actions (e.g. by relying on a `js_library`). This also reduces the set
of unnecessary runfiles being brought in as the whole
`@angular/dev-infra-private` package and transitive deps wouldn't be
always needed.

This also works better within the FW repo where e.g.
`@angular/compiler` needs to be resolved through the Bazel NodeJS
linker. Running the scripts (like spec-bundling) directly in NodeJS
would not work as it wouldn't find the e.g. compiler.