### PR TITLE
fix(ng-dev): release notes not capturing multiple note keywords from single commit

### DIFF
--- a/ng-dev/release/notes/templates/changelog.ts
+++ b/ng-dev/release/notes/templates/changelog.ts
@@ -20,8 +20,14 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
+    for (const commit of group.commits) {
+      for (const breakingChange of commit.breakingChanges) {
+_%>
+<%- bulletizeText(breakingChange.text) %>
+<%_
+      }
+    }
   }
 }
 _%>
@@ -35,8 +41,14 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
+    for (const commit of group.commits) {
+      for (const deprecation of commit.deprecations) {
+_%>
+<%- bulletizeText(deprecation.text) %>
+<%_
+      }
+    }
   }
 }
 _%>

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -20,8 +20,14 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
+    for (const commit of group.commits) {
+      for (const breakingChange of commit.breakingChanges) {
+_%>
+<%- bulletizeText(breakingChange.text) %>
+<%_
+      }
+    }
   }
 }
 _%>
@@ -35,8 +41,14 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
+    for (const commit of group.commits) {
+      for (const deprecation of commit.deprecations) {
+_%>
+<%- bulletizeText(deprecation.text) %>
+<%_
+      }
+    }
   }
 }
 _%>

--- a/tools/local-actions/changelog/main.js
+++ b/tools/local-actions/changelog/main.js
@@ -48384,8 +48384,14 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
+    for (const commit of group.commits) {
+      for (const breakingChange of commit.breakingChanges) {
+_%>
+<%- bulletizeText(breakingChange.text) %>
+<%_
+      }
+    }
   }
 }
 _%>
@@ -48399,8 +48405,14 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
+    for (const commit of group.commits) {
+      for (const deprecation of commit.deprecations) {
+_%>
+<%- bulletizeText(deprecation.text) %>
+<%_
+      }
+    }
   }
 }
 _%>
@@ -48462,8 +48474,14 @@ _%>
   for (const group of asCommitGroups(breakingChanges)) {
 _%>
 ### <%- group.title %>
-<%- group.commits.map(commit => bulletizeText(commit.breakingChanges[0].text)).join('\\n\\n') %>
 <%_
+    for (const commit of group.commits) {
+      for (const breakingChange of commit.breakingChanges) {
+_%>
+<%- bulletizeText(breakingChange.text) %>
+<%_
+      }
+    }
   }
 }
 _%>
@@ -48477,8 +48495,14 @@ _%>
   for (const group of asCommitGroups(deprecations)) {
 _%>
 ### <%- group.title %>
-<%- group.commits.map(commit => bulletizeText(commit.deprecations[0].text)).join('\\n\\n') %>
 <%_
+    for (const commit of group.commits) {
+      for (const deprecation of commit.deprecations) {
+_%>
+<%- bulletizeText(deprecation.text) %>
+<%_
+      }
+    }
   }
 }
 _%>


### PR DESCRIPTION
Commits like the following were not captured properly because we only
assumed a single deprecation/breaking-change to be set on a commit.