### PR TITLE
fix(ng-dev/release): always publish experimental packages for lts patch

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -661,9 +661,7 @@ export abstract class ReleaseAction {
     beforeStagingSha: string,
     publishBranch: string,
     npmDistTag: NpmDistTag,
-    additionalOptions: {skipExperimentalPackages?: boolean} = {},
   ) {
-    const {skipExperimentalPackages} = additionalOptions;
     const versionBumpCommitSha = await this.getLatestCommitOfBranch(publishBranch);
 
     // Ensure the latest commit in the publish branch is the bump commit.
@@ -696,11 +694,6 @@ export abstract class ReleaseAction {
 
     // Walk through all built packages and publish them to NPM.
     for (const pkg of builtPackagesWithInfo) {
-      if (skipExperimentalPackages && pkg.experimental) {
-        debug(`Skipping "${pkg.name}" as it is experimental.`);
-        continue;
-      }
-
       await this._publishBuiltPackageToNpm(pkg, npmDistTag);
     }
 

--- a/ng-dev/release/publish/actions/cut-lts-patch.ts
+++ b/ng-dev/release/publish/actions/cut-lts-patch.ts
@@ -46,10 +46,6 @@ export class CutLongTermSupportPatchAction extends ReleaseAction {
       beforeStagingSha,
       ltsBranch.name,
       ltsBranch.npmDistTag,
-      {
-        // For LTS patch versions, we want to skip experimental packages.
-        skipExperimentalPackages: true,
-      },
     );
     await this.cherryPickChangelogIntoNextBranch(releaseNotes, ltsBranch.name);
   }

--- a/ng-dev/release/publish/test/cut-lts-patch.spec.ts
+++ b/ng-dev/release/publish/test/cut-lts-patch.spec.ts
@@ -80,9 +80,7 @@ describe('cut an LTS patch action', () => {
       npmDistTag: 'v9-lts',
     });
 
-    await expectStagingAndPublishWithCherryPick(action, '9.2.x', '9.2.5', 'v9-lts', {
-      expectNoExperimentalPackages: true,
-    });
+    await expectStagingAndPublishWithCherryPick(action, '9.2.x', '9.2.5', 'v9-lts');
   });
 
   it('should generate release notes capturing changes to previous latest LTS version', async () => {

--- a/ng-dev/release/publish/test/test-utils/staging-test.ts
+++ b/ng-dev/release/publish/test/test-utils/staging-test.ts
@@ -84,7 +84,6 @@ export async function expectStagingAndPublishWithoutCherryPick(
   expectedBranch: string,
   expectedVersion: string,
   expectedNpmDistTag: NpmDistTag,
-  options: {expectNoExperimentalPackages?: boolean} = {},
 ) {
   const {repo, fork, gitClient} = action;
   const expectedStagingForkBranch = `release-stage-${expectedVersion}`;
@@ -109,13 +108,9 @@ export async function expectStagingAndPublishWithoutCherryPick(
     'Expected release staging branch to be created in fork.',
   );
 
-  const publishedPackages = options.expectNoExperimentalPackages
-    ? testReleasePackages.filter((pkg) => !pkg.experimental)
-    : testReleasePackages;
-
   expect(externalCommands.invokeReleasePrecheckCommand).toHaveBeenCalledTimes(1);
   expect(externalCommands.invokeReleaseBuildCommand).toHaveBeenCalledTimes(1);
-  expectNpmPublishToBeInvoked(publishedPackages, expectedNpmDistTag);
+  expectNpmPublishToBeInvoked(testReleasePackages, expectedNpmDistTag);
 }
 
 export async function expectStagingAndPublishWithCherryPick(
@@ -123,7 +118,6 @@ export async function expectStagingAndPublishWithCherryPick(
   expectedBranch: string,
   expectedVersion: string,
   expectedNpmDistTag: NpmDistTag,
-  options: {expectNoExperimentalPackages?: boolean} = {},
 ) {
   const {repo, fork, gitClient} = action;
   const expectedStagingForkBranch = `release-stage-${expectedVersion}`;
@@ -165,11 +159,7 @@ export async function expectStagingAndPublishWithCherryPick(
     'Expected cherry-pick branch to be created in fork.',
   );
 
-  const publishedPackages = options.expectNoExperimentalPackages
-    ? testReleasePackages.filter((pkg) => !pkg.experimental)
-    : testReleasePackages;
-
   expect(externalCommands.invokeReleasePrecheckCommand).toHaveBeenCalledTimes(1);
   expect(externalCommands.invokeReleaseBuildCommand).toHaveBeenCalledTimes(1);
-  expectNpmPublishToBeInvoked(publishedPackages, expectedNpmDistTag);
+  expectNpmPublishToBeInvoked(testReleasePackages, expectedNpmDistTag);
 }


### PR DESCRIPTION
As part of a past refactoring where we made it possible for the release
tool to know whether a package is supposed to be experimental or not, we
also added a change that intended to skip experimental packages from
being published for LTS patch releases.

The idea here was that LTS experimental packages should never need to be
re-published because fixes are supposed to be only made to
non-experimental packages governed by the LTS contract. This should
technically be the case, but in practice with the way we manage our
dependencies/peer dependencies, when we bump a version for an LTS, the
experimental packages are expected to be updated as well.

To simplify this, as it is low-effort, we also publish LTS experimental
packages now.