### PR TITLE
refactor: reference other scripts through relative paths

### DIFF
--- a/ng-dev/pr/merge/strategies/autosquash-merge.ts
+++ b/ng-dev/pr/merge/strategies/autosquash-merge.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {dirname, join} from 'path';
+import {fileURLToPath} from 'url';
 import {PullRequestFailure} from '../../common/validation/failures.js';
 import {PullRequest} from '../pull-request.js';
 import {MergeStrategy, TEMP_PR_HEAD_BRANCH} from './strategy.js';
@@ -121,9 +123,10 @@ export class AutosquashMergeStrategy extends MergeStrategy {
 
 /** Gets the absolute file path to the commit-message filter script. */
 function getCommitMessageFilterScriptPath(): string {
-  // We resolve the script using module resolution as in the package output
-  // the worker might be bundled but exposed through a subpath export mapping.
-  return require.resolve(
-    '@angular/dev-infra-private/ng-dev/pr/merge/strategies/commit-message-filter',
-  );
+  // This file is getting bundled and ends up in `<pkg-root>/bundles/<chunk>`. We also
+  // bundle the commit-message-filter script as another entry-point and can reference
+  // it relatively as the path is preserved inside `bundles/`.
+  // *Note*: Relying on package resolution is problematic within ESM and with `local-dev.sh`
+  const bundlesDir = dirname(fileURLToPath(import.meta.url));
+  return join(bundlesDir, './pr/merge/strategies/commit-message-filter.mjs');
 }

--- a/ng-dev/release/build/index.ts
+++ b/ng-dev/release/build/index.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {dirname, join} from 'path';
+import {fileURLToPath} from 'url';
 import {fork} from 'child_process';
 import {BuiltPackage} from '../config/index.js';
 
@@ -42,7 +44,10 @@ export abstract class BuildWorker {
 
 /** Gets the absolute file path to the build worker script. */
 function getBuildWorkerScriptPath(): string {
-  // We resolve the worker script using module resolution as in the package output
-  // the worker might be bundled but exposed through a subpath export mapping.
-  return require.resolve('@angular/dev-infra-private/ng-dev/release/build/build-worker');
+  // This file is getting bundled and ends up in `<pkg-root>/bundles/<chunk>`. We also
+  // bundle the build worker script as another entry-point and can reference
+  // it relatively as the path is preserved inside `bundles/`.
+  // *Note*: Relying on package resolution is problematic within ESM and with `local-dev.sh`
+  const bundlesDir = dirname(fileURLToPath(import.meta.url));
+  return join(bundlesDir, './release/build/build-worker.mjs');
 }


### PR DESCRIPTION
In order to resolve the build worker script, or the commit message
filter script we should simply compute an absolute path relative
to the current script path. This is better compared to using the CJS
require resolution (going away anyway at some point with ESM), because
it makes our `dev-infra/npm_package` work without necessarily being
installed inside the `node_modules` directory. This allows us to
conveniently run the tool inside the dev-infra repo (dogfooding) and
using it for testing from `HEAD` in other repositories (without risking
to have a mismatch from the dev-infra version actually in the node
modules).