### PR TITLE
fix(ng-dev/release): wait for final branch-off PR before finishing release action

### DIFF
--- a/ng-dev/release/publish/test/branch-off-next-branch-testing.ts
+++ b/ng-dev/release/publish/test/branch-off-next-branch-testing.ts
@@ -52,7 +52,8 @@ async function expectGithubApiRequestsForBranchOff(
     })
     .expectTagToBeCreated(expectedTagName, 'STAGING_COMMIT_SHA')
     .expectReleaseToBeCreated(`v${expectedVersion}`, expectedTagName)
-    .expectPullRequestToBeCreated('master', fork, expectedNextUpdateBranch, 100);
+    .expectPullRequestToBeCreated('master', fork, expectedNextUpdateBranch, 100)
+    .expectPullRequestWait(100);
 
   // In the fork, we make the following branches appear as non-existent,
   // so that the PRs can be created properly without collisions.


### PR DESCRIPTION
This should make it clear to the caretaker (even though we have logging
for it already in the release tool and merge tool) that the final
branch-off PR needs to be merged..