### PR TITLE
fix(ng-dev): avoid ts-node esm shebang that breaks on windows

### DIFF
--- a/ng-dev/cli.ts
+++ b/ng-dev/cli.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S node --loader ts-node/esm --no-warnings
+#!/usr/bin/env node
+
 /**
  * @license
  * Copyright Google LLC All Rights Reserved.

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -19,4 +19,4 @@ bazelCommand=${BAZEL:-"yarn bazel"}
 
 # Execute the built ng-dev command in the current working directory
 # and pass-through arguments unmodified.
-${ngDevBinFile} ${@}
+yarn ts-node --esm --project .ng-dev/tsconfig.json ${ngDevBinFile} ${@}


### PR DESCRIPTION
Consumers should instead run `ts-node` as well. They need to pass in
the project manually anyway already, so it also makes this portion
easier by just having to directly use `ts-node` with `--project`.