### PR TITLE
feat(ng-dev): support skipping version stamp in release stamp env

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -85,12 +85,14 @@ build:remote --remote_accept_cached=true
 #     Release setup            #
 ################################
 
-# Releases should always be stamped with version control info
+# Releases should always be stamped with version control info. The dev-infra project
+# does not have actual versions so we need to skip version stamping. Our NPM package
+# will have a version composed with the current SHA from the SCM stamping info.
 # Note: We usually would use the `ng-dev` tool directly, but that one would need to be
 # built with Bazel and building with Bazel inside the Bazel-invoked workspace status
 # script does not work. To workaround this, we have a `ts-node`-based stamping script.
 # TODO: Consider using `ng-dev` directly if this is possible.
-build:release --workspace_status_command="yarn build-env-stamp --mode=release"
+build:release --workspace_status_command="yarn build-env-stamp --mode=release --include-version=false"
 build:release --stamp
 
 ####################################################

--- a/ng-dev/release/stamping/_private_main.ts
+++ b/ng-dev/release/stamping/_private_main.ts
@@ -8,4 +8,4 @@ yargs(process.argv.slice(2))
   .strict()
   .demandCommand()
   .command(BuildEnvStampCommand)
-  .parseSync();
+  .parseAsync();

--- a/ng-dev/release/stamping/cli.ts
+++ b/ng-dev/release/stamping/cli.ts
@@ -12,18 +12,25 @@ import {buildEnvStamp, EnvStampMode} from './env-stamp';
 
 export interface Options {
   mode: EnvStampMode;
+  includeVersion: boolean;
 }
 
 function builder(args: Argv): Argv<Options> {
-  return args.option('mode', {
-    demandOption: true,
-    description: 'Whether the env-stamp should be built for a snapshot or release',
-    choices: ['snapshot' as const, 'release' as const],
-  });
+  return args
+    .option('mode', {
+      demandOption: true,
+      description: 'Whether the env-stamp should be built for a snapshot or release',
+      choices: ['snapshot' as const, 'release' as const],
+    })
+    .option('includeVersion', {
+      type: 'boolean',
+      description: 'Whether the version should be included in the stamp.',
+      default: true,
+    });
 }
 
