### PR TITLE
fix(ng-dev): do not match dots automatically in pullapprove

### DIFF
--- a/ng-dev/pullapprove/utils.ts
+++ b/ng-dev/pullapprove/utils.ts
@@ -18,7 +18,7 @@ export function getOrCreateGlob(pattern: string) {
   if (patternCache.has(pattern)) {
     return patternCache.get(pattern)!;
   }
-  const glob = new Minimatch(pattern, {dot: true});
+  const glob = new Minimatch(pattern, {dot: false, nobrace: false});
   patternCache.set(pattern, glob);
   return glob;
 }


### PR DESCRIPTION
Pullapprove does not match dot files automatically, using `wcmatch`. We
should adjust our verify logic to reflect that.

This will cause issues in framework, but expected..