### PR TITLE
build: improve stability of concurrent integration tests running locally

### DIFF
--- a/bazel/integration/tests/angular-cli/BUILD.bazel
+++ b/bazel/integration/tests/angular-cli/BUILD.bazel
@@ -14,6 +14,8 @@ integration_test(
         "//bazel/browsers/chromium",
     ],
     environment = {
+        # Ensure Yarn does not try to access the shared system cache (even within sandboxing)
+        "HOME": "<TMP>",
         "CHROMEDRIVER_SKIP_DOWNLOAD": "true",
         "CHROMEDRIVER_PATH": "$(CHROMEDRIVER)",
         "CHROME_BIN": "$(CHROMIUM)",

--- a/bazel/integration/tests/playwright_chromium/BUILD.bazel
+++ b/bazel/integration/tests/playwright_chromium/BUILD.bazel
@@ -12,6 +12,8 @@ integration_test(
         "//bazel/browsers/chromium",
     ],
     environment = {
+        # Ensure Yarn does not try to access the shared system cache (even within sandboxing)
+        "HOME": "<TMP>",
         "CHROME_BIN": "$(CHROMIUM)",
     },
     tags = [


### PR DESCRIPTION
We have some non-RBE tests (to test platform-specific behavior), and
even within the sandbox, the shared Yarn cache is accesed. This can
result in errors as the folder might be accessed concurrently
(even though it should not be writable with Bazels sandbox)

https://app.circleci.com/pipelines/github/angular/dev-infra/306734/workflows/8ee6418f-cac4-489c-9d21-4baf6bf6b35b/jobs/309267/steps