-async function handler({mode}: Arguments<Options>) {
-  buildEnvStamp(mode);
+async function handler({mode, includeVersion}: Arguments<Options>) {
+  buildEnvStamp(mode, includeVersion);
 }
 
 /** CLI command module for building the environment stamp. */

--- a/ng-dev/release/stamping/env-stamp.ts
+++ b/ng-dev/release/stamping/env-stamp.ts
@@ -10,21 +10,14 @@ import {join} from 'path';
 import {SemVer} from 'semver';
 import {GitClient} from '../../utils/git/git-client';
 import {createExperimentalSemver} from '../../release/versioning/experimental-versions';
+import * as fs from 'fs';
 
 export type EnvStampMode = 'snapshot' | 'release';
 
-/**
- * Log the environment variables expected by bazel for stamping.
- *
- * See the section on stamping in docs / BAZEL.md
- *
- * This script must be a NodeJS script in order to be cross-platform.
- * See https://github.com/bazelbuild/bazel/issues/5958
- * Note: git operations, especially git status, take a long time inside mounted docker volumes
- * in Windows or OSX hosts (https://github.com/docker/for-win/issues/188).
- */
-export function buildEnvStamp(mode: EnvStampMode) {
+/** Log the environment variables expected by Bazel for stamping. */
+export function buildEnvStamp(mode: EnvStampMode, includeVersion: boolean) {
   const git = GitClient.get();
+
   console.info(`BUILD_SCM_BRANCH ${getCurrentBranch(git)}`);
   console.info(`BUILD_SCM_COMMIT_SHA ${getCurrentSha(git)}`);
   console.info(`BUILD_SCM_HASH ${getCurrentSha(git)}`);
@@ -32,9 +25,13 @@ export function buildEnvStamp(mode: EnvStampMode) {
   console.info(`BUILD_SCM_BRANCH ${getCurrentBranchOrRevision(git)}`);
   console.info(`BUILD_SCM_LOCAL_CHANGES ${hasLocalChanges(git)}`);
   console.info(`BUILD_SCM_USER ${getCurrentGitUser(git)}`);
-  const {version, experimentalVersion} = getSCMVersions(git, mode);
-  console.info(`BUILD_SCM_VERSION ${version}`);
-  console.info(`BUILD_SCM_EXPERIMENTAL_VERSION ${experimentalVersion}`);
+
+  if (includeVersion === true) {
+    const {version, experimentalVersion} = getSCMVersions(git, mode);
+    console.info(`BUILD_SCM_VERSION ${version}`);
+    console.info(`BUILD_SCM_EXPERIMENTAL_VERSION ${experimentalVersion}`);
+  }
+
   process.exit();
 }
 
@@ -51,40 +48,39 @@ function hasLocalChanges(git: GitClient) {
  * Get the versions for generated packages.
  *
  * In snapshot mode, the version is based on the most recent semver tag.
- * In release mode, the version is based on the base package.json version.
+ * In release mode, the version is based on the workspace version.
  */
 function getSCMVersions(
   git: GitClient,
   mode: EnvStampMode,
 ): {version: string; experimentalVersion: string} {
-  if (mode === 'snapshot') {
-    const localChanges = hasLocalChanges(git) ? '.with-local-changes' : '';
-    const {stdout: rawVersion} = git.run([
-      'describe',
-      '--match',
-      // As git describe uses glob matchers we cannot the specific describe what we expect to see
-      // starting character we expect for our version string.  To ensure we can handle 'v'
-      // prefixed verstions we have the '?' wildcard character.
-      '?[0-9]*.[0-9]*.[0-9]*',
-      '--abbrev=7',
-      '--tags',
-      'HEAD',
-    ]);
-    const {version} = new SemVer(rawVersion);
-    const {version: experimentalVersion} = createExperimentalSemver(version);
+  if (mode === 'release') {
+    const workspaceVersion = getVersionFromWorkspacePackageJson(git);
+
     return {
-      version: `${version.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`,
-      experimentalVersion: `${experimentalVersion.replace(
-        /-([0-9]+)-g/,
-        '+$1.sha-',
-      )}${localChanges}`,
+      version: workspaceVersion.format(),
+      experimentalVersion: createExperimentalSemver(workspaceVersion).format(),
     };
-  } else {
-    const packageJsonPath = join(git.baseDir, 'package.json');
-    const {version} = new SemVer(require(packageJsonPath).version);
-    const {version: experimentalVersion} = createExperimentalSemver(new SemVer(version));
-    return {version, experimentalVersion};
   }
+
+  const localChanges = hasLocalChanges(git) ? '.with-local-changes' : '';
+  const {stdout: rawVersion} = git.run([
+    'describe',
+    '--match',
+    // As git describe uses glob matchers we cannot the specific describe what we expect to see
+    // starting character we expect for our version string.  To ensure we can handle 'v'
+    // prefixed verstions we have the '?' wildcard character.
+    '?[0-9]*.[0-9]*.[0-9]*',
+    '--abbrev=7',
+    '--tags',
+    'HEAD',
+  ]);
+  const {version} = new SemVer(rawVersion);
+  const {version: experimentalVersion} = createExperimentalSemver(version);
+  return {
+    version: `${version.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`,
+    experimentalVersion: `${experimentalVersion.replace(/-([0-9]+)-g/, '+$1.sha-')}${localChanges}`,
+  };
 }
 
 /** Get the current SHA of HEAD. */
@@ -132,4 +128,18 @@ function getCurrentGitUser(git: GitClient) {
   } catch {
     return '';
   }
+}
+
+/** Gets the `version` from the workspace top-level `package.json` file. */
+function getVersionFromWorkspacePackageJson(git: GitClient): SemVer {
+  const packageJsonPath = join(git.baseDir, 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
+    version: string | undefined;
+  };
+
+  if (packageJson.version === undefined) {
+    throw new Error(`No workspace version found in: ${packageJsonPath}`);
+  }
+
+  return new SemVer(packageJson.version);
 }


### PR DESCRIPTION
Some repositories like the `dev-infra` repository do not follow the
usual Angular SemVer versioning but still would like to use the shared
stamping script.

For these repositories, another option is added to the stamping command
that allows version info from being included. There needs to be a way
to disable this as otherwise stamping currently fails when it tries to
find/compute a SemVer version from the workspace `package.json`, causing
errors like:

```
TypeError: Invalid Version: 0.0.0-{SCM_HEAD_SHA}
```