### PR TITLE
feat(ng-dev/format): add staged files back

### DIFF
--- a/ng-dev/format/cli.ts
+++ b/ng-dev/format/cli.ts
@@ -51,6 +51,9 @@ export function buildFormatParser(localYargs: yargs.Argv) {
         const executionCmd = check ? checkFiles : formatFiles;
         const allStagedFiles = GitClient.get().allStagedFiles();
         process.exitCode = await executionCmd(allStagedFiles);
+        if (!check && process.exitCode === 0) {
+          GitClient.get().runGraceful(['add', ...allStagedFiles]);
+        }
       },
     )
     .command(


### PR DESCRIPTION
change the staged command so that after formatting it also adds
formatted files back to the staging area (unless --check is used
of course)
___

I just wanted to improve one small thing for development on the angular repo, basically when I create a commit and the pre-commit git hook formats the staged files, those changes aren't actually included in the commit, so I usually need to re-add the formatted files, update my commit and force push it.

I think that it is pretty inconvenient and it would just make sense for the hook to both format them and add them back to the staging area (I don't think this could be an unwanted behavior since the ci checks would anyways required the user to update those files).

So my idea is to just extend this:
https://github.com/angular/angular/blob/444354855b1e19ef383cf63088cbb31d59a14593/.husky/pre-commit#L5
to use this new `staged-re` command instead

___

Alternatively I could have added a flag as `--re-stage` or whatever but that wouldn't have made sense for the other format commands so I figured just a separate command could make sense

___

Also sorry for my boldness on opening a random PR here, I hope it's fine, if it is a bad idea you can always just shut it down anyways :smiling_face_with_tear: :bow: 
