### PR TITLE
fix(ng-dev): do not throw if there is no diff between `g3` and `main`

### DIFF
--- a/ng-dev/caretaker/check/g3.spec.ts
+++ b/ng-dev/caretaker/check/g3.spec.ts
@@ -75,6 +75,31 @@ describe('G3Module', () => {
       expect(files).toBe(2);
       expect(commits).toBe(3);
     });
+
+    it('should not throw when there is no diff between the g3 and main branch', async () => {
+      getLatestShas.and.returnValue({g3: 'abc123', master: 'zxy987'});
+      getG3FileIncludeAndExcludeLists.and.returnValue({include: ['project1/*'], exclude: []});
+      getDiffStats.and.callThrough();
+
+      spyOn(GitClient.prototype, 'run').and.callFake((args: string[]): any => {
+        const output: Partial<SpawnSyncReturns<string>> = {};
+        if (args[0] === 'rev-list') {
+          output.stdout = '0';
+        }
+        if (args[0] === 'diff') {
+          output.stdout = '';
+        }
+        return output;
+      });
+
+      const module = new G3Module(git, {caretaker: {}, ...mockNgDevConfig});
+      const {insertions, deletions, files, commits} = (await module.data) as G3StatsData;
+
+      expect(insertions).toBe(0);
+      expect(deletions).toBe(0);
+      expect(files).toBe(0);
+      expect(commits).toBe(0);
+    });
   });
 
   describe('printing the data retrieved', () => {

--- a/ng-dev/caretaker/check/g3.ts
+++ b/ng-dev/caretaker/check/g3.ts
@@ -94,11 +94,18 @@ export class G3Module extends BaseModule<G3StatsData | void> {
     );
 
     // Get the numstat information between main and g3
-    this.git
+    const numStatDiff = this.git
       .run(['diff', `${g3Ref}...${mainRef}`, '--numstat'])
       .stdout // Remove the extra space after git's output.
-      .trim()
-      // Split each line of git output into array
+      .trim();
+
+    // If there is no diff, we can return early.
+    if (numStatDiff === '') {
+      return stats;
+    }
+
+    // Split each line of git output into array
+    numStatDiff
       .split('\n')
       // Split each line from the git output into components parts: insertions,
       // deletions and file name respectively
@@ -116,6 +123,7 @@ export class G3Module extends BaseModule<G3StatsData | void> {
           stats.files += 1;
         }
       });
+
     return stats;
   }
   /** Determine whether the file name passes both include and exclude checks. */


### PR DESCRIPTION
It seems like multimatch previously did not throw when it received an
empty file path. We should never need to call multimatch with an empty
path, avoiding the runtime error. To fix this, we just do not
incorrectly try to derive diff information from an empty line if there
is no diff (this was a brittle logic).