### PR TITLE
feat(bazel/api-golden): allow for module types to be provided

### DIFF
--- a/bazel/api-golden/BUILD.bazel
+++ b/bazel/api-golden/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "find_entry_points.ts",
         "index.ts",
         "index_npm_packages.ts",
+        "module_mappings.ts",
         "path-normalize.ts",
         "test_api_report.ts",
     ],

--- a/bazel/api-golden/index.ts
+++ b/bazel/api-golden/index.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {runfiles} from '@bazel/runfiles';
 import * as chalk from 'chalk';
 
+import {runfiles} from '@bazel/runfiles';
 import {testApiGolden} from './test_api_report';
 
 /**
@@ -20,14 +20,14 @@ async function main(
   entryPointFilePath: string,
   approveGolden: boolean,
   stripExportPattern: RegExp,
-  typeNames: string[],
+  typePackageNames: string[],
 ) {
   const {succeeded, apiReportChanged} = await testApiGolden(
     goldenFilePath,
     entryPointFilePath,
     approveGolden,
     stripExportPattern,
-    typeNames,
+    typePackageNames,
   );
 
   if (!succeeded && apiReportChanged) {
@@ -49,12 +49,16 @@ if (require.main === module) {
   const entryPointFilePath = runfiles.resolve(args[1]);
   const approveGolden = args[2] === 'true';
   const stripExportPattern = new RegExp(args[3]);
-  const typeNames = args.slice(4);
+  const typePackageNames = args.slice(4);
 
-  main(goldenFilePath, entryPointFilePath, approveGolden, stripExportPattern, typeNames).catch(
-    (e) => {
-      console.error(e);
-      process.exit(1);
-    },
-  );
+  main(
+    goldenFilePath,
+    entryPointFilePath,
+    approveGolden,
+    stripExportPattern,
+    typePackageNames,
+  ).catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
 }

--- a/bazel/api-golden/index_npm_packages.ts
+++ b/bazel/api-golden/index_npm_packages.ts
@@ -33,7 +33,7 @@ async function main(
   npmPackageDir: string,
   approveGolden: boolean,
   stripExportPattern: RegExp,
-  typeNames: string[],
+  typePackageNames: string[],
 ) {
   const packageJsonPath = join(npmPackageDir, 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageJson;
@@ -56,7 +56,7 @@ async function main(
       typesEntryPointPath,
       approveGolden,
       stripExportPattern,
-      typeNames,
+      typePackageNames,
       packageJsonPath,
       moduleName,
     );
@@ -90,9 +90,9 @@ if (require.main === module) {
   const npmPackageDir = runfiles.resolve(args[1]);
   const approveGolden = args[2] === 'true';
   const stripExportPattern = new RegExp(args[3]);
-  const typeNames = args.slice(4);
+  const typePackageNames = args.slice(4);
 
-  main(goldenDir, npmPackageDir, approveGolden, stripExportPattern, typeNames).catch((e) => {
+  main(goldenDir, npmPackageDir, approveGolden, stripExportPattern, typePackageNames).catch((e) => {
     console.error(e);
     process.exit(1);
   });

--- a/bazel/api-golden/module_mappings.ts
+++ b/bazel/api-golden/module_mappings.ts
@@ -18,7 +18,7 @@ const scopedTypesPackageRegex = /^@types\/([^_\/]+)__(.+)/;
  * Resolves type modules and returns corresponding path mappings and a
  * list of referenced files.
  */
