### PR TITLE
fix(ng-dev): correctly indent bullets in breaking changes and deprecations sections

### DIFF
--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -203,7 +203,7 @@ export class RenderContext {
    * Bulletize a paragraph.
    */
   bulletizeText(text: string): string {
-    return '- ' + text.replace(/\\n/g, '\\n  ');
+    return '- ' + text.replace(/\n/g, '\n  ');
   }
 
   /**

--- a/tools/local-actions/changelog/main.js
+++ b/tools/local-actions/changelog/main.js
@@ -48921,7 +48921,7 @@ var require_context2 = __commonJS({
         return content.replace(/#(\d+)/g, (_, g) => this.pullRequestToLink(Number(g)));
       }
       bulletizeText(text) {
-        return "- " + text.replace(/\\n/g, "\\n  ");
+        return "- " + text.replace(/\n/g, "\n  ");
       }
       commitAuthors(commits) {
         return [...new Set(commits.map((c) => c.author))].filter((a) => !botsAuthorNames.includes(a)).sort();


### PR DESCRIPTION
…
With this change we fix an issue where when breaking changes or deprecations messages contained bullets these were not indented correctly.

Previously
```
## Breaking Changes
### @angular/cli
- Support for Node.js v12 has been removed as it will become EOL on 2022-04-30. Please use Node.js v14.15 or later.

- Several changes in the Angular CLI commands and arguments handling.

- `ng help` has been removed in favour of the `—-help` option.
- `ng —-version` has been removed in favour of `ng version` and `ng v`.
- Deprecated camel cased arguments are no longer supported. Ex. using `—-sourceMap` instead of `—-source-map` will result in an error.
- `ng update`, `—-migrate-only` option no longer accepts a string of migration name, instead use `—-migrate-only -—name <migration-name>`.
- `—-help json` help has been removed.
### @angular/cli
| Commit | Type | Description |
| -- | -- | -- |
| [4ebfe0341](https://github.com/angular/angular-cli/commit/4ebfe03415ebe4e8f1625286d1be8bd1b54d3862) | feat | drop support for Node.js 12 |
| [c0ca87656](https://github.com/angular/angular-cli/commit/c0ca8765619aaa9223b278e394ea296f89857135) | fix | remove JSON serialized description from help output |
| [2e0493130](https://github.com/angular/angular-cli/commit/2e0493130acfe7244f7ee3ef28c961b1b04d7722) | refactor | replace command line arguments parser |
### @angular-devkit/build-angular
| Commit | Type | Description |
| -- | -- | -- |
| [e28c71597](https://github.com/angular/angular-cli/commit/e28c7159725a6d23b218dc6e0f317fc6123173f7) | fix | ignore css only chunks during naming |
## Special Thanks
Alan Agius and Joey Perrott
```

Now
```
## Breaking Changes
### @angular/cli
- Support for Node.js v12 has been removed as it will become EOL on 2022-04-30. Please use Node.js v14.15 or later.

- Several changes in the Angular CLI commands and arguments handling.

  - `ng help` has been removed in favour of the `—-help` option.
  - `ng —-version` has been removed in favour of `ng version` and `ng v`.
  - Deprecated camel cased arguments are no longer supported. Ex. using `—-sourceMap` instead of `—-source-map` will result in an error.
  - `ng update`, `—-migrate-only` option no longer accepts a string of migration name, instead use `—-migrate-only -—name <migration-name>`.
  - `—-help json` help has been removed.
### @angular/cli
| Commit | Type | Description |
| -- | -- | -- |
| [4ebfe0341](https://github.com/angular/angular-cli/commit/4ebfe03415ebe4e8f1625286d1be8bd1b54d3862) | feat | drop support for Node.js 12 |
| [c0ca87656](https://github.com/angular/angular-cli/commit/c0ca8765619aaa9223b278e394ea296f89857135) | fix | remove JSON serialized description from help output |
| [2e0493130](https://github.com/angular/angular-cli/commit/2e0493130acfe7244f7ee3ef28c961b1b04d7722) | refactor | replace command line arguments parser |
### @angular-devkit/build-angular
| Commit | Type | Description |
| -- | -- | -- |
| [e28c71597](https://github.com/angular/angular-cli/commit/e28c7159725a6d23b218dc6e0f317fc6123173f7) | fix | ignore css only chunks during naming |
## Special Thanks
Alan Agius and Joey Perrott
```