### PR TITLE
fix(bazel): consistently run integration tests in sandbox-like directories

### DIFF
--- a/bazel/integration/test_runner/main.ts
+++ b/bazel/integration/test_runner/main.ts
@@ -34,9 +34,16 @@ async function main(): Promise<void> {
   const configContent = await fs.promises.readFile(configPath, 'utf8');
   const config = JSON.parse(configContent) as TestConfig;
 
+  // If we run with `DEBUG=1` or `bazel run`, we assume the user wants to debug
+  // the test and jump into the integration test directory.
+  const isTestDebugMode =
+    process.env.DEBUG === '1' || process.env.BUILD_WORKSPACE_DIRECTORY !== undefined;
+
+  debug('Running in test debug mode:', isTestDebugMode);
   debug('Fetched test config:', config);
 
   const runner = new TestRunner(
+    isTestDebugMode,
     config.testFiles,
     config.testPackage,
     config.testPackageRelativeWorkingDir,


### PR DESCRIPTION
As it can be seen in the `main` branch, one integration test fails on
Windows. I just turned on this test to run on Windows.

The erorr is not something new, but it surfaces here in the dev-infra
repo because we use Yarn berry and Yarn 1.x. The intgeration test uses
Yarn 1.x. but our project itself uses Yarn Berry.

The integration test temporary directory (on Windows without the
sandbox, or on other platforms without the sandbox) resides within the
execroot directory, so that the `.yarnrc.yml` from the project is
inherited. This causes inconsistent test results on platforms and makes
integration tests rather non-hermetic (to an extent possible in
platforms without an actual FS sandbox).

We should fix this by always acquiring a test tmp directory in the
system temporary directories, not relying on temporary directories
provided by Bazel that might reside in the execroot.