### PR TITLE
ci: add permissions to current github action workflows

### DIFF
--- a/.github/workflows/commit-message-based-labels.yml
+++ b/.github/workflows/commit-message-based-labels.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   commit_message_based_labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/feature-request.yml
+++ b/.github/workflows/feature-request.yml
@@ -2,6 +2,10 @@ name: Feature request triage bot
 
 on: [workflow_dispatch]
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   feature_triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   lock_closed:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created, edited]
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   slash_commands:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,6 +6,10 @@ on:
     # Run every Sunday at 0:00
     - cron: '0 0 * * 0'
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   update_changelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The currently recommended best practice for Github action workflows is to set top-level permissions to read only. And if the job uses the automatic `GITHUB_TOKEN`, fine-grained permissions for each job based on the job's requirements should also be added.
All existing workflows in the repository now have top-level read only permission blocks.
Only the `scorecard` workflow currently requires additional job level permissions and the minimum set of permissions were already present for the job.