### PR TITLE
build: fix packaging of dev-infra package

### DIFF
--- a/ng-dev/cli.ts
+++ b/ng-dev/cli.ts
@@ -19,6 +19,13 @@ import {tsCircularDependenciesBuilder} from './ts-circular-dependencies/index';
 import {captureLogOutputForCommand} from './utils/console';
 import {buildMiscParser} from './misc/cli';
 import {buildCiParser} from './ci/cli';
+import {ReleaseAction} from './index';
+
+// Expose the `ReleaseAction` constructor globally so that the COMP repo
+// can hook into it and setup staging/post-building release checks.
+// TODO: Remove once https://github.com/angular/dev-infra/issues/402 is resolved.
+// or if we have code-splitting w/ ESM enabled for the ng-dev bundling.
+(global as any).ReleaseAction = ReleaseAction;
 
 yargs
   .scriptName('ng-dev')

--- a/ng-dev/index.ts
+++ b/ng-dev/index.ts
@@ -23,7 +23,7 @@ export * from './release/versioning';
 export * from './utils/console';
 
 // Additional exports for adding custom release pre-staging, post-build checks.
-// TODO: Remove this once we have a public API for release hooks/checks
+// TODO: Remove once https://github.com/angular/dev-infra/issues/402 is resolved.
 export {ReleaseAction} from './release/publish/actions';
 export {
   FatalReleaseActionError,

--- a/ng-dev/release/stamping/_private_main.ts
+++ b/ng-dev/release/stamping/_private_main.ts
@@ -1,0 +1,11 @@
+// This file can be executed directly for the workspace stamping in this repo.
+// More details can be found in the `.bazelrc` file.
+import yargs from 'yargs';
+import {BuildEnvStampCommand} from './cli';
+
+yargs(process.argv.slice(2))
+  .help()
+  .strict()
+  .demandCommand()
+  .command(BuildEnvStampCommand)
+  .parseSync();

--- a/ng-dev/release/stamping/cli.ts
+++ b/ng-dev/release/stamping/cli.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import yargs, {Arguments, Argv, CommandModule} from 'yargs';
+import {Arguments, Argv, CommandModule} from 'yargs';
 
 import {buildEnvStamp, EnvStampMode} from './env-stamp';
 
@@ -33,14 +33,3 @@ export const BuildEnvStampCommand: CommandModule<{}, Options> = {
   command: 'build-env-stamp',
   describe: 'Build the environment stamping information',
 };
-
-// This file can be executed directly for the workspace stamping in this repo.
-// More details can be found in the `.bazelrc` file.
-if (require.main === module) {
-  yargs(process.argv.slice(2))
-    .help()
-    .strict()
-    .demandCommand()
-    .command(BuildEnvStampCommand)
-    .parseSync();
-}

--- a/package.json
+++ b/package.json
@@ -2,21 +2,24 @@
   "name": "@angular/dev-infra-private",
   "version": "0.0.0-{SCM_HEAD_SHA}",
   "bin": {
-    "ng-dev": "./ng-dev/cli-bundle.js"
+    "ng-dev": "./ng-dev/bundles/cli.js"
   },
   "private": true,
   "scripts": {
     "prepare": "husky install",
     "ng-dev": "bash ./tools/local-dev.sh",
-    "build-env-stamp": "ts-node --transpile-only ./ng-dev/release/stamping/cli.ts build-env-stamp",
+    "build-env-stamp": "ts-node --transpile-only ./ng-dev/release/stamping/_private_main.ts build-env-stamp",
     "update-generated-files": "ts-node --transpile-only ./tools/update-generated-files.ts"
   },
   "exports": {
+    "./ng-dev": {
+      "default": "./ng-dev/bundles/index.js"
+    },
     "./ng-dev/*": {
       "default": "./ng-dev/bundles/*.js"
     },
     "./*": {
-      "default": "./'"
+      "default": "./*"
     }
   },
   "packageManager": "yarn@3.2.0",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,8 +1,9 @@
 load("@npm//@bazel/typescript:index.bzl", _ts_library = "ts_library", _ts_project = "ts_project")
-load("@npm//@bazel/esbuild:index.bzl", _esbuild = "esbuild")
+load("//bazel/esbuild:index.bzl", _esbuild = "esbuild", _esbuild_config = "esbuild_config")
 load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test", _pkg_npm = "pkg_npm")
 load("//tools/jasmine:jasmine.bzl", _jasmine_node_test = "jasmine_node_test")
 
+esbuild_config = _esbuild_config
 jasmine_node_test = _jasmine_node_test
 
 def _get_module_name(testonly):

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,7 +396,7 @@ __metadata:
     yargs: ^17.0.0
     zone.js: ^0.11.4
   bin:
-    ng-dev: ./ng-dev/cli-bundle.js
+    ng-dev: ./ng-dev/bundles/cli.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Fixes a couple of typos, cleans up the stamping private entry-point
and adds a trick to make the release checks in COMP work. It looks
like they did not work for quite a while because the `ReleaseAction`
instance being patched as a trick is not the one used by the CLI
used for publishing the release (since we have multiple copies of the release
action constructor in multiple bundles..)

>  Long-term ESM with code splitting would help more (ESBuild only supports code splitting for ESM), but the ESM change involves a lot of caveats (I just tried and remember from APF) -- so now the little workaround exists and the unfortunate duplication of some bundled deps.

