### PR TITLE
refactor(ng-dev): do not pass `SemVer` object to precheck function to avoid version mismatches

### DIFF
--- a/ng-dev/release/config/index.ts
+++ b/ng-dev/release/config/index.ts
@@ -60,7 +60,7 @@ export interface ReleaseConfig {
    * the release will abort the release and print the `ReleasePrecheckError` error.
    */
   prereleaseCheck?: (
-    newVersion: SemVer,
+    newVersion: string,
     builtPackagesWithInfo: BuiltPackageWithInfo[],
   ) => Promise<void>;
 }

--- a/ng-dev/release/precheck/index.ts
+++ b/ng-dev/release/precheck/index.ts
@@ -36,7 +36,10 @@ export async function assertPassingReleasePrechecks(
   // The user-defined release precheck function is supposed to throw errors upon unmet
   // checks. We catch this here and print a better message and determine the status.
   try {
-    await config.prereleaseCheck(newVersion, builtPackagesWithInfo);
+    // Note: We do not pass the `SemVer` instance to the user-customizable precheck
+    // function. This is because we bundled our version of `semver` and the version
+    // used in the precheck logic might be different, causing unexpected issues.
+    await config.prereleaseCheck(newVersion.format(), builtPackagesWithInfo);
     info(green('  ✓   Release pre-checks passing.'));
     return true;
   } catch (e) {

--- a/ng-dev/release/precheck/precheck.spec.ts
+++ b/ng-dev/release/precheck/precheck.spec.ts
@@ -73,7 +73,7 @@ describe('ng-dev release precheck', () => {
     });
 
     expect(prereleaseCheckSpy).toHaveBeenCalledTimes(1);
-    expect(prereleaseCheckSpy).toHaveBeenCalledWith(semver.parse('0.0.0')!, builtPackagesWithInfo);
+    expect(prereleaseCheckSpy).toHaveBeenCalledWith('0.0.0', builtPackagesWithInfo);
     expect(process.exitCode).toBe(undefined);
   });
 

--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -193,9 +193,11 @@ export abstract class ReleaseAction {
     info(
       yellow(
         '  ⚠   Please review the changelog and ensure that the log contains only changes ' +
-          'that apply to the public API surface. Manual changes can be made. When done, please ' +
-          'proceed with the prompt below.',
+          'that apply to the public API surface.',
       ),
+    );
+    info(
+      yellow('      Manual changes can be made. When done, please proceed with the prompt below.'),
     );
 
     if (!(await promptConfirm('Do you want to proceed and commit the changes?'))) {


### PR DESCRIPTION
The `SemVer` class is bundled in `ng-dev`, like other dependencies. We should not
pass an object instance of `SemVer` to the user-customizable precheck function as it
would be easy for them to run into version-mismatch issues because SemVer utilities rely
heavily on `instanceof` checks.

e.g. in the COMP repo, we use `semver.compare` and passing the version from bundled
ng-dev in there, results in a runtime exception.

We should rather pass the string and expect users to parse it themselves in their own user-space.