### PR TITLE
feat(ng-dev): support exceptional minor target labeling in the interim

### DIFF
--- a/ng-dev/pr/config/index.ts
+++ b/ng-dev/pr/config/index.ts
@@ -51,6 +51,14 @@ export interface PullRequestConfig {
    * scopes in patch branches, no breaking changes in minor or patch changes.
    */
   targetLabelExemptScopes?: string[];
+
+  /**
+   * Special flag that should **NOT** be used without confirming with the dev-infra team.
+   * This flag turns the RC/FF release-train into an exceptional minor release-train by:
+   *
+   *    - changing `target: minor` to point to `target: rc` (without the RC merge restrictions)
+   */
+  __specialTreatRcAsExceptionalMinor?: boolean;
 }
 
 /** Loads and validates the merge configuration. */

--- a/ng-dev/pr/merge/integration.spec.ts
+++ b/ng-dev/pr/merge/integration.spec.ts
@@ -115,6 +115,11 @@ describe('default target labels', () => {
     const targetLabels = await getTargetLabelsForActiveReleaseTrains(releaseTrains, api, {
       github: githubConfig,
       release: releaseConfig,
+      pullRequest: {
+        commitMessageFixupLabel: 'commit message fixup',
+        githubApiMerge: false,
+        mergeReadyLabel: 'merge ready',
+      },
       __isNgDevConfigObject: true,
     });
     let label: TargetLabel;


### PR DESCRIPTION
Until we have implemented the actual exceptional minor mechanism in both
the release and merge tool, we want to be able to turn `target: minor`
into `target: rc` (internally) so that minor changes can go into the
RC/FF phase that we "misuse" as the exceptional minor release train.

Primary reason for this is to avoid all the enforcement we provide for `target: rc` changes.