### PR TITLE
build: fix yarn install with vendored yarn due to bug in `rules_nodejs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+!.yarn/yarn.js
 
 # User specific bazel settings
 .bazelrc.user

--- a/.yarn/yarn.js
+++ b/.yarn/yarn.js
@@ -1,0 +1,6 @@
+const {fork} = require('child_process');
+
+// Wrapper script to workaround a bug in `rules_nodejs` where `.cjs`
+// vendored files are not detected and launched as binaries (breaking Windows).
+// TODO: Remove once https://github.com/bazelbuild/rules_nodejs/pull/3350 is available.
+fork(__dirname + '/releases/yarn-3.2.0.cjs', process.argv.slice(2));

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,6 +42,7 @@ yarn_install(
     args = ["--immutable"],
     data = [
         "//:.yarn/releases/yarn-3.2.0.cjs",
+        "//:.yarn/yarn.js",
         "//:.yarnrc.yml",
     ],
     # Currently disabled due to:
@@ -49,7 +50,8 @@ yarn_install(
     #  2. Incompatibilites with the `ts_library` rule.
     exports_directories_only = False,
     package_json = "//:package.json",
-    yarn = "//:.yarn/releases/yarn-3.2.0.cjs",
+    # TODO: Cleanup when https://github.com/bazelbuild/rules_nodejs/pull/3350 is available.
+    yarn = "//:.yarn/yarn.js",
     yarn_lock = "//:yarn.lock",
 )
 


### PR DESCRIPTION
More details here: https://github.com/bazelbuild/rules_nodejs/pull/3350.

This commit adds a little wrapper script as temporary workaround to fix CI.