### PR TITLE
feat(ng-dev/pr): allow for manual override of targeted branches

### DIFF
--- a/ng-dev/pr/common/validation/failures.ts
+++ b/ng-dev/pr/common/validation/failures.ts
@@ -130,4 +130,11 @@ export class PullRequestFailure {
       'breaking change notes (i.e. commits do not have a `BREAKING CHANGE: <..>` section).';
     return new this(message);
   }
+
+  static failedToManualSelectGithubTargetBranch(branch: string) {
+    const message =
+      `Pull Requests must merge into their targeted Github branch. If this branch (${branch}) ` +
+      'should not be included, please change the targeted branch via the Github UI.';
+    return new this(message);
+  }
 }

--- a/ng-dev/pr/merge/cli.ts
+++ b/ng-dev/pr/merge/cli.ts
@@ -17,6 +17,7 @@ export interface MergeCommandOptions {
   githubToken: string;
   pr: number;
   branchPrompt: boolean;
+  forceManualBranches: boolean;
 }
 
 /** Builds the command. */
@@ -33,12 +34,17 @@ function builder(yargs: Argv) {
       type: 'boolean',
       default: true,
       description: 'Whether to prompt to confirm the branches a PR will merge into.',
+    })
+    .option('force-manual-branches' as 'forceManualBranches', {
+      type: 'boolean',
+      default: false,
+      description: 'Whether to manually select the branches you wish to merge the PR into.',
     });
 }
 
 /** Handles the command. */
-async function handler({pr, branchPrompt}: Arguments<MergeCommandOptions>) {
-  await mergePullRequest(pr, {branchPrompt});
+async function handler({pr, branchPrompt, forceManualBranches}: Arguments<MergeCommandOptions>) {
+  await mergePullRequest(pr, {branchPrompt, forceManualBranches});
 }
 
 /** yargs command module describing the command. */


### PR DESCRIPTION
Using the `manual-branch-targeting` user's can choose to manually select the branches they would like to target rather than relying on the branches defined by the label.  This allows for one-off manual overrides of the logic we rely on. As noted in the warning at runtime, this does remove the attempts we make to guarantee that all commits are valid for the targeted branches.