### PR TITLE
build: add circleci readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # dev-infra
 Angular Development Infrastructure
+
+[![CircleCI](https://dl.circleci.com/insights-snapshot/gh/angular/dev-infra/main/default_workflow/badge.svg?window=7d)](https://app.circleci.com/insights/github/angular/dev-infra/workflows/default_workflow/overview?branch=main&reporting-window=last-7-days&insights-snapshot=true)


### PR DESCRIPTION
Adds the CircleCI readme badge. Just making it easier to see the CI runs on e.g. mobile..