### PR TITLE
build: update to typescript v4.6 to match with FW repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "tmp": "^0.2.1",
     "true-case-path": "^2.2.1",
     "tslib": "^2.3.0",
-    "typescript": "~4.5.0",
+    "typescript": "~4.6.2",
     "uuid": "^8.3.2",
     "yargs": "^17.0.0",
     "zone.js": "^0.11.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,7 +387,7 @@ __metadata:
     tslib: ^2.3.0
     tslint: ^6.1.3
     typed-graphqlify: ^3.1.1
-    typescript: ~4.5.0
+    typescript: ~4.6.2
     uglify-js: ^3.14.2
     uuid: ^8.3.2
     wait-on: ^6.0.0
@@ -12204,7 +12204,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.5.0, typescript@npm:~4.5.2":
+"typescript@npm:~4.5.2":
   version: 4.5.5
   resolution: "typescript@npm:4.5.5"
   bin:
@@ -12214,13 +12214,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~4.5.0#~builtin<compat/typescript>, typescript@patch:typescript@~4.5.2#~builtin<compat/typescript>":
+"typescript@npm:~4.6.2":
+  version: 4.6.2
+  resolution: "typescript@npm:4.6.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 8a44ed7e6f6c4cb1ebe8cf236ecda2fb119d84dcf0fbd77e707b2dfea1bbcfc4e366493a143513ce7f57203c75da9d4e20af6fe46de89749366351046be7577c
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~4.5.2#~builtin<compat/typescript>":
   version: 4.5.5
   resolution: "typescript@patch:typescript@npm%3A4.5.5#~builtin<compat/typescript>::version=4.5.5&hash=bda367"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 858c61fa63f7274ca4aaaffeced854d550bf416cff6e558c4884041b3311fb662f476f167cf5c9f8680c607239797e26a2ee0bcc6467fbc05bfcb218e1c6c671
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~4.6.2#~builtin<compat/typescript>":
+  version: 4.6.2
+  resolution: "typescript@patch:typescript@npm%3A4.6.2#~builtin<compat/typescript>::version=4.6.2&hash=bda367"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 40b493a71747fb89fa70df104e2c4a5e284b43750af5bea024090a5261cefa387f7a9372411b13030f7bf5555cee4275443d08805642ae5c74ef76740854a4c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As we start to update TS in all other Angular repos, we should
make sure the shared tooling is also in sync with regards to the
TS version (https://github.com/angular/angular/commit/94bba76a4a9594a5eb90e581f407f1b70697e715)