### PR TITLE
build: speed up local `ng-dev` and fix release build command

### DIFF
--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -17,6 +17,9 @@ bazelCommand=${BAZEL:-"yarn bazel"}
   ${bazelCommand} build :npm_package
 )
 
+export TS_NODE_TRANSPILE_ONLY=1
+export TS_NODE_PROJECT=${PWD}/.ng-dev/tsconfig.json
+
 # Execute the built ng-dev command in the current working directory
 # and pass-through arguments unmodified.
-yarn ts-node --esm --project .ng-dev/tsconfig.json ${ngDevBinFile} ${@}
+node --no-warnings --loader ts-node/esm ${ngDevBinFile} ${@}


### PR DESCRIPTION
Similar to the `ts-node` fixes we landed in all repositories, we need to
use Node directly to not break the build-worker NodeJS fork invocation.

Also we disable type-checking when `yarn ng-dev` runs, for speed.