### PR TITLE
build: move `@angular/compiler-cli` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@angular-devkit/build-angular": "14.0.0-next.2",
     "@angular/benchpress": "0.3.0",
-    "@angular/compiler-cli": "14.0.0-next.3",
     "@babel/core": "^7.16.0",
     "@bazel/concatjs": "4.6.0",
     "@bazel/esbuild": "4.6.0",
@@ -55,6 +54,7 @@
     "@angular/bazel": "14.0.0-next.3",
     "@angular/common": "14.0.0-next.3",
     "@angular/compiler": "14.0.0-next.3",
+    "@angular/compiler-cli": "14.0.0-next.3",
     "@angular/core": "14.0.0-next.3",
     "@angular/platform-browser": "14.0.0-next.3",
     "@bazel/bazelisk": "^1.10.1",


### PR DESCRIPTION
Although `@angular/compiler-cli` is a dependency of the [//shared-scripts/angular-linker:js_lib][1] target (and would therefore normally appear in `dependencies`), this was causing error in the framework repo tests: [Example failure][2]

Move `@angular/compiler-cli` to `devDependencies` to allow each consumer provide their own version of the package.

##
NOTE 1: _This is a follow-up to #387._
NOTE 2: _I have verified that the framework repo CI passes with the changes in this PR: [CI run][3]._

[1]: https://github.com/angular/dev-infra/blob/5ae1ce8ee8b11b092e9e5c935eeebec58990edee/shared-scripts/angular-linker/BUILD.bazel#L22
[2]: https://circleci.com/gh/angular/angular/1127275
[3]: https://app.circleci.com/pipelines/github/angular/angular/43061/workflows/c56daf0f-d6c1-4c10-8f90-13f1f19e3fe9