### PR TITLE
refactor(apps): use static helper methods for getting firestore references and converters

### DIFF
--- a/apps/functions/githubWebhook/BUILD.bazel
+++ b/apps/functions/githubWebhook/BUILD.bazel
@@ -25,5 +25,6 @@ ts_library(
     deps = [
         "//apps/shared/models:server",
         "@npm//@octokit/webhooks-types",
+        "@npm//firebase-admin",
     ],
 )

--- a/apps/shared/models/app-models.ts
+++ b/apps/shared/models/app-models.ts
@@ -1,9 +1,6 @@
 import {getDoc, getFirestore, doc, DocumentData} from 'firebase/firestore';
 import {BaseModel, Constructor, FirestoreReference, fromFirestoreReference} from './base';
 
-/** Marker symbol for noting that a model has been decorated for app use. */
-const decoratedForApp = Symbol('forApp');
-
 // Import all of the models for the module and decorate all of them for app use.
 import * as models from './index';
 Object.values(models).forEach(forApp);
@@ -18,7 +15,7 @@ function forApp<
   TBase extends Constructor<BaseModel<FirebaseModel>>,
 >(model: TBase) {
   const staticModel = model as unknown as typeof BaseModel;
-  staticModel.decoratedFor(decoratedForApp);
+  staticModel.markAsDecorated();
 
   /** The converter object for performing conversions in and out of Firestore. */
   const converter = {

--- a/apps/shared/models/base.ts
+++ b/apps/shared/models/base.ts
@@ -4,11 +4,11 @@ export type Constructor<T> = new (...args: any[]) => T;
 export abstract class BaseModel<T> {
   data!: T;
   /** The symbol marker for the function which decorated the model for either app or server. */
-  private decoratedFor!: symbol;
+  private isDecorated = false;
 
   /** The data as stored in Firestore. */
   constructor(data: T) {
-    if (this.decoratedFor === null) {
+    if (this.isDecorated === false) {
       throw Error();
     }
     this.setData(data);
@@ -37,19 +37,16 @@ export abstract class BaseModel<T> {
     throw Error('This was not implemented');
   }
 
-  /** Set the decoratedFor value on the prototype of the class. */
-  static decoratedFor(decoratedFor: symbol) {
-    this.prototype.decoratedForFunc(this, decoratedFor);
-  }
-
   /**
-   * Set the decoratedFor method for the prototype of the class, if has not already been set.
+   * Set the decoratedFor value for the prototype of the class, if has not already been set.
    */
-  private decoratedForFunc<T>({prototype: base, name}: typeof BaseModel, decoratedFor: symbol) {
-    if (base.decoratedFor) {
-      throw Error(`Attempted to mark the decorator for '${name}' after it already had been set`);
+  static markAsDecorated() {
+    if (this.prototype.isDecorated) {
+      throw Error(
+        `Attempted to mark the decorator for '${this.name}' after it already had been set`,
+      );
     }
-    base.decoratedFor = decoratedFor;
+    this.prototype.isDecorated = true;
   }
 }
 

--- a/apps/shared/models/base.ts
+++ b/apps/shared/models/base.ts
@@ -3,9 +3,14 @@ export type Constructor<T> = new (...args: any[]) => T;
 /** Base class for all models to inherit from. */
 export abstract class BaseModel<T> {
   data!: T;
+  /** The symbol marker for the function which decorated the model for either app or server. */
+  private decoratedFor!: symbol;
 
   /** The data as stored in Firestore. */
   constructor(data: T) {
+    if (this.decoratedFor === null) {
+      throw Error();
+    }
     this.setData(data);
   }
 
@@ -30,6 +35,21 @@ export abstract class BaseModel<T> {
     toFirestore: (model: any) => any;
   } {
     throw Error('This was not implemented');
+  }
+
+  /** Set the decoratedFor value on the prototype of the class. */
+  static decoratedFor(decoratedFor: symbol) {
+    this.prototype.decoratedForFunc(this, decoratedFor);
+  }
+
+  /**
+   * Set the decoratedFor method for the prototype of the class, if has not already been set.
+   */
+  private decoratedForFunc<T>({prototype: base, name}: typeof BaseModel, decoratedFor: symbol) {
+    if (base.decoratedFor) {
+      throw Error(`Attempted to mark the decorator for '${name}' after it already had been set`);
+    }
+    base.decoratedFor = decoratedFor;
   }
 }
 

--- a/apps/shared/models/base.ts
+++ b/apps/shared/models/base.ts
@@ -1,22 +1,77 @@
+export type Constructor<T> = new (...args: any[]) => T;
+
+/** Base class for all models to inherit from. */
+export abstract class BaseModel<T> {
+  data!: T;
+
+  /** The data as stored in Firestore. */
+  constructor(data: T) {
+    this.setData(data);
+  }
+
+  protected setData(data: T) {
+    this.data = data;
+  }
+
+  static getByReference<T>(ref: FirestoreReference<T>): TypeFromFirestoreRef<typeof ref> {
+    return this.prototype.getByReference(ref);
+  }
+
+  protected getByReference(ref: FirestoreReference<T>): T {
+    throw Error('This was not implemented');
+  }
+
+  /** A function to get the converter for the model */
+  static getConverter() {
+    return this.prototype.getConverter();
+  }
+  protected getConverter(): {
+    fromFirestore: (snapshot: any) => T;
+    toFirestore: (model: any) => any;
+  } {
+    throw Error('This was not implemented');
+  }
+}
+
+/** Github helper functions to be defined in all classes inheriting from GithubBaseModel. */
+export interface GithubHelperFunctions<Model, GithubModel, FirebaseModel> {
+  fromGithub: (m: GithubModel) => FirebaseModel;
+  buildRefString: (m: GithubModel) => FirestoreReference<Model>;
+}
+
+/** Base class for all Github based models to inherit from. */
+export abstract class GithubBaseModel<T> extends BaseModel<T> {
+  /** Helper functions for translating Github objects to Firestore. */
+  static githubHelpers: GithubHelperFunctions<any, any, any>;
+
+  static getGithubHelpers<GithubModel = any>() {
+    return this.prototype.getGithubHelpers<GithubModel>();
+  }
+
+  protected getGithubHelpers<GithubModel>(): {
+    fromGithub: (model: GithubModel) => T;
+    getFirestoreRefForGithubModel: (model: GithubModel) => FirestoreReference<T>;
+  } {
+    throw Error('This was not implemented');
+  }
+}
+
 /**
  * Because it is less expensive to store strings than Firestore references, with no change in the
  * value it provides, we have this local type to express this usage.
  */
-export type FirestoreReference<T> = string;
+export type FirestoreReference<T> = {
+  // ensures this "Reference" string is not passed around as "string" accidentally.
+  __eefirestoreReference: true;
+  __eereferencedType: T;
+};
 
-export type Constructor<T> = new (...args: any[]) => T;
+export type TypeFromFirestoreRef<T> = T extends FirestoreReference<infer ModelType> ? ModelType : T;
 
-export interface GithubHelperFunctions<GithubModel, FirebaseModel> {
-  fromGithub: (m: GithubModel) => FirebaseModel;
-  buildRefString: (m: GithubModel) => string;
+export function fromFirestoreReference<T>(ref: FirestoreReference<T>): string {
+  return ref as unknown as string;
 }
 
-export abstract class BaseModel<T> {
-  /** The data as stored in Firestore. */
-  constructor(protected data: T) {}
-}
-
-export abstract class GithubBaseModel<T> extends BaseModel<T> {
-  /** Helper functions for translating Github objects to Firestore. */
-  protected static githubHelpers: GithubHelperFunctions<any, any> | undefined;
+export function toFirestoreReference<T>(ref: string) {
+  return ref as unknown as FirestoreReference<T>;
 }

--- a/apps/shared/models/check.ts
+++ b/apps/shared/models/check.ts
@@ -1,5 +1,5 @@
 import {CheckRunEvent} from '@octokit/webhooks-types';
-import {GithubBaseModel, GithubHelperFunctions} from './base';
+import {GithubBaseModel, GithubHelperFunctions, toFirestoreReference} from './base';
 
 export interface FirestoreCheck {
   name: string;
@@ -7,14 +7,16 @@ export interface FirestoreCheck {
   state: CheckRunEvent['check_run']['conclusion'];
 }
 
-export class GithubCheck extends GithubBaseModel<FirestoreCheck> {
+export class Check extends GithubBaseModel<FirestoreCheck> {
   readonly name = this.data.name;
   readonly targetUrl = this.data.detailsUrl;
   readonly status = this.data.state;
 
-  static override githubHelpers: GithubHelperFunctions<CheckRunEvent, FirestoreCheck> = {
+  static override githubHelpers: GithubHelperFunctions<Check, CheckRunEvent, FirestoreCheck> = {
     buildRefString(model: CheckRunEvent) {
-      return `githubCommit/${model.check_run.head_sha}/check/${model.check_run.name}`;
+      return toFirestoreReference(
+        `githubCommit/${model.check_run.head_sha}/check/${model.check_run.name}`,
+      );
     },
     fromGithub(model: CheckRunEvent) {
       return {

--- a/apps/shared/models/index.ts
+++ b/apps/shared/models/index.ts
@@ -1,0 +1,7 @@
+export {User} from './user';
+export {Label} from './label';
+export {Milestone} from './milestone';
+export {PullRequest} from './pull-request';
+export {Status} from './status';
+export {Check} from './check';
+export {Team} from './team';

--- a/apps/shared/models/label.ts
+++ b/apps/shared/models/label.ts
@@ -1,20 +1,20 @@
-import {Label} from '@octokit/webhooks-types';
-import {GithubBaseModel, GithubHelperFunctions} from './base';
+import {Label as GithubLabel} from '@octokit/webhooks-types';
+import {GithubBaseModel, GithubHelperFunctions, toFirestoreReference} from './base';
 
 export interface FirestoreLabel {
   name: string;
   color: string;
 }
 
-export class GithubLabel extends GithubBaseModel<FirestoreLabel> {
+export class Label extends GithubBaseModel<FirestoreLabel> {
   readonly name = this.data.name;
   readonly color = this.data.color;
 
-  static override githubHelpers: GithubHelperFunctions<Label, FirestoreLabel> = {
-    buildRefString(model: Label) {
-      return `githubLabel/${model.node_id}`;
+  static override githubHelpers: GithubHelperFunctions<Label, GithubLabel, FirestoreLabel> = {
+    buildRefString(model: GithubLabel) {
+      return toFirestoreReference(`githubLabel/${model.node_id}`);
     },
-    fromGithub(model: Label) {
+    fromGithub(model: GithubLabel) {
       return {
         name: model.name,
         color: model.color,

--- a/apps/shared/models/milestone.ts
+++ b/apps/shared/models/milestone.ts
@@ -1,26 +1,30 @@
-import {Milestone} from '@octokit/webhooks-types';
-import {GithubBaseModel, GithubHelperFunctions} from './base';
+import {Milestone as GithubMilestone} from '@octokit/webhooks-types';
+import {GithubBaseModel, GithubHelperFunctions, toFirestoreReference} from './base';
 
 export interface FirestoreMilestone {
   title: string;
   description: string;
   openIssues: number;
   closedIssues: number;
-  state: Milestone['state'];
+  state: GithubMilestone['state'];
 }
 
-export class GithubMilestone extends GithubBaseModel<FirestoreMilestone> {
+export class Milestone extends GithubBaseModel<FirestoreMilestone> {
   readonly title = this.data.title;
   readonly description = this.data.description;
   readonly openIssues = this.data.openIssues;
   readonly closedIssues = this.data.closedIssues;
   readonly state = this.data.state;
 
-  static override githubHelpers: GithubHelperFunctions<Milestone, FirestoreMilestone> = {
-    buildRefString(model: Milestone) {
-      return `githubMilestone/${model.node_id}`;
+  static override githubHelpers: GithubHelperFunctions<
+    Milestone,
+    GithubMilestone,
+    FirestoreMilestone
+  > = {
+    buildRefString(model: GithubMilestone) {
+      return toFirestoreReference(`githubMilestone/${model.node_id}`);
     },
-    fromGithub(model: Milestone) {
+    fromGithub(model: GithubMilestone) {
       return {
         title: model.title,
         description: model.description || '',

--- a/apps/shared/models/server-models.ts
+++ b/apps/shared/models/server-models.ts
@@ -11,9 +11,6 @@ import {
 
 export {FirestoreReference, fromFirestoreReference};
 
-/** Marker symbol for noting that a model has been decorated for app use. */
-const decoratedForServer = Symbol('forServer');
-
 // Import all of the models for the module and decorate all of them for App usage.
 import * as models from './index';
 Object.values(models).forEach(forServer);
@@ -30,7 +27,7 @@ function forServer<
   TBase extends Constructor<BaseModel<FirebaseModel> | GithubBaseModel<FirebaseModel>>,
 >(model: TBase) {
   const staticModel = model as unknown as typeof GithubBaseModel;
-  staticModel.decoratedFor(decoratedForServer);
+  staticModel.markAsDecorated();
 
   /** The converter object for performing conversions in and out of Firestore. */
   const converter = {

--- a/apps/shared/models/status.ts
+++ b/apps/shared/models/status.ts
@@ -1,5 +1,5 @@
 import {StatusEvent} from '@octokit/webhooks-types';
-import {GithubBaseModel, GithubHelperFunctions} from './base';
+import {GithubBaseModel, GithubHelperFunctions, toFirestoreReference} from './base';
 
 export interface FirestoreStatus {
   context: string;
@@ -7,14 +7,14 @@ export interface FirestoreStatus {
   state: StatusEvent['state'];
 }
 
-export class GithubStatus extends GithubBaseModel<FirestoreStatus> {
+export class Status extends GithubBaseModel<FirestoreStatus> {
   readonly context = this.data.context;
   readonly targetUrl = this.data.targetUrl;
   readonly status = this.data.state;
 
-  static override githubHelpers: GithubHelperFunctions<StatusEvent, FirestoreStatus> = {
+  static override githubHelpers: GithubHelperFunctions<Status, StatusEvent, FirestoreStatus> = {
     buildRefString(model: StatusEvent) {
-      return `githubCommit/${model.sha}/status/${model.context}`;
+      return toFirestoreReference(`githubCommit/${model.sha}/status/${model.context}`);
     },
     fromGithub(model: StatusEvent) {
       return {

--- a/apps/shared/models/team.ts
+++ b/apps/shared/models/team.ts
@@ -1,22 +1,22 @@
-import {Team, User} from '@octokit/webhooks-types';
-import {GithubBaseModel, GithubHelperFunctions} from './base';
+import {Team as GithubTeam, User as GithubUser} from '@octokit/webhooks-types';
+import {GithubBaseModel, GithubHelperFunctions, toFirestoreReference} from './base';
 
 export interface FirestoreTeam {
   slug: string;
   name: string;
-  privacy: Team['privacy'];
+  privacy: GithubTeam['privacy'];
 }
 
-export class GithubTeam extends GithubBaseModel<FirestoreTeam> {
+export class Team extends GithubBaseModel<FirestoreTeam> {
   readonly slug = this.data.slug;
   readonly name = this.data.name;
   readonly private = this.data.privacy;
 
-  static override githubHelpers: GithubHelperFunctions<Team, FirestoreTeam> = {
-    buildRefString(model: Team) {
-      return `githubTeam/${model.node_id}`;
+  static override githubHelpers: GithubHelperFunctions<Team, GithubTeam, FirestoreTeam> = {
+    buildRefString(model: GithubTeam) {
+      return toFirestoreReference(`githubTeam/${model.node_id}`);
     },
-    fromGithub(model: Team) {
+    fromGithub(model: GithubTeam) {
       return {
         name: model.name,
         privacy: model.privacy,
@@ -26,7 +26,7 @@ export class GithubTeam extends GithubBaseModel<FirestoreTeam> {
   };
 }
 
-export function isTeamFromGithub(userOrTeam: User | Team): userOrTeam is Team {
+export function isTeamFromGithub(userOrTeam: GithubUser | GithubTeam): userOrTeam is GithubTeam {
   if ((userOrTeam as any).type !== undefined) {
     return true;
   }

--- a/apps/shared/models/user.ts
+++ b/apps/shared/models/user.ts
@@ -1,24 +1,24 @@
-import {User, Team} from '@octokit/webhooks-types';
-import {GithubBaseModel, GithubHelperFunctions} from './base';
+import {User as GithubUser, Team as GithubTeam} from '@octokit/webhooks-types';
+import {GithubBaseModel, GithubHelperFunctions, toFirestoreReference} from './base';
 
 export interface FirestoreUser {
   username: string;
-  type: User['type'];
+  type: GithubUser['type'];
   avatarUrl: string;
   name: string;
 }
 
-export class GithubUser extends GithubBaseModel<FirestoreUser> {
+export class User extends GithubBaseModel<FirestoreUser> {
   readonly avatarUrl = this.data.avatarUrl;
   readonly name = this.data.name;
   readonly type = this.data.type;
   readonly username = this.data.username;
 
-  static override githubHelpers: GithubHelperFunctions<User, FirestoreUser> = {
-    buildRefString(model: User) {
-      return `githubUser/${model.node_id}`;
+  static override githubHelpers: GithubHelperFunctions<User, GithubUser, FirestoreUser> = {
+    buildRefString(model: GithubUser) {
+      return toFirestoreReference(`githubUser/${model.node_id}`);
     },
-    fromGithub(model: User) {
+    fromGithub(model: GithubUser) {
       return {
         avatarUrl: model.avatar_url,
         name: model.name || model.login,
@@ -29,7 +29,7 @@ export class GithubUser extends GithubBaseModel<FirestoreUser> {
   };
 }
 
-export function isUserFromGithub(userOrTeam: User | Team): userOrTeam is User {
+export function isUserFromGithub(userOrTeam: GithubUser | GithubTeam): userOrTeam is GithubUser {
   if ((userOrTeam as any).type === undefined) {
     return true;
   }


### PR DESCRIPTION
Instead of creating a static converter with a mixin, the mixin instead sets methods to get the converter and DocumentReference using the class definition.