### PR TITLE
fix(ng-dev): do not accidentally leak github tokens for errors

### DIFF
--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -45759,9 +45759,8 @@ var require_git_client = __commonJS({
     var github_12 = require_github2();
     var github_urls_1 = require_github_urls();
     var GitCommandError = class extends Error {
-      constructor(client, args) {
-        super(`Command failed: git ${client.sanitizeConsoleOutput(args.join(" "))}`);
-        this.args = args;
+      constructor(client, unsanitizedArgs) {
+        super(`Command failed: git ${client.sanitizeConsoleOutput(unsanitizedArgs.join(" "))}`);
       }
     };
     exports2.GitCommandError = GitCommandError;

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -51433,9 +51433,8 @@ var require_git_client = __commonJS({
     var github_12 = require_github2();
     var github_urls_1 = require_github_urls();
     var GitCommandError = class extends Error {
-      constructor(client, args) {
-        super(`Command failed: git ${client.sanitizeConsoleOutput(args.join(" "))}`);
-        this.args = args;
+      constructor(client, unsanitizedArgs) {
+        super(`Command failed: git ${client.sanitizeConsoleOutput(unsanitizedArgs.join(" "))}`);
       }
     };
     exports2.GitCommandError = GitCommandError;

--- a/ng-dev/utils/git/git-client.ts
+++ b/ng-dev/utils/git/git-client.ts
@@ -17,11 +17,13 @@ import {getRepositoryGitUrl} from './github-urls';
 
 /** Error for failed Git commands. */
 export class GitCommandError extends Error {
-  constructor(client: GitClient, public args: string[]) {
+  // Note: Do not expose the unsanitized arguments as a public property. NodeJS
+  // could print the properties of an error instance and leak e.g. a token.
+  constructor(client: GitClient, unsanitizedArgs: string[]) {
     // Errors are not guaranteed to be caught. To ensure that we don't
     // accidentally leak the Github token that might be used in a command,
     // we sanitize the command that will be part of the error message.
-    super(`Command failed: git ${client.sanitizeConsoleOutput(args.join(' '))}`);
+    super(`Command failed: git ${client.sanitizeConsoleOutput(unsanitizedArgs.join(' '))}`);
   }
 }
 

--- a/tools/local-actions/changelog/main.js
+++ b/tools/local-actions/changelog/main.js
@@ -42860,9 +42860,8 @@ var require_git_client = __commonJS({
     var github_12 = require_github2();
     var github_urls_1 = require_github_urls();
     var GitCommandError = class extends Error {
-      constructor(client, args) {
-        super(`Command failed: git ${client.sanitizeConsoleOutput(args.join(" "))}`);
-        this.args = args;
+      constructor(client, unsanitizedArgs) {
+        super(`Command failed: git ${client.sanitizeConsoleOutput(unsanitizedArgs.join(" "))}`);
       }
     };
     exports2.GitCommandError = GitCommandError;


### PR DESCRIPTION
NodeJS seems to print public properties of error instances. This
can result in the Github token for Git client errors to be printed.

We do not want the token to be printed as often team members might
escalate to dev-infra and just share the log output. In those cases
the token should be reducted to avoid unnecessary rotations.