### PR TITLE
fix(github-actions): properly spread the requested_teams values for pending reviews

### DIFF
--- a/github-actions/post-approval-changes/lib/main.ts
+++ b/github-actions/post-approval-changes/lib/main.ts
@@ -43,7 +43,7 @@ async function run(): Promise<void> {
     return;
   }
 
-  if ([...pr.requested_reviewers, pr.requested_teams].length > 0) {
+  if ([...pr.requested_reviewers, ...pr.requested_teams].length > 0) {
     core.info('Skipping check as there are still pending reviews.');
     return;
   }

--- a/github-actions/post-approval-changes/main.js
+++ b/github-actions/post-approval-changes/main.js
@@ -15279,7 +15279,7 @@ async function run() {
     core.info("PR author is a googler, skipping as post approval changes are allowed.");
     return;
   }
-  if ([...pr.requested_reviewers, pr.requested_teams].length > 0) {
+  if ([...pr.requested_reviewers, ...pr.requested_teams].length > 0) {
     core.info("Skipping check as there are still pending reviews.");
     return;
   }


### PR DESCRIPTION
Previously the requested_teams was not spread resulting in an array like [[]] instead of [] when no reviews are pending.