### PR TITLE
feat(ng-dev): abbreviated SHA stamp

### DIFF
--- a/ng-dev/release/stamping/env-stamp.ts
+++ b/ng-dev/release/stamping/env-stamp.ts
@@ -28,6 +28,7 @@ export function buildEnvStamp(mode: EnvStampMode) {
   console.info(`BUILD_SCM_BRANCH ${getCurrentBranch(git)}`);
   console.info(`BUILD_SCM_COMMIT_SHA ${getCurrentSha(git)}`);
   console.info(`BUILD_SCM_HASH ${getCurrentSha(git)}`);
+  console.info(`BUILD_SCM_ABBREV_HASH ${getCurrentAbbrevSha(git)}`);
   console.info(`BUILD_SCM_BRANCH ${getCurrentBranchOrRevision(git)}`);
   console.info(`BUILD_SCM_LOCAL_CHANGES ${hasLocalChanges(git)}`);
   console.info(`BUILD_SCM_USER ${getCurrentGitUser(git)}`);
@@ -94,6 +95,15 @@ function getSCMVersions(
 function getCurrentSha(git: GitClient) {
   try {
     return git.run(['rev-parse', 'HEAD']).stdout.trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Get the current abbreviated SHA of HEAD. */
+function getCurrentAbbrevSha(git: GitClient) {
+  try {
+    return git.run(['rev-parse', '--short', 'HEAD']).stdout.trim();
   } catch {
     return '';
   }


### PR DESCRIPTION
@josephperrott @devversion 
fyi: @gregmagolan 

Test output:
```
BUILD_SCM_BRANCH snapshot-test
BUILD_SCM_COMMIT_SHA bb8bc80581417898b10bdc23ef4d9ee4295da2a9
BUILD_SCM_HASH bb8bc80581417898b10bdc23ef4d9ee4295da2a9
BUILD_SCM_HASH_ABBREV bb8bc8058
BUILD_SCM_BRANCH snapshot-test
BUILD_SCM_LOCAL_CHANGES false
BUILD_SCM_USER Derek Cormier <derek@aspect.dev>
BUILD_SCM_VERSION 14.0.0-next.0
BUILD_SCM_EXPERIMENTAL_VERSION 0.1400.0-next.0
```

Needed for cli snapshot build tagging.