### PR TITLE
fix(bazel): do not always treat parts of `app_bundle` rule as testonly

### DIFF
--- a/bazel/benchmark/app_bundling/index.bzl
+++ b/bazel/benchmark/app_bundling/index.bzl
@@ -67,7 +67,6 @@ def app_bundle(
 
     common_esbuild_options = dict(kwargs, **{
         "config": "%s_esbuild_config" % name,
-        "testonly": True,
         "entry_point": entry_point,
         "target": target,
         "platform": platform,


### PR DESCRIPTION
This is a new difference that came up accidentally when the
ng_rollup_bundle rule has been reworked. A subset of targets
generated by the `app_bundle` macro is always testonly. This results
in unnecessary/unavoidable churn when the rule is used like in
Angular framework.