### PR TITLE
fix(ng-dev/release): do not error when yarn version of publish branch is older

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -80,25 +80,12 @@ export abstract class ReleaseAction {
    */
   abstract perform(): Promise<void>;
 
-  /** Cached found fork of the configured project. */
-  private _cachedForkRepo: GithubRepo | null = null;
-
   constructor(
     protected active: ActiveReleaseTrains,
     protected git: AuthenticatedGitClient,
     protected config: ReleaseConfig,
     protected projectDir: string,
   ) {}
-
-  /** Retrieves the version in the project top-level `package.json` file. */
-  private async getProjectVersion() {
-    const pkgJsonPath = join(this.projectDir, workspaceRelativePackageJsonPath);
-    const pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, 'utf8')) as {
-      version: string;
-      [key: string]: any;
-    };
-    return new semver.SemVer(pkgJson.version);
-  }
 
   /** Updates the version in the project top-level `package.json` file. */
   protected async updateProjectVersion(newVersion: semver.SemVer) {
@@ -599,7 +586,7 @@ export abstract class ReleaseAction {
     // publish branch. e.g. consider we publish patch version and a new package has been
     // created in the `next` branch. The new package would not be part of the patch branch,
     // so we cannot build and publish it.
-    const builtPackages = await invokeReleaseBuildCommand();
+    const builtPackages = await invokeReleaseBuildCommand(this.projectDir);
 
     // Verify the packages built are the correct version.
     await this._verifyPackageVersions(releaseNotes.version, builtPackages);

--- a/ng-dev/release/publish/actions/cut-stable.ts
+++ b/ng-dev/release/publish/actions/cut-stable.ts
@@ -69,7 +69,7 @@ export class CutStableAction extends ReleaseAction {
       await this.checkoutUpstreamBranch(previousPatch.branchName);
       await this.installDependenciesForCurrentBranch();
 
-      await invokeSetNpmDistCommand(ltsTagForPatch, previousPatch.version);
+      await invokeSetNpmDistCommand(this.projectDir, ltsTagForPatch, previousPatch.version);
     }
 
     await this.cherryPickChangelogIntoNextBranch(releaseNotes, branchName);

--- a/ng-dev/release/publish/actions/tag-recent-major-as-latest.ts
+++ b/ng-dev/release/publish/actions/tag-recent-major-as-latest.ts
@@ -35,7 +35,7 @@ export class TagRecentMajorAsLatest extends ReleaseAction {
     await this.updateGithubReleaseEntryToStable(this.active.latest.version);
     await this.checkoutUpstreamBranch(this.active.latest.branchName);
     await this.installDependenciesForCurrentBranch();
-    await invokeSetNpmDistCommand('latest', this.active.latest.version);
+    await invokeSetNpmDistCommand(this.projectDir, 'latest', this.active.latest.version);
   }
 
   /**

--- a/ng-dev/release/publish/test/BUILD.bazel
+++ b/ng-dev/release/publish/test/BUILD.bazel
@@ -2,6 +2,7 @@ load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
 
 ts_library(
     name = "test_lib",
+    testonly = True,
     srcs = glob([
         "**/*.ts",
     ]),
