### PR TITLE
build: exclude `tools/ts_proto` from renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,13 +11,13 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "ignorePaths": ["bazel/integration/tests/**"],
+  "ignorePaths": ["bazel/integration/tests/**", "tools/ts_proto/**"],
   "enabledManagers": ["npm", "bazel", "github-actions"],
   "baseBranches": ["main"],
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],
-      "excludePackageNames": ["@types/node", "espree", "escodegen", "glob"],
+      "excludePackageNames": ["@types/node"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "schedule": ["at any time"]


### PR DESCRIPTION
This folder cannot be updated as the dependencies need to
match 1:1 with the protobufjs CLI dependencies (which are installed
at runtime). This allows us to also remove the package excludes so
that we can update other dependencies outside of `tools/ts_proto`.