### PR TITLE
refactor(ng-dev): expose git and github client classes in ng-dev entry-point

### DIFF
--- a/ng-dev/index.ts
+++ b/ng-dev/index.ts
@@ -22,6 +22,12 @@ export * from './release/versioning';
 // to the dev-infra log which is stored on failures.
 export * from './utils/console';
 
+// Exposes Git/Github client classes needed for interacting with some of the
+// release versioning APIs.
+export * from './utils/git/authenticated-git-client';
+export * from './utils/git/git-client';
+export * from './utils/git/github';
+
 // Additional exports for adding custom release pre-staging, post-build checks.
 // TODO: Remove once https://github.com/angular/dev-infra/issues/402 is resolved.
 export {ReleaseAction} from './release/publish/actions';


### PR DESCRIPTION
These classes will be needed for interacting with the release versioning APIs.