### PR TITLE
build: tag cc_toolchain_suite as manual

### DIFF
--- a/bazel/remote-execution/cpp/BUILD.bazel
+++ b/bazel/remote-execution/cpp/BUILD.bazel
@@ -9,6 +9,7 @@ filegroup(
 
 cc_toolchain_suite(
     name = "cc_toolchain_suite",
+    tags = ["manual"],
     toolchains = {
         "k8": ":cc_compiler_k8",
     },


### PR DESCRIPTION
.. so builds can be run locally on non-k8 machines.

Replaces #429