### PR TITLE
refactor(ng-dev): include branch name for feature-freeze train for cut RC option

### DIFF
--- a/ng-dev/release/publish/actions/cut-release-candidate-for-feature-freeze.ts
+++ b/ng-dev/release/publish/actions/cut-release-candidate-for-feature-freeze.ts
@@ -19,7 +19,8 @@ export class CutReleaseCandidateForFeatureFreezeAction extends ReleaseAction {
 
   override async getDescription() {
     const newVersion = this._newVersion;
-    return `Cut a first release-candidate for the feature-freeze branch (v${newVersion}).`;
+    const branchName = this.active.releaseCandidate!.branchName;
+    return `Cut a first release-candidate for the "${branchName}" feature-freeze branch (v${newVersion}).`;
   }
 
   override async perform() {

--- a/ng-dev/release/publish/test/common.spec.ts
+++ b/ng-dev/release/publish/test/common.spec.ts
@@ -63,7 +63,7 @@ describe('common release action logic', () => {
       }
 
       expect(descriptions).toEqual([
-        `Cut a first release-candidate for the feature-freeze branch (v10.1.0-rc.0).`,
+        `Cut a first release-candidate for the "10.1.x" feature-freeze branch (v10.1.0-rc.0).`,
         `Cut a new patch release for the "10.0.x" branch (v10.0.2).`,
         `Cut a new next pre-release for the "10.1.x" branch (v10.1.0-next.4).`,
         `Cut a new release for an active LTS branch (0 active).`,


### PR DESCRIPTION
Fixes #556.

@AndrewKushnir I kept the version at the end of the message since I want the "to-be-cut" version always easily discoverable. Hope that makes sense.