### PR TITLE
ci: group all scorecard action dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,12 @@
       "matchPackageNames": ["typescript"],
       "updateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchPaths": [".github/workflows/scorecard.yml"],
+      "matchPackagePatterns": ["*"],
+      "groupName": "scorecard action dependencies",
+      "groupSlug": "scorecard-action"
     }
   ]
 }


### PR DESCRIPTION
With this change we group all the scorecard action dependencies so that Renovate opens a single PR.