@@ -17,8 +18,6 @@ ts_library(
         "//ng-dev/utils",
         "//ng-dev/utils/testing",
         "@npm//@octokit/plugin-rest-endpoint-methods",
-        "@npm//@types/jasmine",
-        "@npm//@types/node",
         "@npm//@types/semver",
         "@npm//@types/yargs",
         "@npm//nock",

--- a/ng-dev/release/publish/test/common.spec.ts
+++ b/ng-dev/release/publish/test/common.spec.ts
@@ -181,7 +181,7 @@ describe('common release action logic', () => {
     const forkBranchName = `changelog-cherry-pick-${version}`;
 
     it('should prepend the changelog to the next branch', async () => {
-      const {repo, fork, instance, testTmpDir} = setupReleaseActionForTesting(
+      const {repo, fork, instance, projectDir} = setupReleaseActionForTesting(
         TestAction,
         baseReleaseTrains,
       );
@@ -199,7 +199,7 @@ describe('common release action logic', () => {
       await instance.testCherryPickWithPullRequest(version, branchName);
 
       const changelogContent = readFileSync(
-        join(testTmpDir, workspaceRelativeChangelogPath),
+        join(projectDir, workspaceRelativeChangelogPath),
         'utf8',
       );
       expect(changelogContent).toMatch(changelogPattern`

--- a/ng-dev/release/publish/test/cut-next-prerelease.spec.ts
+++ b/ng-dev/release/publish/test/cut-next-prerelease.spec.ts
@@ -62,7 +62,7 @@ describe('cut next pre-release action', () => {
       await expectStagingAndPublishWithoutCherryPick(action, 'master', '10.2.0-next.0', 'next');
 
       const pkgJsonContents = readFileSync(
-        join(action.testTmpDir, workspaceRelativePackageJsonPath),
+        join(action.projectDir, workspaceRelativePackageJsonPath),
         'utf8',
       );
       const pkgJson = JSON.parse(pkgJsonContents) as {version: string; [key: string]: any};

--- a/ng-dev/release/publish/test/cut-stable.spec.ts
+++ b/ng-dev/release/publish/test/cut-stable.spec.ts
@@ -112,6 +112,7 @@ describe('cut stable action', () => {
     await expectStagingAndPublishWithCherryPick(action, '11.0.x', '11.0.0', 'next');
     expect(externalCommands.invokeSetNpmDistCommand).toHaveBeenCalledTimes(1);
     expect(externalCommands.invokeSetNpmDistCommand).toHaveBeenCalledWith(
+      action.projectDir,
       'v10-lts',
       matchesVersion('10.0.3'),
     );

--- a/ng-dev/release/publish/test/tag-recent-major-as-latest.spec.ts
+++ b/ng-dev/release/publish/test/tag-recent-major-as-latest.spec.ts
@@ -111,7 +111,7 @@ describe('tag recent major as latest action', () => {
   );
 
   it('should re-tag the version in the NPM registry and update the Github release', async () => {
-    const {instance, gitClient, releaseConfig, repo} = setupReleaseActionForTesting(
+    const {instance, gitClient, projectDir, releaseConfig, repo} = setupReleaseActionForTesting(
       TagRecentMajorAsLatest,
       new ActiveReleaseTrains({
         releaseCandidate: null,
@@ -140,6 +140,7 @@ describe('tag recent major as latest action', () => {
 
     expect(externalCommands.invokeSetNpmDistCommand).toHaveBeenCalledTimes(1);
     expect(externalCommands.invokeSetNpmDistCommand).toHaveBeenCalledWith(
+      projectDir,
       'latest',
       matchesVersion('10.0.0'),
     );

--- a/ng-dev/release/publish/test/test-utils/test-action.ts
+++ b/ng-dev/release/publish/test/test-utils/test-action.ts
@@ -40,7 +40,7 @@ export interface TestReleaseAction<
   instance: T;
   repo: GithubTestingRepo;
   fork: GithubTestingRepo;
-  testTmpDir: string;
+  projectDir: string;
   githubConfig: GithubConfig;
   releaseConfig: ReleaseConfig;
   gitClient: O['useSandboxGitClient'] extends true ? SandboxGitClient : VirtualGitClient;

--- a/ng-dev/release/publish/test/test-utils/test-utils.ts
+++ b/ng-dev/release/publish/test/test-utils/test-utils.ts
@@ -33,6 +33,7 @@ export function setupReleaseActionForTesting<T extends ReleaseAction, O extends 
   // Reset existing HTTP interceptors.
   nock.cleanAll();
 
+  const projectDir = testTmpDir;
   const {githubConfig, releaseConfig} = getTestConfigurationsForAction();
   const repo = new GithubTestingRepo(githubConfig.owner, githubConfig.name);
   const fork = new GithubTestingRepo('some-user', 'fork');
@@ -52,9 +53,18 @@ export function setupReleaseActionForTesting<T extends ReleaseAction, O extends 
     testOptions.useSandboxGitClient,
   );
 
-  const action = new actionCtor(active, gitClient, releaseConfig, testTmpDir);
+  const action = new actionCtor(active, gitClient, releaseConfig, projectDir);
 
-  return {instance: action, active, repo, fork, testTmpDir, githubConfig, releaseConfig, gitClient};
+  return {
+    instance: action,
+    active,
+    repo,
+    fork,
+    projectDir,
+    githubConfig,
+    releaseConfig,
+    gitClient,
+  };
 }
 
 /** Parses the specified version into Semver. */

--- a/ng-dev/utils/BUILD.bazel
+++ b/ng-dev/utils/BUILD.bazel
@@ -22,6 +22,7 @@ ts_library(
         "@npm//@types/inquirer",
         "@npm//@types/node",
         "@npm//@types/semver",
+        "@npm//@types/which",
         "@npm//@types/yargs",
         "@npm//@types/yarnpkg__lockfile",
         "@npm//@yarnpkg/lockfile",
@@ -29,6 +30,8 @@ ts_library(
         "@npm//inquirer",
         "@npm//semver",
         "@npm//typed-graphqlify",
+        "@npm//which",
+        "@npm//yaml",
         "@npm//yargs",
     ],
 )

--- a/ng-dev/utils/nodejs-errors.ts
+++ b/ng-dev/utils/nodejs-errors.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Type narrowing function that becomes true if the given error is of type `T`.
+ * The narrowed type will include the NodeJS `ErrnoException` properties.
+ */
+export function isNodeJSWrappedError<T extends new (...args: any) => Error>(
+  value: Error | unknown,
+  errorType: T,
+): value is InstanceType<T> & NodeJS.ErrnoException {
+  return value instanceof errorType;
+}

--- a/ng-dev/utils/resolve-yarn-bin.ts
+++ b/ng-dev/utils/resolve-yarn-bin.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as which from 'which';
+import {isNodeJSWrappedError} from './nodejs-errors';
+import {parse as parseLockfile} from '@yarnpkg/lockfile';
+import {parse as parseYaml} from 'yaml';
+import {spawn} from './child-process';
+import {debug} from './console';
+
+/** Type describing a Yarn configuration and its potential properties. */
+export interface YarnConfiguration {
+  'yarnPath': string | undefined;
+  'yarn-path': string | undefined;
+}
+
+/** Type describing a configuration with its corresponding parsing mechanism. */
+export type ConfigWithParser = {fileName: string; parse: (c: string) => YarnConfiguration};
+
+/** Interface describing a command that will invoke Yarn. */
+export interface YarnCommandInfo {
+  binary: string;
+  args: string[];
+}
+
+/** List of Yarn configuration files and their parsing mechanisms. */
+export const yarnConfigFiles: ConfigWithParser[] = [
+  {fileName: '.yarnrc', parse: (c) => parseLockfile(c).object},
+  {fileName: '.yarnrc.yml', parse: (c) => parseYaml(c)},
+];
+
+/**
+ * Resolves Yarn for the given project directory.
+ *
+ * This function exists so that Yarn can be invoked from within Yarn-initiated processes.
+ * Yarn uses some magical logic where it creates a temporary directory to make Yarn resolvable.
+ * This temporary directory is then wired up in `process.env.PATH` and can break for example
+ * when a command switches branches, causing the originally invoked Yarn checked-in file to
+ * become unavailable.
+ */
+export async function resolveYarnScriptForProject(projectDir: string): Promise<YarnCommandInfo> {
+  const yarnPathFromConfig = await getYarnPathFromConfigurationIfPresent(projectDir);
+  if (yarnPathFromConfig !== null) {
+    return {binary: 'node', args: [yarnPathFromConfig]};
+  }
+
+  const yarnPathFromNpmBin = await getYarnPathFromNpmGlobalBinaries();
+  if (yarnPathFromNpmBin !== null) {
+    return {binary: yarnPathFromNpmBin, args: []};
+  }
+
+  return {binary: 'yarn', args: []};
+}
+
+/** Gets the path to the Yarn binary from the NPM global binary directory. */
+export async function getYarnPathFromNpmGlobalBinaries(): Promise<string | null> {
+  const npmGlobalBinPath = await getNpmGlobalBinPath();
+  if (npmGlobalBinPath === null) {
+    return null;
+  }
+  try {
+    return await which('yarn', {path: npmGlobalBinPath});
+  } catch (e) {
+    debug('Could not find Yarn within NPM global binary directory. Error:', e);
+    return null;
+  }
+}
+
+/** Gets the path to the system-wide global NPM binary directory. */
+async function getNpmGlobalBinPath(): Promise<string | null> {
+  try {
+    return (await spawn('npm', ['bin', '--global'], {mode: 'silent'})).stdout.trim();
+  } catch (e) {
+    debug('Could not determine NPM global binary directory. Error:', e);
+    return null;
+  }
+}
+
+/** Gets the Yarn path from the Yarn configuration if present. */
+async function getYarnPathFromConfigurationIfPresent(projectDir: string): Promise<string | null> {
+  const yarnRc = await findAndParseYarnConfiguration(projectDir);
+  if (yarnRc === null) {
+    return null;
+  }
+
+  const yarnPath = yarnRc['yarn-path'] ?? yarnRc['yarnPath'];
+  if (yarnPath === undefined) {
+    return null;
+  }
+
+  return path.resolve(projectDir, yarnPath);
+}
+
+/** Finds and parses the Yarn configuration file for the given project. */
+async function findAndParseYarnConfiguration(
+  projectDir: string,
+): Promise<YarnConfiguration | null> {
+  const files = await Promise.all(
+    yarnConfigFiles.map(async (entry) => ({
+      entry,
+      content: await readFileGracefully(path.join(projectDir, entry.fileName)),
+    })),
+  );
+  const config = files.find((entry) => entry.content !== null);
+  if (config === undefined) {
+    return null;
+  }
+
+  try {
+    return config.entry.parse(config.content!);
+  } catch (e) {
+    debug(`Could not parse determined Yarn configuration file (${config.entry.fileName}).`);
+    debug(`Error:`, e);
+    return null;
+  }
+}
+
+/**
+ * Reads the specified file gracefully.
+ * @returns The file contents. Null if the file does not exist.
+ */
+async function readFileGracefully(filePath: string): Promise<string | null> {
+  try {
+    return await fs.promises.readFile(filePath, 'utf8');
+  } catch (error) {
+    if (isNodeJSWrappedError(error, Error) && error.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/ng-dev/utils/test/BUILD.bazel
+++ b/ng-dev/utils/test/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob([
+        "**/*.ts",
+    ]),
+    deps = [
+        "//ng-dev/utils",
+        "//ng-dev/utils/testing",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    specs = [":test_lib"],
+)

--- a/ng-dev/utils/test/resolve-yarn-bin.spec.ts
+++ b/ng-dev/utils/test/resolve-yarn-bin.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import * as child_process from '../child-process';
+import {resolveYarnScriptForProject} from '../resolve-yarn-bin';
+import {testTmpDir} from '../testing';
+
+describe('resolve yarn bin', () => {
+  it('should respect yarn 1.x configuration files', async () => {
+    fs.writeFileSync(path.join(testTmpDir, '.yarnrc'), `yarn-path "./a/b/c"`);
+
+    expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
+      binary: 'node',
+      args: [path.resolve(testTmpDir, 'a/b/c')],
+    });
+  });
+
+  it('should respect yarn 2.x+ configuration files', async () => {
+    fs.writeFileSync(path.join(testTmpDir, '.yarnrc.yml'), `yarnPath: a/b/c`);
+
+    expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
+      binary: 'node',
+      args: [path.resolve(testTmpDir, 'a/b/c')],
+    });
+  });
+
+  describe('with NPM global binary directory', () => {
+    let fakeNpmBinDir: string;
+
+    beforeEach(() => {
+      fakeNpmBinDir = path.join(testTmpDir, 'npm-global-bin');
+
+      // Write Yarn to the test temporary directory so that it appears to be
+      // resolvable from the NPM global binary directory.
+      fs.mkdirSync(fakeNpmBinDir);
+      fs.writeFileSync(path.join(fakeNpmBinDir, 'yarn'), '', {mode: 0o777});
+      fs.writeFileSync(path.join(fakeNpmBinDir, 'yarn.cmd'), '', {mode: 0o777});
+      fs.writeFileSync(path.join(fakeNpmBinDir, 'yarn.bat'), '', {mode: 0o777});
+
+      // The `npm bin --global` command should return the fake global directory.
+      spyOn(child_process, 'spawn').and.resolveTo({stdout: fakeNpmBinDir, stderr: '', status: 0});
+    });
+
+    it('should check if no config is found', async () => {
+      expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
+        binary: jasmine.stringContaining(fakeNpmBinDir),
+        args: [],
+      });
+    });
+
+    it('should check if no yarn-path is configured', async () => {
+      // Write a config that does not specify a checked-in Yarn file.
+      fs.writeFileSync(path.join(testTmpDir, '.yarnrc'), ``);
+
+      expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
+        binary: jasmine.stringContaining(fakeNpmBinDir),
+        args: [],
+      });
+    });
+  });
+
+  it('should fallback to just `yarn` and leave resolution to system', async () => {
+    expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
+      binary: 'yarn',
+      args: [],
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "typed-graphqlify": "^3.1.1",
     "typescript": "~4.5.0",
     "uuid": "^8.3.2",
+    "which": "^2.0.2",
     "yaml": "^1.10.0",
     "yargs": "^17.0.0"
   },
@@ -88,6 +89,7 @@
     "@types/semver": "^7.3.6",
     "@types/shelljs": "^0.8.8",
     "@types/uuid": "^8.3.1",
+    "@types/which": "^2.0.1",
     "@types/yargs": "^17.0.0",
     "@types/yarnpkg__lockfile": "^1.1.5",
     "jsdoc": "^3.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1948,6 +1948,11 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.3.tgz#c6a60686d953dbd1b1d45e66f4ecdbd5d471b4d0"
   integrity sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==
 
+"@types/which@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.1.tgz#27ecd67f915b7c3d6ba552135bb1eecd66e63501"
+  integrity sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==
+
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
@@ -7995,7 +8000,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
Currently there is one surprising issue within the release tool that
breaks the release of LTS versions.

If the ng-dev release tool is invoked through Yarn. e.g. `yarn ng-dev`,
Yarn will create a temporary directory and create wrappers for a binary
called `yarn` that will directly point to the checked-in Yarn file that
originally invoked the `ng-dev` tool. This means that child processes
calling to `yarn` will actually depend on the checked-in Yarn version
that invoked the `ng-dev` tool.

This logic works fine for most scripts/commands, but it breaks if the
release tool checks out an LTS branch and runs `yarn`. The checked-in
Yarn file from the original invocation may not exist anymore.

We fix this by resolving Yarn directly within the project, falling back
to the NPM global bin, or ultimately by leaving to the process `PATH`
standard resolution. This prevents this issue in all of our Angular
repositories where we check-in Yarn and have a `yarnrc` configuration.