### PR TITLE
build: remove workaround for rules_nodejs#3106 which landed in 4.5.0

### DIFF
--- a/bazel/benchmark/app_bundling/index.bzl
+++ b/bazel/benchmark/app_bundling/index.bzl
@@ -17,8 +17,6 @@ def _create_esbuild_minify_options(debug = False):
         "minifyIdentifiers": not debug,
         "minifySyntax": True,
         "minifyWhitespace": False,
-        # TODO: Remove when https://github.com/bazelbuild/rules_nodejs/pull/3106 landed.
-        "ignoreAnnotations": False,
     }
 
 def app_bundle(


### PR DESCRIPTION
https://github.com/bazelbuild/rules_nodejs/pull/3106