### PR TITLE
refactor(ng-dev): do not capture Angular robot in release notes

### DIFF
--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -18,7 +18,7 @@ const typesToIncludeInReleaseNotes = Object.values(COMMIT_TYPES)
   .map((type) => type.name);
 
 /** List of commit authors which are bots. */
-const botsAuthorNames = ['dependabot[bot]', 'Renovate Bot'];
+const botsAuthorNames = ['dependabot[bot]', 'Renovate Bot', 'angular-robot', 'Angular Robot'];
 
 /** Data used for context during rendering. */
 export interface RenderContextData {


### PR DESCRIPTION
We now use the Angular robot for managing dependencies, and likely it
will be used more in the future. The bot commits should not end up
polluting release notes.