### PR TITLE
feat(bazel/karma): expose karma web test rule in shared karma code

### DIFF
--- a/bazel/karma/index.bzl
+++ b/bazel/karma/index.bzl
@@ -4,6 +4,9 @@ load(
     _karma_web_test_suite = "karma_web_test_suite",
 )
 
+# Re-export of unmodified Karma test macros/rules.
+karma_web_test = _karma_web_test
+
 def _karma_debug_browsers_target(name, **web_test_args):
     """Macro for defining a standalone karma web test target that starts Karma
       without a browser, allowing for manual debugging."""


### PR DESCRIPTION
We should re-export the unmodified karma web test macro/rule in the
dev-infra Karma shared code so that a single import in consumer
repositories like framework is sufficient. Currently framework
would need to import from `@bazel/concatjs` and from `dev-infra-private/bazel/karma`
to get access to the Karma Bazel rules/macros.