### PR TITLE
fix(ng-dev): make `new-main-branch` command more flexible to local setup

### DIFF
--- a/ng-dev/misc/new-main-branch/cli.ts
+++ b/ng-dev/misc/new-main-branch/cli.ts
@@ -39,12 +39,12 @@ async function handler() {
   }
 
   if (hasLocalBranch(git, 'main')) {
-    console.warn(yellow('The new `main` branch is already fetched locally. In order to run'));
-    console.warn(yellow('this tool, the `main` branch needs to be non-existent locally.'));
-    console.warn('');
-    console.warn(yellow('The tool will re-fetch the `main` branch and configure it properly.'));
+    warn(yellow('The new `main` branch is already fetched locally. In order to run'));
+    warn(yellow('this tool, the `main` branch needs to be non-existent locally.'));
+    warn('');
+    warn(yellow('The tool will re-fetch the `main` branch and configure it properly.'));
 
-    if (!(await promptConfirm('Do you want to proceed and delete the `main` branch?'))) {
+    if (!(await promptConfirm('Do you want to proceed and delete the local `main` branch?'))) {
       error(red('Aborting..'));
       return;
     }

--- a/ng-dev/misc/new-main-branch/local-branch.ts
+++ b/ng-dev/misc/new-main-branch/local-branch.ts
@@ -25,3 +25,8 @@ export function findAvailableLocalBranchName(git: GitClient, baseName: string): 
 export function hasLocalBranch(git: GitClient, branchName: string): boolean {
   return git.runGraceful(['rev-parse', `refs/heads/${branchName}`], {stdio: 'ignore'}).status === 0;
 }
+
+/** Gets the current branch name. */
+export function getCurrentBranch(git: GitClient): string {
+  return git.run(['rev-parse', '--abbrev-ref', 'HEAD']).stdout.trim();
+}

--- a/ng-dev/misc/new-main-branch/remote-fork-update.ts
+++ b/ng-dev/misc/new-main-branch/remote-fork-update.ts
@@ -23,7 +23,7 @@ import {info} from 'console';
 export async function promptForRemoteForkUpdate() {
   if (
     !(await promptConfirm(
-      'Do you want to update your fork(s) on Github to also use `main`? (recommended)',
+      'Do you also want to update your fork(s) on Github to `main`? (recommended)',
     ))
   ) {
     return;


### PR DESCRIPTION
After we will perform the default branch rename, there are three scenarios for
a contributor:

1. They manually fetch `upstream/main`, run `yarn` and then the
   migration tool.
2. They will not sync with upstream (as `upstream/master` does not
   exist), run `yarn` and then the migration tool.
3. They will manually update everything locally and in their forks. This
bullet-point is just for completion (not something we bother about here).

For (1): The `master` branch and `main` branch will locally exist. We should
ask to delete the `main` branch switch back to `master`. Then continue with
the full migration (with all other changes to the local git config)

For (2): We should run the migration as is (e.g. fetch main and set it up locally).