-export async function resolveTypeModules(typePackageNames: string[]): Promise<{
+export async function resolveTypePackages(typePackageNames: string[]): Promise<{
   paths: Record<string, string[]>;
   typeFiles: string[];
 }> {
@@ -27,7 +27,7 @@ export async function resolveTypeModules(typePackageNames: string[]): Promise<{
 
   for (const typePackageName of typePackageNames) {
     const moduleNames = getModuleNamesForTypePackage(typePackageName);
-    const {entryPointTypeFile, resolvedPackageDir} = await resolveTypeDeclarationOfModule(
+    const {entryPointTypeFile, resolvedPackageDir} = await resolveTypeDeclarationOfPackage(
       typePackageName,
     );
 
@@ -41,8 +41,8 @@ export async function resolveTypeModules(typePackageNames: string[]): Promise<{
   return {paths, typeFiles};
 }
 
-/** Resolves the type declaration entry-point file of a given module. */
-async function resolveTypeDeclarationOfModule(moduleName: string): Promise<{
+/** Resolves the type declaration entry-point file of a given package. */
+async function resolveTypeDeclarationOfPackage(moduleName: string): Promise<{
   entryPointTypeFile: string;
   resolvedPackageDir: string;
 }> {

--- a/bazel/api-golden/module_mappings.ts
+++ b/bazel/api-golden/module_mappings.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as path from 'path';
+
+import {runfiles} from '@bazel/runfiles';
+
+/** Regular expression that matches a scoped type package name. */
+const scopedTypesPackageRegex = /^@types\/([^_\/]+)__(.+)/;
+
+/**
+ * Resolves type modules and returns corresponding path mappings and a
+ * list of referenced files.
+ */
+export function resolveTypeModules(typePackageNames: string[]): {
+  paths: Record<string, string[]>;
+  typeFiles: string[];
+} {
+  const typeFiles = [];
+  const paths: Record<string, string[]> = {};
+
+  for (const moduleName of typePackageNames) {
+    const resolvedModuleDir = resolveNodeModuleToDirectory(moduleName);
+    const scopedAlternativeName = getScopedNameFromTypeName(moduleName);
+
+    // It's a naive assumption that type files exist directly in `index.d.ts` of
+    // the package. The file does not necessarily exist but this assumption is
+    // sufficient for our current needs. API golden tests rarely rely on global types.
+    typeFiles.push(path.join(resolvedModuleDir, 'index.d.ts'));
+
+    paths[moduleName] = [resolvedModuleDir];
+
+    if (scopedAlternativeName !== null) {
+      paths[scopedAlternativeName] = paths[moduleName];
+    }
+  }
+
+  return {paths, typeFiles};
+}
+
+/**
+ * Gets the scoped module name from a type package, if available.
+ * e.g. for `@types/babel__core` this returns `@babel/core`.
+ */
+function getScopedNameFromTypeName(name: string): string | null {
+  const matches = name.match(scopedTypesPackageRegex);
+
+  if (matches === null) {
+    return null;
+  }
+
+  return `@${matches[1]}/${matches[2]}`;
+}
+
+/** Resolves a node module to an absolute file directory path. */
+function resolveNodeModuleToDirectory(moduleName: string): string {
+  return runfiles.resolve(`npm/node_modules/${moduleName}/`);
+}

--- a/bazel/api-golden/test/BUILD.bazel
+++ b/bazel/api-golden/test/BUILD.bazel
@@ -8,6 +8,8 @@ api_golden_test(
     ],
     entry_point = "dev-infra/bazel/api-golden/test/fixtures/test_fixture.d.ts",
     golden = "dev-infra/bazel/api-golden/test/goldens/test_golden.md",
+    # API extractor type resolution is prone to non-sandbox errors, so we test Windows.
+    tags = ["windows"],
     types = ["@npm//@types/node"],
 )
 
@@ -19,6 +21,11 @@ api_golden_test_npm_package(
     ],
     golden_dir = "dev-infra/bazel/api-golden/test/goldens/test_package",
     npm_package = "dev-infra/bazel/api-golden/test/fixtures/test_package",
+    # API extractor type resolution is prone to non-sandbox errors, so we test Windows.
+    tags = ["windows"],
+    # API extractor needs to be able to resolve `@babel/core` due to an aliased namespace
+    # we expose as part of the `nested.d.ts` fake entry-point.
+    types = ["@npm//@types/babel__core"],
 )
 
 api_golden_test_npm_package(
@@ -29,4 +36,6 @@ api_golden_test_npm_package(
     ],
     golden_dir = "dev-infra/bazel/api-golden/test/goldens/pkg_no_exports_field",
     npm_package = "dev-infra/bazel/api-golden/test/fixtures/pkg_no_exports_field",
+    # API extractor type resolution is prone to non-sandbox errors, so we test Windows.
+    tags = ["windows"],
 )

--- a/bazel/api-golden/test/fixtures/test_package/testing/namespace-alias.ts
+++ b/bazel/api-golden/test/fixtures/test_package/testing/namespace-alias.ts
@@ -1,0 +1,6 @@
+import * as _babelNamespace from '@babel/core';
+
+// Alias namespace.
+import aliasNamespace = _babelNamespace.types;
+
+export import types = aliasNamespace;

--- a/bazel/api-golden/test/fixtures/test_package/testing/nested.d.ts
+++ b/bazel/api-golden/test/fixtures/test_package/testing/nested.d.ts
@@ -1,1 +1,7 @@
+import {types} from './namespace-alias';
+
+import aliased = types;
+export import reexposed = aliased;
+
+export declare function acceptVersion(v: aliased.ExistsTypeAnnotation): void;
 export declare const nestedFile = true;

--- a/bazel/api-golden/test/goldens/test_package/testing/nested/index.md
+++ b/bazel/api-golden/test/goldens/test_package/testing/nested/index.md
@@ -4,8 +4,15 @@
 
 ```ts
 
+import * as reexposed from '@babel/types';
+
+// @public (undocumented)
+export function acceptVersion(v: reexposed.ExistsTypeAnnotation): void;
+
 // @public (undocumented)
 export const nestedFile = true;
+
+export { reexposed }
 
 // (No @packageDocumentation comment for this package)
 

--- a/bazel/api-golden/test_api_report.ts
+++ b/bazel/api-golden/test_api_report.ts
@@ -20,6 +20,7 @@ import {basename, dirname} from 'path';
 
 import {AstModule} from '@microsoft/api-extractor/lib/analyzer/AstModule';
 import {ExportAnalyzer} from '@microsoft/api-extractor/lib/analyzer/ExportAnalyzer';
+import {resolveTypeModules} from './module_mappings';
 import {runfiles} from '@bazel/runfiles';
 
 /**
@@ -38,8 +39,8 @@ const _origFetchAstModuleExportInfo = ExportAnalyzer.prototype.fetchAstModuleExp
  * @param approveGolden Whether the golden file should be updated.
  * @param stripExportPattern Regular Expression that can be used to filter out exports
  *   from the API report.
- * @param typeNames Name of types which should be included for analysis of the entry-point.
- *   Types are expected to exist within the default `node_modules/@types/` folder.
+ * @param typePackageNames Package names for which types should be included in the analysis of the
+ *   API-report entry-point. Packages are expected to exist within the external `npm` workspace.
  * @param packageJsonPath Optional path to a `package.json` file that contains the entry
  *   point. Note that the `package.json` is currently only used by `api-extractor` to determine
  *   the package name displayed within the API golden.
@@ -52,21 +53,31 @@ export async function testApiGolden(
   indexFilePath: string,
   approveGolden: boolean,
   stripExportPattern: RegExp,
-  typeNames: string[] = [],
+  typePackageNames: string[] = [],
   packageJsonPath = resolveWorkspacePackageJsonPath(),
   customPackageName?: string,
 ): Promise<ExtractorResult> {
   // If no `TEST_TMPDIR` is defined, then this script runs using `bazel run`. We use
   // the runfile directory as temporary directory for API extractor.
   const tempDir = process.env.TEST_TMPDIR ?? process.cwd();
+  const {paths, typeFiles} = resolveTypeModules(typePackageNames);
 
   const configObject: IConfigFile = {
     compiler: {
       overrideTsconfig:
-        // We disable automatic `@types` resolution as this throws-off API reports
-        // when the API test is run outside sandbox. Instead we expect a list of
-        // hard-coded types that should be included. This works in non-sandbox too.
-        {files: [indexFilePath], compilerOptions: {types: typeNames, lib: ['esnext', 'dom']}},
+        // We disable automatic `@types` resolution as this throws-off API reports when the API
+        // test is run outside sandbox. Instead we expect a list of  hard-coded types that should
+        // be added.This works in non-sandbox and Windows. Note that we include the type files
+        // directly in the compilation, and additionally set up path mappings. This allows
+        // for global type definitions and module-scoped types to work.
+        {
+          files: [indexFilePath, ...typeFiles],
+          compilerOptions: {
+            paths,
+            types: [],
+            lib: ['esnext', 'dom'],
+          },
+        },
     },
     projectFolder: dirname(packageJsonPath),
     mainEntryPointFilePath: indexFilePath,

--- a/bazel/api-golden/test_api_report.ts
+++ b/bazel/api-golden/test_api_report.ts
@@ -60,7 +60,7 @@ export async function testApiGolden(
   // If no `TEST_TMPDIR` is defined, then this script runs using `bazel run`. We use
   // the runfile directory as temporary directory for API extractor.
   const tempDir = process.env.TEST_TMPDIR ?? process.cwd();
-  const {paths, typeFiles} = resolveTypeModules(typePackageNames);
+  const {paths, typeFiles} = await resolveTypeModules(typePackageNames);
 
   const configObject: IConfigFile = {
     compiler: {

--- a/bazel/api-golden/test_api_report.ts
+++ b/bazel/api-golden/test_api_report.ts
@@ -20,7 +20,7 @@ import {basename, dirname} from 'path';
 
 import {AstModule} from '@microsoft/api-extractor/lib/analyzer/AstModule';
 import {ExportAnalyzer} from '@microsoft/api-extractor/lib/analyzer/ExportAnalyzer';
-import {resolveTypeModules} from './module_mappings';
+import {resolveTypePackages} from './module_mappings';
 import {runfiles} from '@bazel/runfiles';
 
 /**
@@ -60,7 +60,7 @@ export async function testApiGolden(
   // If no `TEST_TMPDIR` is defined, then this script runs using `bazel run`. We use
   // the runfile directory as temporary directory for API extractor.
   const tempDir = process.env.TEST_TMPDIR ?? process.cwd();
-  const {paths, typeFiles} = await resolveTypeModules(typePackageNames);
+  const {paths, typeFiles} = await resolveTypePackages(typePackageNames);
 
   const configObject: IConfigFile = {
     compiler: {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@octokit/request-error": "^2.1.0",
     "@octokit/rest": "^18.7.0",
     "@octokit/types": "^6.16.6",
+    "@types/babel__core": "^7.1.19",
     "@types/cli-progress": "^3.9.1",
     "@types/conventional-commits-parser": "^3.0.1",
     "@types/ejs": "^3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,6 +332,7 @@ __metadata:
     "@octokit/request-error": ^2.1.0
     "@octokit/rest": ^18.7.0
     "@octokit/types": ^6.16.6
+    "@types/babel__core": ^7.1.19
     "@types/browser-sync": ^2.26.3
     "@types/cli-progress": ^3.9.1
     "@types/conventional-commits-parser": ^3.0.1
@@ -777,7 +778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.17.3, @babel/parser@npm:^7.17.7, @babel/parser@npm:^7.17.8, @babel/parser@npm:^7.9.4":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.17.3, @babel/parser@npm:^7.17.7, @babel/parser@npm:^7.17.8, @babel/parser@npm:^7.9.4":
   version: 7.17.8
   resolution: "@babel/parser@npm:7.17.8"
   bin:
@@ -1692,7 +1693,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.16.0, @babel/types@npm:^7.16.7, @babel/types@npm:^7.16.8, @babel/types@npm:^7.17.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.16.0, @babel/types@npm:^7.16.7, @babel/types@npm:^7.16.8, @babel/types@npm:^7.17.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.17.0
   resolution: "@babel/types@npm:7.17.0"
   dependencies:
@@ -2673,6 +2674,47 @@ __metadata:
   version: 1.0.38
   resolution: "@types/argparse@npm:1.0.38"
   checksum: 26ed7e3f1e3595efdb883a852f5205f971b798e4c28b7e30a32c5298eee596e8b45834ce831f014d250b9730819ab05acff5b31229666d3af4ba465b4697d0eb
+  languageName: node
+  linkType: hard
+
+"@types/babel__core@npm:^7.1.19":
+  version: 7.1.19
+  resolution: "@types/babel__core@npm:7.1.19"
+  dependencies:
+    "@babel/parser": ^7.1.0
+    "@babel/types": ^7.0.0
+    "@types/babel__generator": "*"
+    "@types/babel__template": "*"
+    "@types/babel__traverse": "*"
+  checksum: 8c9fa87a1c2224cbec251683a58bebb0d74c497118034166aaa0491a4e2627998a6621fc71f8a60ffd27d9c0c52097defedf7637adc6618d0331c15adb302338
+  languageName: node
+  linkType: hard
+
+"@types/babel__generator@npm:*":
+  version: 7.6.4
+  resolution: "@types/babel__generator@npm:7.6.4"
+  dependencies:
+    "@babel/types": ^7.0.0
+  checksum: 20effbbb5f8a3a0211e95959d06ae70c097fb6191011b73b38fe86deebefad8e09ee014605e0fd3cdaedc73d158be555866810e9166e1f09e4cfd880b874dcb0
+  languageName: node
+  linkType: hard
+
+"@types/babel__template@npm:*":
+  version: 7.4.1
+  resolution: "@types/babel__template@npm:7.4.1"
+  dependencies:
+    "@babel/parser": ^7.1.0
+    "@babel/types": ^7.0.0
+  checksum: 649fe8b42c2876be1fd28c6ed9b276f78152d5904ec290b6c861d9ef324206e0a5c242e8305c421ac52ecf6358fa7e32ab7a692f55370484825c1df29b1596ee
+  languageName: node
+  linkType: hard
+
+"@types/babel__traverse@npm:*":
+  version: 7.14.2
+  resolution: "@types/babel__traverse@npm:7.14.2"
+  dependencies:
+    "@babel/types": ^7.3.0
+  checksum: a797ea09c72307569e3ee08aa3900ca744ce3091114084f2dc59b67a45ee7d01df7865252790dbfa787a7915ce892cdc820c9b920f3683292765fc656b08dc63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently the API golden bazel test rule will just add `@types/<..>`
modules to the TSConfig `types` section. This is unreliable and relies
on the Bazel NodeJS linker which does not work well on Windows.

This commit refactors the logic to rely on path mappings for type
resolution inside the API golden Bazel-based tests. This guarantees
a working rule on Windows and also supports scoped packages. Currently
scoped package types do not work, like `@types/babel__core` which is
actually mapping internally to `@babel/core`.

Our trick will be to use path mappings as mentioned before, manually
computing the scoped package types (like with `@babel/core`). Additionally
referenced types will still be loaded directly as part of the compilation
inputs to support global type definitions like `NodeJS.ProcessEnv`.

The solution is not 100% ideal but it's less breaky than how type resolution
works within `@bazel/typescript` currently.. ~~The biggest issue is that we
assume for global types that the file is called `index.d.ts`.~~ The biggest
issue is that we implement the `types` resolution manually to some extent..