### PR TITLE
build: skip building of bottleneck `re2` native dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,11 @@
     "yaml": "^2.0.0",
     "zone.js": "^0.11.4"
   },
+  "dependenciesMeta": {
+    "re2": {
+      "built": false
+    }
+  },
   "resolutions": {
     "@angular/benchpress/@angular/core": "14.1.0-next.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -541,6 +541,9 @@ __metadata:
     yaml: ^2.0.0
     yargs: ^17.0.0
     zone.js: ^0.11.4
+  dependenciesMeta:
+    re2:
+      built: false
   bin:
     ng-dev: ./ng-dev/bundles/cli.mjs
   languageName: unknown


### PR DESCRIPTION
The `re2` package is an optional dependency of `firebase-tools`
(transitively). It's super slow to build locally and also doesn't
seem to be cached locally, nor on CI. We should disable it as it
slows down the install by 1min.

Can be removed in the future with (worth checking) https://github.com/uhop/node-re2/issues/125