### PR TITLE
fix(bazel/benchmark): missing uuid runtime dependency for perf utils

### DIFF
--- a/bazel/benchmark/driver-utilities/BUILD.bazel
+++ b/bazel/benchmark/driver-utilities/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "@npm//@types/uuid",
         "@npm//protractor",
         "@npm//selenium-webdriver",
+        "@npm//uuid",
     ],
 )
 


### PR DESCRIPTION
With the replacement of `node-uuid` to `uuid`, the runtime dependency
on the `uuid` module has been accidentally left out. See:

https://github.com/angular/dev-infra/commit/1638e3ff580204d3b6755ad6cd353a8e8031151d

Fixing errors like:

```
17:43:07] E/launcher - Error: Error: Cannot find module 'uuid'. Please verify that the package.json has a valid "main" entry
    at Function.module.constructor._resolveFilename (/b/f/w/bazel-out/k8-fastbuild/bin/modules/benchmarks/src/tree/iv/e2e_chromium.sh.runfiles/angular/modules/benchmarks/src/tree/iv/e2e_wrapped_test_protractor_bin_require_patch.js:481:17)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at /b/f/w/bazel-out/k8-fastbuild/bin/modules/benchmarks/external/npm/@angular/dev-infra-private/bazel/benchmark/driver-utilities/perf_util.ts:25:1
    at /b/f/w/bazel-out/k8-fastbuild/bin/modules/benchmarks/src/tree/iv/e2e_chromium.sh.runfiles/npm/@angular/dev-infra-private/bazel/benchmark/driver-utilities/perf_util.js:12:17
    at Object.<anonymous> (/b/f/w/bazel-out/k8-fastbuild/bin/modules/benchmarks/src/tree/iv/e2e_chromium.sh.runfiles/npm/@angular/dev-infra-private/bazel/benchmark/driver-utilities/perf_util.js:18:3)
```

Related to: https://github.com/angular/angular/pull/44735