### PR TITLE
build: fix post-approval-changes key

### DIFF
--- a/.github/workflows/post-approval-changes.yml
+++ b/.github/workflows/post-approval-changes.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
       - uses: ./github-actions/post-approval-changes
         with:
-          lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}
+          angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}


### PR DESCRIPTION
Use the ANGULAR_ROBOT_PRIVATE_KEY for the post-approval-changes action