### PR TITLE
refactor(ng-dev): do not print `undefined` when release prechecks fail

### DIFF
--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -9,7 +9,7 @@
 import * as semver from 'semver';
 
 import {spawn} from '../../utils/child-process';
-import {error, green, info, red} from '../../utils/console';
+import {debug, error, green, info, red} from '../../utils/console';
 import {Spinner} from '../../utils/spinner';
 import {NpmDistTag} from '../versioning';
 
@@ -196,7 +196,9 @@ export async function invokeReleasePrecheckCommand(
     );
     info(green(`  ✓   Executed release pre-checks for ${newVersion}`));
   } catch (e) {
-    error(e);
+    // The `spawn` invocation already prints all stdout/stderr, so we don't need re-print.
+    // To ease debugging in case of runtime exceptions, we still print the error to `debug`.
+    debug(e);
     error(red(`  ✘   An error occurred while running release pre-checks.`));
     throw new FatalReleaseActionError();
   }


### PR DESCRIPTION
We always print `undefined` upon release pre-check errors. The actual
pre-check error messaging is piped from the child process to
stdout/stderr, and therefore the the `spawn` utility-thrown error
is not necessary to be printed.