### PR TITLE
build: enable node module symlinking for Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,9 @@ yarn_install(
     #  2. Incompatibilites with the `ts_library` rule.
     exports_directories_only = False,
     package_json = "//:package.json",
+    # We prefer to symlink the `node_modules` to only maintain a single install.
+    # See https://github.com/angular/dev-infra/pull/446#issuecomment-1059820287 for details.
+    symlink_node_modules = True,
     # TODO: Cleanup when https://github.com/bazelbuild/rules_nodejs/pull/3350 is available.
     yarn = "//:.yarn/yarn.js",
     yarn_lock = "//:yarn.lock",


### PR DESCRIPTION
Enables symlinking of the node modules folder to keep a single
install of NPM/Yarn. More details can be found here:

https://github.com/angular/dev-infra/pull/446#issuecomment-1059820287

Symlinking previously was enabled by default, but as part of RNJ 5 this
has changed without any super-noticable changelog entry.