### PR TITLE
fix(bazel): unable to set tags for `app_bundle` rule due to conflict

### DIFF
--- a/bazel/benchmark/app_bundling/index.bzl
+++ b/bazel/benchmark/app_bundling/index.bzl
@@ -65,7 +65,7 @@ def app_bundle(
         visibility = visibility,
     )
 
-    common_esbuild_options = dict(kwargs, **{
+    common_esbuild_options = {
         "config": "%s_esbuild_config" % name,
         "entry_point": entry_point,
         "target": target,
@@ -73,7 +73,7 @@ def app_bundle(
         "format": format,
         "sourcemap": "external",
         "visibility": visibility,
-    })
+    }
 
     common_terser_options = {
         "visibility": visibility,
@@ -86,14 +86,13 @@ def app_bundle(
     esbuild(
         name = name,
         args = _create_esbuild_minify_options(False),
-        **common_esbuild_options
+        **dict(kwargs, **common_esbuild_options)
     )
 
     esbuild(
         name = "%s.debug" % name,
         args = _create_esbuild_minify_options(True),
-        tags = ["manual"],
-        **common_esbuild_options
+        **dict(kwargs, tags = ["manual"], **common_esbuild_options)
     )
 
     terser_minified(name = name + ".min", src = name + ".js", **common_terser_options)

--- a/bazel/benchmark/app_bundling/test/BUILD.bazel
+++ b/bazel/benchmark/app_bundling/test/BUILD.bazel
@@ -15,6 +15,7 @@ ng_module(
 app_bundle(
     name = "bundle",
     entry_point = "main_fixture.ts",
+    tags = ["some-test-tag"],
     deps = [":test_fixture_lib"],
 )
 


### PR DESCRIPTION
Fixes that no tags can be specified for `app_bundle` benchmark
targets due to a conflict with the debug target and its tags.