### PR TITLE
build: fix workspace stamping breaking snapshot publishing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -86,7 +86,11 @@ build:remote --remote_accept_cached=true
 ################################
 
 # Releases should always be stamped with version control info
-build:release --workspace_status_command="yarn ng-dev release build-env-stamp --mode=release"
+# Note: We usually would use the `ng-dev` tool directly, but that one would need to be
+# built with Bazel and building with Bazel inside the Bazel-invoked workspace status
+# script does not work. To workaround this, we have a `ts-node`-based stamping script.
+# TODO: Consider using `ng-dev` directly if this is possible.
+build:release --workspace_status_command="yarn build-env-stamp --mode=release"
 build:release --stamp
 
 ####################################################

--- a/ng-dev/release/stamping/cli.ts
+++ b/ng-dev/release/stamping/cli.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Arguments, Argv, CommandModule} from 'yargs';
+import yargs, {Arguments, Argv, CommandModule} from 'yargs';
 
 import {buildEnvStamp, EnvStampMode} from './env-stamp';
 
@@ -33,3 +33,14 @@ export const BuildEnvStampCommand: CommandModule<{}, Options> = {
   command: 'build-env-stamp',
   describe: 'Build the environment stamping information',
 };
+
+// This file can be executed directly for the workspace stamping in this repo.
+// More details can be found in the `.bazelrc` file.
+if (require.main === module) {
+  yargs(process.argv.slice(2))
+    .help()
+    .strict()
+    .demandCommand()
+    .command(BuildEnvStampCommand)
+    .parseSync();
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "prepare": "husky install",
     "ng-dev": "bash ./tools/local-dev.sh",
+    "build-env-stamp": "ts-node --transpile-only ./ng-dev/release/stamping/cli.ts build-env-stamp",
     "update-generated-files": "ts-node --transpile-only ./tools/update-generated-files.ts"
   },
   "exports": {


### PR DESCRIPTION
We usually would use the `ng-dev` tool directly for stamping, but that one would need to be
built with Bazel and building with Bazel inside the Bazel-invoked workspace status
script does not work. To workaround this we have a `ts-node`-based stamping script.
