### PR TITLE
fix(ng-dev): ensure config can be properly loaded on windows

### DIFF
--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -24535,6 +24535,7 @@ function parseInternal(fullText) {
 }
 
 // 
+import { pathToFileURL } from "url";
 import { join } from "path";
 
 // 
@@ -25287,7 +25288,7 @@ function assertValidGithubConfig(config) {
 }
 async function readConfigFile(configPath, returnEmptyObjectOnError = false) {
   try {
-    return await import(configPath);
+    return await import(pathToFileURL(configPath).toString());
   } catch (e) {
     if (returnEmptyObjectOnError) {
       Log.debug(`Could not read configuration file at ${configPath}, returning empty object instead.`);

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -60973,6 +60973,7 @@ function getCommitsInRange(from, to = "HEAD") {
 }
 
 // 
+import { pathToFileURL } from "url";
 import { join } from "path";
 
 // 
@@ -61739,7 +61740,7 @@ function assertValidGithubConfig(config) {
 }
 async function readConfigFile(configPath, returnEmptyObjectOnError = false) {
   try {
-    return await import(configPath);
+    return await import(pathToFileURL(configPath).toString());
   } catch (e2) {
     if (returnEmptyObjectOnError) {
       Log.debug(`Could not read configuration file at ${configPath}, returning empty object instead.`);

--- a/ng-dev/utils/config.ts
+++ b/ng-dev/utils/config.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {pathToFileURL} from 'url';
 import {join} from 'path';
 import {Assertions, MultipleAssertions} from './config-assertions.js';
 
@@ -156,7 +157,9 @@ export function assertValidGithubConfig<T extends NgDevConfig>(
  */
 async function readConfigFile(configPath: string, returnEmptyObjectOnError = false): Promise<{}> {
   try {
-    return await import(configPath);
+    // ESM imports expect a valid URL. On Windows, the disk name causes errors like:
+    // `ERR_UNSUPPORTED_ESM_URL_SCHEME: <..> Received protocol 'c:'`
+    return await import(pathToFileURL(configPath).toString());
   } catch (e) {
     if (returnEmptyObjectOnError) {
       Log.debug(

--- a/tools/local-actions/changelog/main.js
+++ b/tools/local-actions/changelog/main.js
@@ -59277,6 +59277,7 @@ var DryRunError = class extends Error {
 };
 
 // 
+import { pathToFileURL } from "url";
 import { join } from "path";
 
 // 
@@ -59335,7 +59336,7 @@ function assertValidGithubConfig(config2) {
 }
 async function readConfigFile(configPath, returnEmptyObjectOnError = false) {
   try {
-    return await import(configPath);
+    return await import(pathToFileURL(configPath).toString());
   } catch (e) {
     if (returnEmptyObjectOnError) {
       Log.debug(`Could not read configuration file at ${configPath}, returning empty object instead.`);


### PR DESCRIPTION
Fixes errors like in:
https://app.circleci.com/pipelines/github/angular/dev-infra/307198/workflows/dd98537a-4142-459d-9942-43d17e832b7d/jobs/309755.

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported 
by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```