### PR TITLE
build: fix scorecard config

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 1 * * 0'
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 # Declare default permissions as read only.


### PR DESCRIPTION
We use the main branch, not master.