### PR TITLE
feat(ng-dev/release): support for custom release pre-checks to be provided

### DIFF
--- a/ng-dev/BUILD.bazel
+++ b/ng-dev/BUILD.bazel
@@ -30,6 +30,7 @@ ts_library(
         "//ng-dev/pullapprove",
         "//ng-dev/release",
         "//ng-dev/release/config",
+        "//ng-dev/release/precheck",
         "//ng-dev/release/publish",
         "//ng-dev/release/versioning",
         "//ng-dev/ts-circular-dependencies",

--- a/ng-dev/cli.ts
+++ b/ng-dev/cli.ts
@@ -9,23 +9,16 @@
 import * as yargs from 'yargs';
 
 import {buildCaretakerParser} from './caretaker/cli';
+import {buildCiParser} from './ci/cli';
 import {buildCommitMessageParser} from './commit-message/cli';
 import {buildFormatParser} from './format/cli';
+import {buildMiscParser} from './misc/cli';
 import {buildNgbotParser} from './ngbot/cli';
 import {buildPrParser} from './pr/cli';
 import {buildPullapproveParser} from './pullapprove/cli';
 import {buildReleaseParser} from './release/cli';
 import {tsCircularDependenciesBuilder} from './ts-circular-dependencies/index';
 import {captureLogOutputForCommand} from './utils/console';
-import {buildMiscParser} from './misc/cli';
-import {buildCiParser} from './ci/cli';
-import {ReleaseAction} from './index';
-
-// Expose the `ReleaseAction` constructor globally so that the COMP repo
-// can hook into it and setup staging/post-building release checks.
-// TODO: Remove once https://github.com/angular/dev-infra/issues/402 is resolved.
-// or if we have code-splitting w/ ESM enabled for the ng-dev bundling.
-(global as any).ReleaseAction = ReleaseAction;
 
 yargs
   .scriptName('ng-dev')

--- a/ng-dev/index.ts
+++ b/ng-dev/index.ts
@@ -18,6 +18,10 @@ export * from './release/config';
 // respect to Angular's branching/versioning and release process.
 export * from './release/versioning';
 
+// Exposes the release precheck command utilities. These should be available
+// as they are needed for authoring pre-release custom checks.
+export {ReleasePrecheckError} from './release/precheck';
+
 // Exposes console utils that can be used by consumers to e.g. add messages
 // to the dev-infra log which is stored on failures.
 export * from './utils/console';
@@ -27,11 +31,3 @@ export * from './utils/console';
 export * from './utils/git/authenticated-git-client';
 export * from './utils/git/git-client';
 export * from './utils/git/github';
-
-// Additional exports for adding custom release pre-staging, post-build checks.
-// TODO: Remove once https://github.com/angular/dev-infra/issues/402 is resolved.
-export {ReleaseAction} from './release/publish/actions';
-export {
-  FatalReleaseActionError,
-  UserAbortedReleaseActionError,
-} from './release/publish/actions-error';

--- a/ng-dev/release/BUILD.bazel
+++ b/ng-dev/release/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
         "//ng-dev/release/build",
         "//ng-dev/release/info",
         "//ng-dev/release/notes",
+        "//ng-dev/release/precheck",
         "//ng-dev/release/publish",
         "//ng-dev/release/set-dist-tag",
         "//ng-dev/release/stamping",

--- a/ng-dev/release/build/cli.ts
+++ b/ng-dev/release/build/cli.ts
@@ -6,6 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// ---- **IMPORTANT** ----
+// This command is part of our external commands invoked by the release publish
+// command. Before making changes, keep in mind that more recent `ng-dev` versions
+// can still invoke this command.
+// ------------------------
+
 import {Arguments, Argv, CommandModule} from 'yargs';
 
 import {getConfig} from '../../utils/config';

--- a/ng-dev/release/cli.ts
+++ b/ng-dev/release/cli.ts
@@ -10,6 +10,7 @@ import * as yargs from 'yargs';
 import {ReleaseBuildCommandModule} from './build/cli';
 import {ReleaseInfoCommandModule} from './info/cli';
 import {ReleaseNotesCommandModule} from './notes/cli';
+import {ReleasePrecheckCommandModule} from './precheck/cli';
 import {ReleasePublishCommandModule} from './publish/cli';
 import {ReleaseSetDistTagCommand} from './set-dist-tag/cli';
 import {BuildEnvStampCommand} from './stamping/cli';
@@ -23,6 +24,7 @@ export function buildReleaseParser(localYargs: yargs.Argv) {
     .command(ReleasePublishCommandModule)
     .command(ReleaseBuildCommandModule)
     .command(ReleaseInfoCommandModule)
+    .command(ReleasePrecheckCommandModule)
     .command(ReleaseSetDistTagCommand)
     .command(BuildEnvStampCommand)
     .command(ReleaseNotesCommandModule);

--- a/ng-dev/release/config/BUILD.bazel
+++ b/ng-dev/release/config/BUILD.bazel
@@ -13,5 +13,6 @@ ts_library(
         "//ng-dev/commit-message",
         "//ng-dev/utils",
         "@npm//@types/semver",
+        "@npm//semver",
     ],
 )

--- a/ng-dev/release/config/index.ts
+++ b/ng-dev/release/config/index.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {SemVer} from 'semver';
+
 import {CommitFromGitLog} from '../../commit-message/parse';
 import {ConfigValidationError} from '../../utils/config';
 
@@ -50,6 +52,15 @@ export interface ReleaseConfig {
   releasePrLabels?: string[];
   /** Configuration for creating release notes during publishing. */
   releaseNotes?: ReleaseNotesConfig;
+}
+
+/**
+ * Type describing a built package with its associated NPM package info and package
+ * content hash, useful for verifying its integrity or running custom prechecks.
+ */
+export interface BuiltPackageWithInfo extends BuiltPackage, NpmPackage {
+  /** A deterministic hash that can be used to verify the contents of the package. */
+  hash: string;
 }
 
 /** Configuration for creating release notes during publishing. */

--- a/ng-dev/release/config/index.ts
+++ b/ng-dev/release/config/index.ts
@@ -52,6 +52,17 @@ export interface ReleaseConfig {
   releasePrLabels?: string[];
   /** Configuration for creating release notes during publishing. */
   releaseNotes?: ReleaseNotesConfig;
+  /**
+   * Optional function that can be provided to run checks for a version before
+   * it can be released.
+   *
+   * If provided, the release can occur when the promise resolves. Upon rejection,
+   * the release will abort the release and print the `ReleasePrecheckError` error.
+   */
+  prereleaseCheck?: (
+    newVersion: SemVer,
+    builtPackagesWithInfo: BuiltPackageWithInfo[],
+  ) => Promise<void>;
 }
 
 /**

--- a/ng-dev/release/info/cli.ts
+++ b/ng-dev/release/info/cli.ts
@@ -6,6 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// ---- **IMPORTANT** ----
+// This command is part of our external commands invoked by the release publish
+// command. Before making changes, keep in mind that more recent `ng-dev` versions
+// can still invoke this command.
+// ------------------------
+
 import {Arguments, Argv, CommandModule} from 'yargs';
 
 import {GitClient} from '../../utils/git/git-client';

--- a/ng-dev/release/precheck/BUILD.bazel
+++ b/ng-dev/release/precheck/BUILD.bazel
@@ -1,0 +1,40 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+
+ts_library(
+    name = "precheck",
+    srcs = glob(
+        [
+            "**/*.ts",
+        ],
+        exclude = ["*.spec.ts"],
+    ),
+    visibility = ["//ng-dev:__subpackages__"],
+    deps = [
+        "//ng-dev/release/config",
+        "//ng-dev/utils",
+        "@npm//@types/node",
+        "@npm//@types/semver",
+        "@npm//@types/yargs",
+        "@npm//semver",
+    ],
+)
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob([
+        "*.spec.ts",
+    ]),
+    deps = [
+        ":precheck",
+        "//ng-dev/release/config",
+        "//ng-dev/utils",
+        "@npm//@types/semver",
+        "@npm//semver",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    specs = [":test_lib"],
+)

