### PR TITLE
build: remove unused managed directory bazel setup for node modules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,5 @@
 workspace(
     name = "dev-infra",
-    managed_directories = {"@npm": ["node_modules"]},
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")


### PR DESCRIPTION
As of RNJ v5, the node modules are no longer symlinked by default. Rather
a new separate install is maintained inside Bazel. This was a little
controversial in the past since it made debugging harder, and required
more IO locally/or even downloads depending on how Yarn is cached/configured
locally.

With the current setup, symlinks are no longer enabled and we can remove
the managed directory configuration.

https://github.com/bazelbuild/rules_nodejs/pull/3214