### PR TITLE
build: add darwin_arm64 support

### DIFF
--- a/bazel/remote-execution/cpp/BUILD.bazel
+++ b/bazel/remote-execution/cpp/BUILD.bazel
@@ -11,6 +11,7 @@ cc_toolchain_suite(
     name = "cc_toolchain_suite",
     toolchains = {
         "k8": ":cc_compiler_k8",
+        "darwin_arm64": ":cc_compiler_k8",
     },
 )
 


### PR DESCRIPTION
May also require a fix or patch to the cc config: https://github.com/bazelbuild/bazel/issues/13514#issuecomment-847917936


I'm not sure if there's anything that should be added, or maybe we'd want to wait until that patch isn't required? But without this and the linked patch the build on an m1 doesn't work...