### PR TITLE
refactor: add workaround for shared-scripts not working with linker

### DIFF
--- a/shared-scripts/angular-linker/BUILD.bazel
+++ b/shared-scripts/angular-linker/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin", "js_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -7,10 +7,17 @@ filegroup(
     srcs = glob(["*"]),
 )
 
+# Workaround for: https://github.com/bazelbuild/rules_nodejs/pull/3083.
+# TODO: Remove this once non-generated files can work with the linker.
+copy_to_bin(
+    name = "js_lib_files",
+    srcs = ["esbuild-plugin.mjs"],
+)
+
 js_library(
     name = "js_lib",
     package_name = "@angular/dev-infra-private/shared-scripts/angular-linker",
-    srcs = ["esbuild-plugin.mjs"],
+    srcs = [":js_lib_files"],
     deps = [
         "@npm//@angular/compiler-cli",
         "@npm//@babel/core",


### PR DESCRIPTION
Adds a small workaround for
https://github.com/bazelbuild/rules_nodejs/pull/3083.

Currently it is not possible to expose a `js_library` from an external
workspace and make it work with the linker. The JS library rule always
assumes that files are located in the `bazel-out/<..>/bin` directory.
This is not necessarily true and it would also be inefficient always
copying sources to the bazel-out when they originate from an external
workspace (although that is what we are doing now as a workaround).