### PR TITLE
refactor: allow http-server to serve dotfiles

### DIFF
--- a/bazel/http-server/server.ts
+++ b/bazel/http-server/server.ts
@@ -109,7 +109,7 @@ export class HttpServer {
         return;
       }
 
-      send(req, resolvedPath).pipe(res);
+      send(req, resolvedPath, {dotfiles: 'allow'}).pipe(res);
     }
   }
 


### PR DESCRIPTION
It is currently not possible to serve dotfiles (e.g. .stackblitzrc) from the http-server. This PR changes the configuration to allow this.

We understand that this repository is only intended for internal Angular development and in this regard we completely understand if you reject this PR. Still we wanted to ask if you could accept this change, since this PR only changes a small configuration, without having any semantic impact. 