### PR TITLE
fix(ng-dev): uncommitted changes check returning false-positives

### DIFF
--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -49407,6 +49407,7 @@ var require_git_client = __commonJS({
         return branchName;
       }
       hasUncommittedChanges() {
+        this.runGraceful(["update-index", "-q", "--refresh"]);
         return this.runGraceful(["diff-index", "--quiet", "HEAD"]).status !== 0;
       }
       checkout(branchOrRevision, cleanState) {

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -55081,6 +55081,7 @@ var require_git_client = __commonJS({
         return branchName;
       }
       hasUncommittedChanges() {
+        this.runGraceful(["update-index", "-q", "--refresh"]);
         return this.runGraceful(["diff-index", "--quiet", "HEAD"]).status !== 0;
       }
       checkout(branchOrRevision, cleanState) {

--- a/ng-dev/utils/git/git-client.ts
+++ b/ng-dev/utils/git/git-client.ts
@@ -158,6 +158,13 @@ export class GitClient {
 
   /** Gets whether the current Git repository has uncommitted changes. */
   hasUncommittedChanges(): boolean {
+    // We also need to refresh the index in case some files have been touched
+    // but not modified. The diff-index command will not check contents so we
+    // manually need to refresh and cleanup the index before performing the diff.
+    // Relevant info: https://git-scm.com/docs/git-diff-index#_non_cached_mode,
+    // https://git-scm.com/docs/git-update-index and https://stackoverflow.com/a/34808299.
+    this.runGraceful(['update-index', '-q', '--refresh']);
+
     return this.runGraceful(['diff-index', '--quiet', 'HEAD']).status !== 0;
   }
 

--- a/tools/local-actions/changelog/main.js
+++ b/tools/local-actions/changelog/main.js
@@ -46508,6 +46508,7 @@ var require_git_client = __commonJS({
         return branchName;
       }
       hasUncommittedChanges() {
+        this.runGraceful(["update-index", "-q", "--refresh"]);
         return this.runGraceful(["diff-index", "--quiet", "HEAD"]).status !== 0;
       }
       checkout(branchOrRevision, cleanState) {


### PR DESCRIPTION
In some cases the `hasUncommittedChanges` check returns false-positives
that occur due to us not refreshing & cleaning up the index before diffing
the index. The index needs a cleanup/refresh when a file is simply touched/modified with the actual content not changing. i.e. just the last modified time got updated.

More details: https://stackoverflow.com/questions/34807971/why-does-git-diff-index-head-result-change-for-touched-files-after-git-diff-or-g/34808299#34808299