### PR TITLE
Specify worker pool in remote execution property

### DIFF
--- a/bazel/remote-execution/BUILD.bazel
+++ b/bazel/remote-execution/BUILD.bazel
@@ -24,6 +24,8 @@ platform(
         # property in the platform again in case the default ever changes. Network access is not desirable in
         # Bazel builds as it is potential source of flaky tests and therefore also breaks hermeticity.
         "dockerNetwork": "off",
+        # Specify the name of the remote worker pool all actions will execute on.
+        "Pool": "default",
     },
 )
 


### PR DESCRIPTION
Explicitly specify the default remote pool as where all remote actions should run. This should in theory be a no-op right now because the remote execution instance only has one pool where all actions run anyway. However, specifying the pool for all actions will eventually become mandatory on RBE.

Not sure how to test whether this PR breaks Angular's remote builds.