--- a/ng-dev/release/precheck/cli.ts
+++ b/ng-dev/release/precheck/cli.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// ---- **IMPORTANT** ----
+// This command is part of our external commands invoked by the release publish
+// command. Before making changes, keep in mind that more recent `ng-dev` versions
+// can still invoke this command.
+// ------------------------
+
+import * as semver from 'semver';
+import {CommandModule} from 'yargs';
+
+import {assertPassingReleasePrechecks} from './index';
+import {getConfig} from '../../utils/config';
+import {readBufferFromStdinUntilClosed} from '../../utils/read-stdin-until-closed';
+import {assertValidReleaseConfig, BuiltPackageWithInfo} from '../config/index';
+import {error, red} from '../../utils/console';
+
+/**
+ * Type describing the JSON stdin input of this command. The release tool will
+ * deliver this information through `stdin` because command line arguments are
+ * less reliable and have max-length limits.
+ *
+ * @important When changing this, make sure the release action
+ *   invocation is updated as well.
+ */
+export interface ReleasePrecheckJsonStdin {
+  /** Package output that has been built and can be checked. */
+  builtPackagesWithInfo: BuiltPackageWithInfo[];
+  /** New version that is intended to be released. */
+  newVersion: string;
+}
+
+async function handler() {
+  // Note: Stdin input is buffered until we start reading from it. This allows us to
+  // asynchronously start reading the `stdin` input. With the default `readableFlowing`
+  // value of `null`, data is buffered. See: https://nodejs.org/api/stream.html#three-states.
+  const stdin = await readBufferFromStdinUntilClosed();
+  const config = getConfig();
+  assertValidReleaseConfig(config);
+
+  // Parse the JSON metadata read from `stdin`.
+  const {builtPackagesWithInfo, newVersion: newVersionRaw} = JSON.parse(
+    stdin.toString('utf8'),
+  ) as ReleasePrecheckJsonStdin;
+
+  if (!Array.isArray(builtPackagesWithInfo)) {
+    error(red(`  ✘   Release pre-checks failed. Invalid list of built packages was provided.`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const newVersion = semver.parse(newVersionRaw);
+  if (newVersion === null) {
+    error(red(`  ✘   Release pre-checks failed. Invalid new version was provided.`));
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!(await assertPassingReleasePrechecks(config.release, newVersion, builtPackagesWithInfo))) {
+    process.exitCode = 1;
+  }
+}
+
+/** CLI command module for running checks before releasing. */
+export const ReleasePrecheckCommandModule: CommandModule<{}, {}> = {
+  handler,
+  command: 'precheck',
+  describe: false,
+};

--- a/ng-dev/release/precheck/index.ts
+++ b/ng-dev/release/precheck/index.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {debug} from 'console';
+import {SemVer} from 'semver';
+import {error, green, info, red, warn, yellow} from '../../utils/console';
+import {BuiltPackageWithInfo, ReleaseConfig} from '../config';
+
+/**
+ * Error class that can be used to report precheck failures. Messaging with
+ * respect to the pre-check error is required to be handled manually.
+ */
+export class ReleasePrecheckError extends Error {}
+
+/**
+ * Runs the release prechecks and checks whether they are passing for the
+ * specified release config, intended new version and built release packages.
+ *
+ * @returns A boolean that indicates whether the prechecks are passing or not.
+ */
+export async function assertPassingReleasePrechecks(
+  config: ReleaseConfig,
+  newVersion: SemVer,
+  builtPackagesWithInfo: BuiltPackageWithInfo[],
+): Promise<boolean> {
+  if (config.prereleaseCheck === undefined) {
+    warn(yellow('  ⚠   Skipping release pre-checks. No checks configured.'));
+    return true;
+  }
+
+  // The user-defined release precheck function is supposed to throw errors upon unmet
+  // checks. We catch this here and print a better message and determine the status.
+  try {
+    await config.prereleaseCheck(newVersion, builtPackagesWithInfo);
+    info(green('  ✓   Release pre-checks passing.'));
+    return true;
+  } catch (e) {
+    if (isReleasePrecheckError(e)) {
+      // Note: Error messaging is expected to be handled manually.
+      debug(e.message);
+      error(red(`  ✘   Release pre-checks failed. Please check the output above.`));
+    } else {
+      error(red(e), '\n');
+      error(red(`  ✘   Release pre-checks errored with unexpected runtime error.`));
+    }
+
+    return false;
+  }
+}
+
+/**
+ * Gets whether the given value is a `ReleasePrecheckError`. This helper exists
+ * because `instanceof` checks would not work due to us not using code-splitting.
+ *
+ * TODO(devversion): Remove this when we expose the same code we use in the CLI,
+ *   using ESBuild code-splitting.
+ */
+function isReleasePrecheckError(value: unknown): value is ReleasePrecheckError {
+  return (value as Partial<Object>).constructor?.name === 'ReleasePrecheckError';
+}

--- a/ng-dev/release/precheck/precheck.spec.ts
+++ b/ng-dev/release/precheck/precheck.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as semver from 'semver';
+import {Readable} from 'stream';
+import {BuiltPackageWithInfo, ReleaseConfig} from '../config';
+import {ReleasePrecheckCommandModule, ReleasePrecheckJsonStdin} from './cli';
+
+import * as configUtils from '../../utils/config';
+import * as console from '../../utils/console';
+import {ReleasePrecheckError} from '.';
+
+describe('ng-dev release precheck', () => {
+  // Keep track of the original `stdin` since we might fake it within specs.
+  const _originalStdin = process.stdin;
+  const _originalProcessExitCode = process.exitCode;
+
+  const npmPackages = [{name: '@angular/pkg1'}, {name: '@angular/pkg2'}];
+  const builtPackagesWithInfo: BuiltPackageWithInfo[] = [
+    {name: '@angular/pkg1', outputPath: 'dist/pkg1', hash: '<>', experimental: false},
+    {name: '@angular/pkg2', outputPath: 'dist/pkg2', hash: '<>', experimental: false},
+  ];
+
+  let prereleaseCheckSpy: jasmine.Spy<NonNullable<ReleaseConfig['prereleaseCheck']>> | undefined =
+    undefined;
+
+  beforeEach(() => {
+    prereleaseCheckSpy = jasmine
+      .createSpy('ReleaseConfig#prereleaseCheck')
+      .and.callFake(() => Promise.resolve());
+
+    spyOn(configUtils, 'getConfig').and.callFake(() => ({
+      release: {
+        representativeNpmPackage: npmPackages[0].name,
+        npmPackages,
+        prereleaseCheck: prereleaseCheckSpy,
+        buildPackages: () => Promise.resolve(builtPackagesWithInfo),
+      } as ReleaseConfig,
+    }));
+  });
+
+  afterEach(() => {
+    updateStdinGetter(_originalStdin);
+    process.exitCode = _originalProcessExitCode;
+  });
+
+  /**
+   * Updates the `process.stdin` property. Direct assignments will not work
+   * since NodeJS declares `stdin` using a property accessor.
+   */
+  function updateStdinGetter(newStdin: NodeJS.ReadableStream) {
+    Object.defineProperty(process, 'stdin', {get: () => newStdin});
+  }
+
+  /** Invokes the build command handler. */
+  async function invokePrecheck(stdin: ReleasePrecheckJsonStdin) {
+    const fakeStdin = Readable.from(Buffer.from(JSON.stringify(stdin)));
+
+    updateStdinGetter(fakeStdin);
+
+    await ReleasePrecheckCommandModule.handler({$0: '', _: []});
+  }
+
+  it('should invoke configured pre-check function', async () => {
+    await invokePrecheck({
+      builtPackagesWithInfo,
+      newVersion: '0.0.0',
+    });
+
+    expect(prereleaseCheckSpy).toHaveBeenCalledTimes(1);
+    expect(prereleaseCheckSpy).toHaveBeenCalledWith(semver.parse('0.0.0')!, builtPackagesWithInfo);
+    expect(process.exitCode).toBe(undefined);
+  });
+
+  it('should pass pre-check if no custom check function is defined', async () => {
+    prereleaseCheckSpy = undefined;
+
+    await invokePrecheck({
+      builtPackagesWithInfo,
+      newVersion: '0.0.0',
+    });
+
+    expect(process.exitCode).toBe(undefined);
+  });
+
+  it('should allow for failures to be reported in prechecks', async () => {
+    const precheckUserError =
+      'The peer dependency in `a/b/c` is invalid. Please update it ' +
+      'to `X` before re-attempting to release.';
+
+    prereleaseCheckSpy!.and.callFake(async () => {
+      // print the error explaining the issue and how it can be fixed.
+      // this is how a real custom pre-check should be built.
+      console.error(precheckUserError);
+
+      // throw the error to indicate the pre-check failure.
+      throw new ReleasePrecheckError();
+    });
+
+    spyOn(console, 'error');
+
+    await invokePrecheck({
+      builtPackagesWithInfo,
+      newVersion: '0.0.0',
+    });
+
+    expect(prereleaseCheckSpy).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+    expect(console.error).toHaveBeenCalledTimes(2);
+    expect(console.error).toHaveBeenCalledWith(precheckUserError);
+    expect(console.error).toHaveBeenCalledWith(
+      jasmine.stringContaining('Release pre-checks failed.'),
+    );
+  });
+
+  it('should recognize runtime errors in custom pre-check function', async () => {
+    prereleaseCheckSpy!.and.callFake(() =>
+      Promise.reject(new Error('SyntaxError/Some runtime error')),
+    );
+
+    await invokePrecheck({
+      builtPackagesWithInfo,
+      newVersion: '0.0.0',
+    });
+
+    expect(prereleaseCheckSpy).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should error if transported stdin metadata is invalid', async () => {
+    await invokePrecheck({
+      builtPackagesWithInfo,
+      // pass a version object instead of the string.
+      newVersion: semver.parse('0.0.0') as any,
+    });
+
+    expect(prereleaseCheckSpy).toHaveBeenCalledTimes(0);
+    expect(process.exitCode).toBe(1);
+
+    process.exitCode = 0;
+
+    await invokePrecheck({
+      builtPackagesWithInfo: 'not the expected array' as any,
+      newVersion: '0.0.0',
+    });
+
+    expect(prereleaseCheckSpy).toHaveBeenCalledTimes(0);
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/ng-dev/release/publish/BUILD.bazel
+++ b/ng-dev/release/publish/BUILD.bazel
@@ -13,6 +13,7 @@ ts_library(
         "//ng-dev/release/config",
         "//ng-dev/release/info",
         "//ng-dev/release/notes",
+        "//ng-dev/release/precheck",
         "//ng-dev/release/versioning",
         "//ng-dev/utils",
         "@npm//@octokit/rest",

--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -20,7 +20,7 @@ import {
   getRepositoryGitUrl,
 } from '../../utils/git/github-urls';
 import {Spinner} from '../../utils/spinner';
-import {BuiltPackage, ReleaseConfig} from '../config/index';
+import {BuiltPackage, BuiltPackageWithInfo, ReleaseConfig} from '../config/index';
 import {ReleaseNotes, workspaceRelativeChangelogPath} from '../notes/release-notes';
 import {NpmDistTag} from '../versioning';
 import {ActiveReleaseTrains} from '../versioning/active-release-trains';
@@ -31,7 +31,6 @@ import {FatalReleaseActionError, UserAbortedReleaseActionError} from './actions-
 import {
   analyzeAndExtendBuiltPackagesWithInfo,
   assertIntegrityOfBuiltPackages,
-  BuiltPackageWithInfo,
 } from './built-package-info';
 import {getCommitMessageForRelease, getReleaseNoteCherryPickCommitMessage} from './commit-message';
 import {githubReleaseBodyLimit, waitForPullRequestInterval} from './constants';

--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -37,6 +37,7 @@ import {githubReleaseBodyLimit, waitForPullRequestInterval} from './constants';
 import {
   invokeReleaseBuildCommand,
   invokeReleaseInfoCommand,
+  invokeReleasePrecheckCommand,
   invokeYarnInstallCommand,
 } from './external-commands';
 import {getPullRequestState} from './pull-request-state';
@@ -483,6 +484,9 @@ export abstract class ReleaseAction {
     await this.installDependenciesForCurrentBranch();
 
     const builtPackagesWithInfo = await this.buildReleaseForCurrentBranch();
+
+    // Run release pre-checks (e.g. validating the release output).
+    await invokeReleasePrecheckCommand(this.projectDir, newVersion, builtPackagesWithInfo);
 
     // Verify the packages built are the correct version.
     await this._verifyPackageVersions(releaseNotes.version, builtPackagesWithInfo);

--- a/ng-dev/release/publish/built-package-info.ts
+++ b/ng-dev/release/publish/built-package-info.ts
@@ -9,17 +9,8 @@
 import {hashElement} from 'folder-hash';
 
 import {debug, error, red} from '../../utils/console';
-import {BuiltPackage, NpmPackage} from '../config';
+import {BuiltPackage, BuiltPackageWithInfo, NpmPackage} from '../config';
 import {FatalReleaseActionError} from './actions-error';
-
-/**
- * Type describing a built package with its associated NPM package info
- * and package content hash, useful for verifying its integrity.
- */
-export interface BuiltPackageWithInfo extends BuiltPackage, NpmPackage {
-  /** A deterministic hash that can be used to verify the contents of the package. */
-  hash: string;
-}
 
 /**
  * Analyzes and extends the given built packages with additional information,

--- a/ng-dev/release/publish/test/branch-off-next-branch-testing.ts
+++ b/ng-dev/release/publish/test/branch-off-next-branch-testing.ts
@@ -135,6 +135,7 @@ export async function expectBranchOffActionToRun(
     'Expected next release-train update branch be created in fork.',
   );
 
+  expect(externalCommands.invokeReleasePrecheckCommand).toHaveBeenCalledTimes(1);
   expect(externalCommands.invokeReleaseBuildCommand).toHaveBeenCalledTimes(1);
   expect(npm.runNpmPublish).toHaveBeenCalledTimes(testReleasePackages.length);
 

--- a/ng-dev/release/publish/test/delegate-test-action.ts
+++ b/ng-dev/release/publish/test/delegate-test-action.ts
@@ -7,11 +7,11 @@
  */
 
 import * as semver from 'semver';
+import {BuiltPackageWithInfo} from '../../config';
 
 import {ReleaseNotes} from '../../notes/release-notes';
 import {NpmDistTag} from '../../versioning';
 import {ReleaseAction} from '../actions';
-import {BuiltPackageWithInfo} from '../built-package-info';
 
 /**
  * Test release action that exposes protected units of the base

--- a/ng-dev/release/publish/test/test-utils/action-mocks.ts
+++ b/ng-dev/release/publish/test/test-utils/action-mocks.ts
@@ -101,6 +101,7 @@ export function setupMocksForReleaseAction<T extends boolean>(
   spyOn(externalCommands, 'invokeYarnInstallCommand').and.resolveTo();
   spyOn(externalCommands, 'invokeReleaseInfoCommand').and.resolveTo(releaseConfig);
   spyOn(externalCommands, 'invokeReleaseBuildCommand').and.resolveTo(builtPackages);
+  spyOn(externalCommands, 'invokeReleasePrecheckCommand').and.resolveTo();
 
   if (stubBuiltPackageOutputChecks) {
     // Fake checking the package versions since we don't actually create NPM

--- a/ng-dev/release/publish/test/test-utils/action-mocks.ts
+++ b/ng-dev/release/publish/test/test-utils/action-mocks.ts
@@ -19,10 +19,9 @@ import {
   testTmpDir,
   VirtualGitClient,
 } from '../../../../utils/testing';
-import {BuiltPackage, NpmPackage, ReleaseConfig} from '../../../config';
+import {BuiltPackage, BuiltPackageWithInfo, NpmPackage, ReleaseConfig} from '../../../config';
 import * as npm from '../../../versioning/npm-publish';
 import {ReleaseAction} from '../../actions';
-import {BuiltPackageWithInfo} from '../../built-package-info';
 import * as constants from '../../constants';
 import * as externalCommands from '../../external-commands';
 

--- a/ng-dev/release/publish/test/test-utils/staging-test.ts
+++ b/ng-dev/release/publish/test/test-utils/staging-test.ts
@@ -113,6 +113,7 @@ export async function expectStagingAndPublishWithoutCherryPick(
     ? testReleasePackages.filter((pkg) => !pkg.experimental)
     : testReleasePackages;
 
+  expect(externalCommands.invokeReleasePrecheckCommand).toHaveBeenCalledTimes(1);
   expect(externalCommands.invokeReleaseBuildCommand).toHaveBeenCalledTimes(1);
   expectNpmPublishToBeInvoked(publishedPackages, expectedNpmDistTag);
 }
@@ -168,6 +169,7 @@ export async function expectStagingAndPublishWithCherryPick(
     ? testReleasePackages.filter((pkg) => !pkg.experimental)
     : testReleasePackages;
 
+  expect(externalCommands.invokeReleasePrecheckCommand).toHaveBeenCalledTimes(1);
   expect(externalCommands.invokeReleaseBuildCommand).toHaveBeenCalledTimes(1);
   expectNpmPublishToBeInvoked(publishedPackages, expectedNpmDistTag);
 }

--- a/ng-dev/release/publish/test/test-utils/test-action.ts
+++ b/ng-dev/release/publish/test/test-utils/test-action.ts
@@ -8,10 +8,9 @@
 
 import {GithubConfig} from '../../../../utils/config';
 import {GithubTestingRepo, SandboxGitClient, VirtualGitClient} from '../../../../utils/testing';
-import {ReleaseConfig} from '../../../config';
+import {BuiltPackageWithInfo, ReleaseConfig} from '../../../config';
 import {ActiveReleaseTrains} from '../../../versioning';
 import {ReleaseAction} from '../../actions';
-import {BuiltPackageWithInfo} from '../../built-package-info';
 
 export interface TestOptions {
   /**

--- a/ng-dev/release/set-dist-tag/cli.ts
+++ b/ng-dev/release/set-dist-tag/cli.ts
@@ -6,6 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// ---- **IMPORTANT** ----
+// This command is part of our external commands invoked by the release publish
+// command. Before making changes, keep in mind that more recent `ng-dev` versions
+// can still invoke this command.
+// ------------------------
+
 import * as semver from 'semver';
 import {Arguments, Argv, CommandModule} from 'yargs';
 import {getConfig} from '../../utils/config';

--- a/ng-dev/utils/child-process.ts
+++ b/ng-dev/utils/child-process.ts
@@ -26,6 +26,9 @@ export interface SpawnOptions extends Omit<_SpawnOptions, 'shell' | 'stdio'> {
   mode?: 'enabled' | 'silent' | 'on-error';
   /** Whether to prevent exit codes being treated as failures. */
   suppressErrorOnFailingExitCode?: boolean;
+  // Stdin text to provide to the process. The raw text will be written to `stdin` and then
+  // the stream is closed. This is equivalent to the `input` option from `SpawnSyncOption`.
+  input?: string;
 }
 
 /** Interface describing the options for spawning an interactive process. */
@@ -86,6 +89,12 @@ export function spawn(
     let logOutput = '';
     let stdout = '';
     let stderr = '';
+
+    // If provided, write `input` text to the process `stdin`.
+    if (options.input !== undefined) {
+      childProcess.stdin.write(options.input);
+      childProcess.stdin.end();
+    }
 
     // Capture the stdout separately so that it can be passed as resolve value.
     // This is useful if commands return parsable stdout.

--- a/ng-dev/utils/read-stdin-until-closed.ts
+++ b/ng-dev/utils/read-stdin-until-closed.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Unique error class for failures when reading from the stdin. */
+export class ReadBufferFromStdinError extends Error {}
+
+/**
+ * Reads a `Buffer` from `stdin` until the stream is closed.
+ *
+ * @returns a Promise resolving with the `Buffer`. Rejects with `ReadBufferFromStdinError`
+ *   on unexpected read errors.
+ */
+export function readBufferFromStdinUntilClosed(
+  input: NodeJS.ReadStream = process.stdin,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const data: Buffer[] = [];
+
+    input.on('data', (chunk) => data.push(chunk));
+    input.on('end', () => resolve(Buffer.concat(data)));
+    input.on('error', () => reject(new ReadBufferFromStdinError()));
+    input.on('timeout', () => reject(new ReadBufferFromStdinError('Unexpected timeout')));
+  });
+}

--- a/tools/local-actions/changelog/main.js
+++ b/tools/local-actions/changelog/main.js
@@ -48173,6 +48173,10 @@ var require_child_process = __commonJS({
         let logOutput = "";
         let stdout = "";
         let stderr = "";
+        if (options.input !== void 0) {
+          childProcess.stdin.write(options.input);
+          childProcess.stdin.end();
+        }
         childProcess.stderr.on("data", (message) => {
           stderr += message;
           logOutput += message;


### PR DESCRIPTION
This commit introduces a new config option that can be defined to
configure custom release pre-checks that will run before releasing,
and after the release output has been built.

This allows for pre-release checks and post-build checks. Useful for
e.g. validating release output, checking the migration collection,
checking the peer dependency ranges etc.