### PR TITLE
refactor: no longer import `JSModuleInfo` provider through backwards-compat entry

### DIFF
--- a/bazel/extract_js_module_output.bzl
+++ b/bazel/extract_js_module_output.bzl
@@ -1,4 +1,5 @@
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "ExternalNpmPackageInfo", "JSEcmaScriptModuleInfo", "JSModuleInfo", "JSNamedModuleInfo", "node_modules_aspect")
+load("@rules_nodejs//nodejs:providers.bzl", "JSModuleInfo")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "ExternalNpmPackageInfo", "JSEcmaScriptModuleInfo", "JSNamedModuleInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "LinkerPackageMappingInfo", "module_mappings_aspect")
 
 """Converts a provider name to its actually Starlark provider instance."""

--- a/bazel/spec-bundling/spec-entrypoint.bzl
+++ b/bazel/spec-bundling/spec-entrypoint.bzl
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_nodejs//:providers.bzl", "JSModuleInfo")
+load("@rules_nodejs//nodejs:providers.bzl", "JSModuleInfo")
 
 def _is_spec_file(file):
     """Gets whether the given file is a spec file."""


### PR DESCRIPTION
The `JSModuleInfo` provider is no longer part of the `build_bazel_rules_nodejs` repository
but rather part of the "rules_nodejs" fundamentals. We should no longer rely on the
backwards-compatibility exposed provider, but instead use the expected new import.