### PR TITLE
fix(bazel/karma): web test arguments not passed through

### DIFF
--- a/.ng-dev/commit-message.ts
+++ b/.ng-dev/commit-message.ts
@@ -13,8 +13,14 @@ export const commitMessage: CommitMessageConfig = {
       'api-golden',
       'benchmark',
       'browsers',
+      'constraints',
+      'esbuild',
+      'http-server',
+      'integration',
+      'karma',
       'protos',
       'remote-execution',
+      'spec-bundling',
     ]),
     ...buildScopesFor('github-actions', [
       'commit-message-based-labels',
@@ -35,5 +41,6 @@ export const commitMessage: CommitMessageConfig = {
       'ts-circular-dependencies',
     ]),
     ...buildScopesFor('tslint-rules', []),
+    ...buildScopesFor('shared-scripts', []),
   ],
 };

--- a/bazel/browsers/test/BUILD.bazel
+++ b/bazel/browsers/test/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
-load("@npm//@bazel/concatjs:index.bzl", "karma_web_test_suite")
+load("//bazel/karma:index.bzl", "karma_web_test_suite")
 load("//bazel/spec-bundling:index.bzl", "spec_bundle")
 
 karma_web_test_suite(

--- a/bazel/karma/index.bzl
+++ b/bazel/karma/index.bzl
@@ -46,7 +46,7 @@ def karma_web_test_suite(name, **kwargs):
 
     # Custom standalone web test that can be run to test against any
     # browser that is manually connected to.
-    _karma_debug_browsers_target(name = "%s_debug" % name)
+    _karma_debug_browsers_target(name = "%s_debug" % name, **web_test_args)
 
     # Default test suite with all configured browsers.
     _karma_web_test_suite(name = name, **kwargs)


### PR DESCRIPTION
Fixes that the webtest arguments are not passed through to the
debug target. Also wires up the rule in our own tests as planned
initially (now that the test is merged)