### PR TITLE
fix(ng-dev/release): resolved yarn instance not used for "release info" command

### DIFF
--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -129,10 +129,14 @@ export async function invokeReleaseInfoCommand(projectDir: string): Promise<Rele
 
   try {
     // Note: No progress indicator needed as that is expected to be a fast operation.
-    const {stdout} = await spawn('yarn', ['--silent', 'ng-dev', 'release', 'info', '--json'], {
-      cwd: projectDir,
-      mode: 'silent',
-    });
+    const {stdout} = await spawn(
+      yarnCommand.binary,
+      [...yarnCommand.args, '--silent', 'ng-dev', 'release', 'info', '--json'],
+      {
+        cwd: projectDir,
+        mode: 'silent',
+      },
+    );
     // The `ng-dev release info` command prints a JSON object to stdout.
     return JSON.parse(stdout.trim()) as ReleaseInfoJsonStdout;
   } catch (e) {

--- a/shared-scripts/angular-linker/BUILD.bazel
+++ b/shared-scripts/angular-linker/BUILD.bazel
@@ -7,8 +7,8 @@ filegroup(
     srcs = glob(["*"]),
 )
 
-# Workaround for: https://github.com/bazelbuild/rules_nodejs/pull/3083.
-# TODO: Remove this once non-generated files can work with the linker.
+# Exposed `js_library` targets need to copy files to `bazel-out`. More details here:
+# https://github.com/bazelbuild/rules_nodejs/pull/3083.
 copy_to_bin(
     name = "js_lib_files",
     srcs = ["esbuild-plugin.mjs"],

--- a/shared-scripts/angular-optimization/BUILD.bazel
+++ b/shared-scripts/angular-optimization/BUILD.bazel
@@ -7,8 +7,8 @@ filegroup(
     srcs = glob(["*"]),
 )
 
-# Workaround for: https://github.com/bazelbuild/rules_nodejs/pull/3083.
-# TODO: Remove this once non-generated files can work with the linker.
+# Exposed `js_library` targets need to copy files to `bazel-out`. More details here:
+# https://github.com/bazelbuild/rules_nodejs/pull/3083.
 copy_to_bin(
     name = "js_lib_files",
     srcs = ["esbuild-plugin.mjs"],
@@ -20,7 +20,6 @@ js_library(
     srcs = [":js_lib_files"],
     deps = [
         "@npm//@angular-devkit/build-angular",
-        "@npm//@angular/compiler-cli",
         "@npm//@babel/core",
     ],
 )


### PR DESCRIPTION
See individual commits