### PR TITLE
fix(ng-dev/release): only match on a single character prefixed version for snapshotting

### DIFF
--- a/ng-dev/release/stamping/env-stamp.ts
+++ b/ng-dev/release/stamping/env-stamp.ts
@@ -63,7 +63,10 @@ function getSCMVersions(
       const {stdout: rawVersion} = git.run([
         'describe',
         '--match',
-        '*[0-9]*.[0-9]*.[0-9]*',
+        // As git describe uses glob matchers we cannot the specific describe what we expect to see
+        // starting character we expect for our version string.  To ensure we can handle 'v'
+        // prefixed verstions we have the '?' wildcard character.
+        '?[0-9]*.[0-9]*.[0-9]*',
         '--abbrev=7',
         '--tags',
         'HEAD',
@@ -83,7 +86,8 @@ function getSCMVersions(
       const {version: experimentalVersion} = createExperimentalSemver(new SemVer(version));
       return {version, experimentalVersion};
     }
-  } catch {
+  } catch (e) {
+    console.error(e);
     return {
       version: '',
       experimentalVersion: '',

--- a/ng-dev/release/stamping/env-stamp.ts
+++ b/ng-dev/release/stamping/env-stamp.ts
@@ -57,41 +57,33 @@ function getSCMVersions(
   git: GitClient,
   mode: EnvStampMode,
 ): {version: string; experimentalVersion: string} {
-  try {
-    if (mode === 'snapshot') {
-      const localChanges = hasLocalChanges(git) ? '.with-local-changes' : '';
-      const {stdout: rawVersion} = git.run([
-        'describe',
-        '--match',
-        // As git describe uses glob matchers we cannot the specific describe what we expect to see
-        // starting character we expect for our version string.  To ensure we can handle 'v'
-        // prefixed verstions we have the '?' wildcard character.
-        '?[0-9]*.[0-9]*.[0-9]*',
-        '--abbrev=7',
-        '--tags',
-        'HEAD',
-      ]);
-      const {version} = new SemVer(rawVersion);
-      const {version: experimentalVersion} = createExperimentalSemver(version);
-      return {
-        version: `${version.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`,
-        experimentalVersion: `${experimentalVersion.replace(
-          /-([0-9]+)-g/,
-          '+$1.sha-',
-        )}${localChanges}`,
-      };
-    } else {
-      const packageJsonPath = join(git.baseDir, 'package.json');
-      const {version} = new SemVer(require(packageJsonPath).version);
-      const {version: experimentalVersion} = createExperimentalSemver(new SemVer(version));
-      return {version, experimentalVersion};
-    }
-  } catch (e) {
-    console.error(e);
+  if (mode === 'snapshot') {
+    const localChanges = hasLocalChanges(git) ? '.with-local-changes' : '';
+    const {stdout: rawVersion} = git.run([
+      'describe',
+      '--match',
+      // As git describe uses glob matchers we cannot the specific describe what we expect to see
+      // starting character we expect for our version string.  To ensure we can handle 'v'
+      // prefixed verstions we have the '?' wildcard character.
+      '?[0-9]*.[0-9]*.[0-9]*',
+      '--abbrev=7',
+      '--tags',
+      'HEAD',
+    ]);
+    const {version} = new SemVer(rawVersion);
+    const {version: experimentalVersion} = createExperimentalSemver(version);
     return {
-      version: '',
-      experimentalVersion: '',
+      version: `${version.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`,
+      experimentalVersion: `${experimentalVersion.replace(
+        /-([0-9]+)-g/,
+        '+$1.sha-',
+      )}${localChanges}`,
     };
+  } else {
+    const packageJsonPath = join(git.baseDir, 'package.json');
+    const {version} = new SemVer(require(packageJsonPath).version);
+    const {version: experimentalVersion} = createExperimentalSemver(new SemVer(version));
+    return {version, experimentalVersion};
   }
 }
 


### PR DESCRIPTION
Previously we matched on all characters before our semver matching in the glob used for finding
the latest version for the branch we are on.  However when the branch contains something like
`zonejs-1.2.3`, the `*` matcher would capture it, leading to an unexpected syntax.  Instead we should
allow for only a single letter, typically `v`, to prefix our version tags.


cc: @AndrewKushnir 