### PR TITLE
fix(ng-dev/pr): properly name the rebase command

### DIFF
--- a/ng-dev/pr/discover-new-conflicts/cli.ts
+++ b/ng-dev/pr/discover-new-conflicts/cli.ts
@@ -55,6 +55,6 @@ function getThirtyDaysAgoDate() {
 export const DiscoverNewConflictsCommandModule: CommandModule<{}, DiscoverNewConflictsOptions> = {
   handler,
   builder,
-  command: 'checkout <pr>',
-  describe: 'Checkout a PR from the upstream repo',
+  command: 'discover-new-conflicts <pr>',
+  describe: 'Check if a pending PR causes new conflicts for other pending PRs',
 };

--- a/ng-dev/pr/rebase/cli.ts
+++ b/ng-dev/pr/rebase/cli.ts
@@ -32,6 +32,6 @@ async function handler({pr, githubToken}: Arguments<RebaseOptions>) {
 export const RebaseCommandModule: CommandModule<{}, RebaseOptions> = {
   handler,
   builder,
-  command: 'checkout <pr>',
-  describe: 'Checkout a PR from the upstream repo',
+  command: 'rebase <pr>',
+  describe: 'Rebase a pending PR and push the rebased commits back to Github',
 };


### PR DESCRIPTION
Properly sets the rebase subcommand so it is accessible in the tooling.