### PR TITLE
build: prevent `glob` from being updated by renovate due to protobufjs limitation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
-      "excludePackageNames": ["@types/node", "espree", "escodegen"],
+      "excludePackageNames": ["@types/node", "espree", "escodegen", "glob"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "schedule": ["after 1am every weekday", "every weekend"]


### PR DESCRIPTION
We need to maintain a matching version of `glob` with the one provided by `protobufjs` since
protobufjs would otherwise throw. Similar to 405b6f6e874e6e297d00e8100bd0b5d31e00ea96