### PR TITLE
feat(ng-dev/pr): provide instructions for pushing back to the remote branch for pr checkout

### DIFF
--- a/ng-dev/pr/checkout/cli.ts
+++ b/ng-dev/pr/checkout/cli.ts
@@ -7,6 +7,7 @@
  */
 
 import {Argv, Arguments, CommandModule} from 'yargs';
+import {Log} from '../../utils/logging.js';
 
 import {addGithubTokenOption} from '../../utils/git/github-yargs.js';
 import {checkOutPullRequestLocally} from '../common/checkout-pr.js';
@@ -23,8 +24,11 @@ function builder(yargs: Argv) {
 
 /** Handles the checkout pull request command. */
 async function handler({pr, githubToken}: Arguments<CheckoutOptions>) {
-  const prCheckoutOptions = {allowIfMaintainerCannotModify: true, branchName: `pr-${pr}`};
-  await checkOutPullRequestLocally(pr, githubToken, prCheckoutOptions);
+  const options = {allowIfMaintainerCannotModify: true, branchName: `pr-${pr}`};
+  const {pushToUpstreamCommand} = await checkOutPullRequestLocally(pr, githubToken, options);
+  Log.info(`Checked out the remote branch for pull request #${pr}\n`);
+  Log.info('To push the checked out branch back to its PR, run the following command:');
+  Log.info(`  $ ${pushToUpstreamCommand}`);
 }
 
 /** yargs command module for checking out a PR  */

--- a/ng-dev/pr/common/checkout-pr.ts
+++ b/ng-dev/pr/common/checkout-pr.ts
@@ -131,5 +131,7 @@ export async function checkOutPullRequestLocally(
     resetGitState: (): boolean => {
       return git.checkout(previousBranchOrRevision, true);
     },
+    pushToUpstreamCommand: `git push ${pr.headRef.repository.url} HEAD:${headRefName} ${forceWithLeaseFlag}`,
+    resetGitStateCommand: `git rebase --abort && git reset --hard && git checkout ${previousBranchOrRevision}`,
   };
 }


### PR DESCRIPTION
Provide, as a convenience, the command for pushing the locally checked out branch back to the PR on github.