### PR TITLE
feat(github-actions): skip angular-robot in postapproval action

### DIFF
--- a/github-actions/post-approval-changes/lib/main.ts
+++ b/github-actions/post-approval-changes/lib/main.ts
@@ -31,6 +31,8 @@ const googlers = [
   'zarend',
 ];
 
+const googleOwnedRobots = ['angular-robot'];
+
 async function main() {
   let installationClient: Octokit | null = null;
 
@@ -55,6 +57,10 @@ async function runPostApprovalChangesAction(client: Octokit): Promise<void> {
   if (googlers.includes(pr.user.login)) {
     core.info('PR author is a googler, skipping as post approval changes are allowed.');
     return;
+  }
+
+  if (googleOwnedRobots.includes(pr.user.login)) {
+    core.info('PR author is a robot owned by Google. Post approval changes are allowed.');
   }
 
   console.debug(`Requested Reviewers: ${pr.requested_reviewers.join(', ')}`);

--- a/github-actions/post-approval-changes/main.js
+++ b/github-actions/post-approval-changes/main.js
@@ -25955,6 +25955,7 @@ var googlers = [
   "wagnermaciel",
   "zarend"
 ];
+var googleOwnedRobots = ["angular-robot"];
 async function main() {
   let installationClient = null;
   try {
@@ -25976,6 +25977,9 @@ async function runPostApprovalChangesAction(client) {
   if (googlers.includes(pr.user.login)) {
     core.info("PR author is a googler, skipping as post approval changes are allowed.");
     return;
+  }
+  if (googleOwnedRobots.includes(pr.user.login)) {
+    core.info("PR author is a robot owned by Google. Post approval changes are allowed.");
   }
   console.debug(`Requested Reviewers: ${pr.requested_reviewers.join(", ")}`);
   console.debug(`Requested Teams:     ${pr.requested_teams.join(", ")}`);


### PR DESCRIPTION
The Angular Robot is used for Renovate, and when Renovate pushes a small
update / or rebases upon conflicts, we should not need another explicit
review.

All actions performed by the `angular-robot` are managed by Googlers, so
this account should be able to skip the post approval checks.