### PR TITLE
fix(apps): avoid symlink that breaks github action cloning

### DIFF
--- a/apps/BUILD.bazel
+++ b/apps/BUILD.bazel
@@ -1,11 +1,20 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin", "nodejs_binary")
+
+copy_to_bin(
+    name = "static_runfiles",
+    srcs = [
+        "firebase.json",
+        "firestore.indexes.json",
+        "firestore.rules",
+    ],
+)
 
 nodejs_binary(
     name = "serve",
     chdir = package_name(),
     data = [
-        # primary firebase configuration file
-        "firebase.json",
+        # top-level static runfiles
+        ":static_runfiles",
 
         # Firebase function files
         "//apps/functions:functions_compiled",
@@ -17,7 +26,7 @@ nodejs_binary(
         "internal-200822",
         "--config",
         # TODO: Find a way to do this without relying on the copy_to_bin that works cross platform.
-        "$$(rlocation $(execpath :firebase.json))",
+        "$$(rlocation dev-infra/apps/firebase.json)",
         "emulators:start",
     ],
 )
@@ -26,8 +35,8 @@ nodejs_binary(
     name = "deploy",
     chdir = package_name(),
     data = [
-        # primary firebase configuration file
-        "firebase.json",
+        # top-level static runfiles
+        ":static_runfiles",
 
         # Firebase function files
         "//apps/functions:functions_compiled",
@@ -39,7 +48,7 @@ nodejs_binary(
         "internal-200822",
         "--config",
         # TODO: Find a way to do this without relying on the copy_to_bin that works cross platform.
-        "$$(rlocation $(execpath :firebase.json))",
+        "$$(rlocation dev-infra/apps/firebase.json)",
         "deploy",
         "--only",
         "functions",

--- a/apps/firebase.json
+++ b/apps/firebase.json
@@ -4,8 +4,7 @@
     "indexes": "firestore.indexes.json"
   },
   "functions": {
-    "predeploy": "bazel build //apps/functions:functions_compiled",
-    "source": "./functions/dist/functions"
+    "source": "./functions"
   },
   "emulators": {
     "functions": {

--- a/apps/functions/dist
+++ b/apps/functions/dist
@@ -1,1 +1,0 @@
-../../dist/bin/apps/


### PR DESCRIPTION
The symlink is invalid when a Github action is cloned because
Bazel did not run yet. We should avoid the symlink to keep our
actions working:

https://github.com/angular/components/runs/6127973017?check_suite_focus=true