### PR TITLE
ci: ignore integration test projects in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "ignorePaths": ["bazel/integration/tests/**"],
   "enabledManagers": ["npm", "bazel", "github-actions"],
   "baseBranches": ["main"],
   "packageRules": [


### PR DESCRIPTION
Renovate is never able to fully/properly update integration
test projects as they are technically invalid (due to e.g.
`file:../../whatever` version installs).

We should just skip these tests as they should rarely need
updates anyway, and since that makes Renovate happy and not
complain about broken updates/invalid artifacts.