### PR TITLE
fix(bazel): use correct `LinkerPackageMappingInfo` field name

### DIFF
--- a/bazel/extract_js_module_output.bzl
+++ b/bazel/extract_js_module_output.bzl
@@ -18,7 +18,7 @@ def _name_to_js_module_provider(name):
 def _extract_js_module_output_impl(ctx):
     js_module_provider = _name_to_js_module_provider(ctx.attr.provider)
     transitive_mappings = []
-    transitive_node_module_roots = []
+    transitive_node_modules_roots = []
     depsets = []
 
     for dep in ctx.attr.deps:
@@ -36,7 +36,7 @@ def _extract_js_module_output_impl(ctx):
         # linker mappings and collect them in a dictionary that we will re-expose.
         if ctx.attr.forward_linker_mappings and LinkerPackageMappingInfo in dep:
             transitive_mappings.append(dep[LinkerPackageMappingInfo].mappings)
-            transitive_node_module_roots.append(dep[LinkerPackageMappingInfo].node_module_roots)
+            transitive_node_modules_roots.append(dep[LinkerPackageMappingInfo].node_modules_roots)
 
         # Based on whether declarations should be collected, extract direct
         # and transitive declaration files using the `DeclarationInfo` provider.
@@ -59,7 +59,7 @@ def _extract_js_module_output_impl(ctx):
             # Example of how linker mappings are constructed in `rules_nodejs`.
             # https://github.com/bazelbuild/rules_nodejs/blob/ae49c0e85a60234f273ea6629bc6056ab293fe5b/internal/linker/link_node_modules.bzl#L220-L222.
             mappings = depset(transitive = transitive_mappings),
-            node_modules_roots = depset(transitive = transitive_node_module_roots),
+            node_modules_roots = depset(transitive = transitive_node_modules_roots),
         ),
     ]
 


### PR DESCRIPTION
Use the correct field name (`node_modules_roots` instead of `node_module_roots`) when trying to access data off of the [LinkerPackageMappingInfo][1] value of a dependency in `extract_js_module_output()`.

See [here][2] for an example of a failure with the current incorrect field name.

[1]: https://github.com/bazelbuild/rules_nodejs/blob/2a78e6d815ee36e99cf9cc6462419e16f11c057d/internal/linker/link_node_modules.bzl#L34
[2]: https://circleci.com/gh/angular/angular/1137996