### PR TITLE
test: add basic tests to ensure `extract_types` and `extract_js_module_output` works

### DIFF
--- a/bazel/test/BUILD.bazel
+++ b/bazel/test/BUILD.bazel
@@ -1,0 +1,57 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
+load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:extract_types.bzl", "extract_types")
+load("//bazel:extract_js_module_output.bzl", "extract_js_module_output")
+
+ts_library(
+    name = "transitive_lib",
+    testonly = True,
+    srcs = ["transitive_file.ts"],
+)
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = ["fixture.ts"],
+    deps = [":transitive_lib"],
+)
+
+filegroup(
+    name = "text_fixture",
+    testonly = True,
+    srcs = ["fixture.txt"],
+)
+
+extract_types(
+    name = "extract_types_target",
+    testonly = True,
+    deps = [":test_lib"],
+)
+
+extract_js_module_output(
+    name = "extract_js_module_output_target",
+    testonly = True,
+    forward_linker_mappings = True,
+    include_declarations = True,
+    include_default_files = True,
+    include_external_npm_packages = True,
+    provider = "JSModuleInfo",
+    deps = [
+        ":test_lib",
+        ":text_fixture",
+    ],
+)
+
+nodejs_test(
+    name = "extract_types_test",
+    data = [":extract_types_target"],
+    entry_point = "extract_types_test.js",
+    templated_args = ["$(rootpaths :extract_types_target)"],
+)
+
+nodejs_test(
+    name = "extract_js_module_test",
+    data = [":extract_js_module_output_target"],
+    entry_point = "extract_js_module_test.js",
+    templated_args = ["$(rootpaths :extract_js_module_output_target)"],
+)

--- a/bazel/test/extract_js_module_test.js
+++ b/bazel/test/extract_js_module_test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+
+/**
+ * Files exposed through the `extract_js_module_output` target are passed
+ * as command line arguments.
+ */
+const extractedFileRootpaths = process.argv.slice(2);
+
+assert.deepStrictEqual(extractedFileRootpaths, [
+  // TypeScript files transitively added to every `ts_library` target. This might be
+  // cleaned up in the future, but is captured in this test as it rarely should change.
+  '../npm/node_modules/typescript/lib/protocol.d.ts',
+  '../npm/node_modules/typescript/lib/tsserverlibrary.d.ts',
+  '../npm/node_modules/typescript/lib/typescript.d.ts',
+  '../npm/node_modules/typescript/lib/typescriptServices.d.ts',
+  // Actual workspace-local extracted files.
+  'bazel/test/fixture.d.ts',
+  'bazel/test/fixture.js',
+  'bazel/test/fixture.txt',
+  'bazel/test/transitive_file.d.ts',
+  'bazel/test/transitive_file.js',
+]);

--- a/bazel/test/extract_types_test.js
+++ b/bazel/test/extract_types_test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+
+/**  Files exposed through the `extract_types` target are passed as arguments. */
+const typeRootpaths = process.argv.slice(2);
+
+assert.deepStrictEqual(typeRootpaths, [
+  // TypeScript types transitively added to every `ts_library` target. This might be
+  // cleaned up in the future, but is captured in this test as it rarely should change.
+  '../npm/node_modules/typescript/lib/protocol.d.ts',
+  '../npm/node_modules/typescript/lib/tsserverlibrary.d.ts',
+  '../npm/node_modules/typescript/lib/typescript.d.ts',
+  '../npm/node_modules/typescript/lib/typescriptServices.d.ts',
+  // Actual workspace-local `d.ts` files.
+  'bazel/test/fixture.d.ts',
+  'bazel/test/transitive_file.d.ts',
+]);

--- a/bazel/test/fixture.ts
+++ b/bazel/test/fixture.ts
@@ -1,0 +1,2 @@
+export {transitiveFile} from './transitive_file';
+export const someConstant = 1;

--- a/bazel/test/fixture.txt
+++ b/bazel/test/fixture.txt
@@ -1,0 +1,1 @@
+a simple text file

--- a/bazel/test/transitive_file.ts
+++ b/bazel/test/transitive_file.ts
@@ -1,0 +1,1 @@
+export const transitiveFile = true;


### PR DESCRIPTION
Self-explanatory.

Note: I want to clean up the extract JS module rule as I find it being concerned with _too_ much, but that's
another story. This commit just adds a little test ensuring it does what it suggests + continues to work.