### PR TITLE
fix(bazel): disable angular linker sourcemaps

### DIFF
--- a/shared-scripts/angular-linker/esbuild-plugin.mjs
+++ b/shared-scripts/angular-linker/esbuild-plugin.mjs
@@ -60,6 +60,8 @@ export async function createLinkerEsbuildPlugin(
     logger: new ConsoleLogger(LogLevel.warn),
     // We enable JIT mode as unit tests also will rely on the linked ESM files.
     linkerJitMode: true,
+    // Workaround for https://github.com/angular/angular/issues/42769 and https://github.com/angular/angular-cli/issues/22647.
+    sourceMapping: false,
     ...linkerOptions,
   });
 


### PR DESCRIPTION
When using the linker on `@angular/material` or packages which contain external sourcemap. The sourcemap will contain multiple sources example.

Babel now uses [remapping](https://github.com/ampproject/remapping/) to merge sourcemaps, see: https://github.com/babel/babel/pull/14209. This doesn't support multiple sources which the linker produduces. Previously, Babel failed silently and didn't generate a sourcemap https://github.com/angular/angular/issues/42769 at all.

Linker produced sourcemap
```js
  [
    '/packages/web-app-edit/Users/cli-reproductions/monorepo-new/node_modules/@angular/material/fesm2020/card.mjs',
    '/packages/web-app-edit/Users/src/material/card/card.html',
    '/packages/web-app-edit/Users/src/material/card/card-header.html',
    '/packages/web-app-edit/Users/src/material/card/card-title-group.html'
  ]
```

Will cause the below error during merging
```
Transformation map 0 must have exactly one source file.
```

Related to
- https://github.com/angular/angular/issues/42769
- https://github.com/angular/angular/issues/44972

Addresses CI failure
- https://app.circleci.com/pipelines/github/angular/angular/42281/workflows/e060088b-5963-43b0-b6fc-b4ddd8855bee/jobs/1116551