### PR TITLE
ci: fix yarn install timeout in macos job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ var_5: &save_cache
   save_cache:
     key: *cache_key
     paths:
+      - '.yarn/cache'
       - '~/.cache/bazelisk'
       - '~/bazel_repository_cache'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
       - run:
           name: yarn install
           command: yarn install --immutable
-          no_output_timeout: 2m
+          no_output_timeout: 5m
 
   setup_bazel_config:
     description: 'Setting up Bazel configuration for CI'
@@ -156,9 +156,7 @@ jobs:
     steps:
       - checkout
       - *restore_cache
-      # Note: We cannot use the config-shared Yarn install command because the output timeout
-      # needs to be increased due to slower windows I/O (back to the 10min default for CircleCI).
-      - run: yarn install --immutable
+      - yarn_install
       - run: yarn bazel test --test_tag_filters=windows --build_tests_only -- ... -bazel/remote-execution/...
       - prepare_and_store_test_results
       - *save_cache


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/angular/dev-infra/164070/workflows/cc6cd9a7-5e0f-450c-b839-ece856156796/jobs/165678

@josephperrott I'm proposing to just always set the timeout to 5min (windows takes 3min fresh as it seems), so we could use the shared command and avoid some complexity in the config (as macos 2min also is too short)
