### PR TITLE
feat(ng-dev): automatically merge pull requests from within release tool 

### DIFF
--- a/ng-dev/release/publish/actions/branch-off-next-branch.ts
+++ b/ng-dev/release/publish/actions/branch-off-next-branch.ts
@@ -69,17 +69,17 @@ export abstract class BranchOffNextBranchBaseAction extends ReleaseAction {
         newBranch,
       );
 
-    // Wait for the staging PR to be merged. Then build and publish the feature-freeze next
-    // pre-release. Finally, cherry-pick the release notes into the next branch in combination
-    // with bumping the version to the next minor too.
-    await this.waitForPullRequestToBeMerged(pullRequest);
+    // Wait for the staging PR to be merged. Then publish the feature-freeze next pre-release. Finally,
+    // cherry-pick the release notes into the next branch in combination with bumping the version to
+    // the next minor too.
+    await this.promptAndWaitForPullRequestMerged(pullRequest);
     await this.publish(builtPackagesWithInfo, releaseNotes, beforeStagingSha, newBranch, 'next');
 
     const branchOffPullRequest = await this._createNextBranchUpdatePullRequest(
       releaseNotes,
       newVersion,
     );
-    await this.waitForPullRequestToBeMerged(branchOffPullRequest);
+    await this.promptAndWaitForPullRequestMerged(branchOffPullRequest);
   }
 
   /** Computes the new version for the release-train being branched-off. */
@@ -142,7 +142,6 @@ export abstract class BranchOffNextBranchBaseAction extends ReleaseAction {
     );
 
     Log.info(green(`  ✓   Pull request for updating the "${nextBranch}" branch has been created.`));
-    Log.info(yellow(`      Please ask team members to review: ${nextUpdatePullRequest.url}.`));
 
     return nextUpdatePullRequest;
   }

--- a/ng-dev/release/publish/actions/configure-next-as-major.ts
+++ b/ng-dev/release/publish/actions/configure-next-as-major.ts
@@ -45,6 +45,8 @@ export class ConfigureNextAsMajorAction extends ReleaseAction {
     );
 
     Log.info(green('  ✓   Next branch update pull request has been created.'));
+
+    await this.promptAndWaitForPullRequestMerged(pullRequest);
   }
 
   static override async isActive(active: ActiveReleaseTrains) {

--- a/ng-dev/release/publish/actions/configure-next-as-major.ts
+++ b/ng-dev/release/publish/actions/configure-next-as-major.ts
@@ -45,7 +45,6 @@ export class ConfigureNextAsMajorAction extends ReleaseAction {
     );
 
     Log.info(green('  ✓   Next branch update pull request has been created.'));
-    Log.info(yellow(`      Please ask team members to review: ${pullRequest.url}.`));
   }
 
   static override async isActive(active: ActiveReleaseTrains) {

--- a/ng-dev/release/publish/actions/cut-lts-patch.ts
+++ b/ng-dev/release/publish/actions/cut-lts-patch.ts
@@ -42,7 +42,7 @@ export class CutLongTermSupportPatchAction extends ReleaseAction {
         ltsBranch.name,
       );
 
-    await this.waitForPullRequestToBeMerged(pullRequest);
+    await this.promptAndWaitForPullRequestMerged(pullRequest);
     await this.publish(
       builtPackagesWithInfo,
       releaseNotes,

--- a/ng-dev/release/publish/actions/cut-new-patch.ts
+++ b/ng-dev/release/publish/actions/cut-new-patch.ts
@@ -37,7 +37,7 @@ export class CutNewPatchAction extends ReleaseAction {
         branchName,
       );
 
-    await this.waitForPullRequestToBeMerged(pullRequest);
+    await this.promptAndWaitForPullRequestMerged(pullRequest);
     await this.publish(builtPackagesWithInfo, releaseNotes, beforeStagingSha, branchName, 'latest');
     await this.cherryPickChangelogIntoNextBranch(releaseNotes, branchName);
   }

--- a/ng-dev/release/publish/actions/cut-next-prerelease.ts
+++ b/ng-dev/release/publish/actions/cut-next-prerelease.ts
@@ -43,7 +43,7 @@ export class CutNextPrereleaseAction extends ReleaseAction {
         branchName,
       );
 
-    await this.waitForPullRequestToBeMerged(pullRequest);
+    await this.promptAndWaitForPullRequestMerged(pullRequest);
     await this.publish(builtPackagesWithInfo, releaseNotes, beforeStagingSha, branchName, 'next');
 
     // If the pre-release has been cut from a branch that is not corresponding

--- a/ng-dev/release/publish/actions/cut-release-candidate-for-feature-freeze.ts
+++ b/ng-dev/release/publish/actions/cut-release-candidate-for-feature-freeze.ts
@@ -35,7 +35,7 @@ export class CutReleaseCandidateForFeatureFreezeAction extends ReleaseAction {
         branchName,
       );
 
-    await this.waitForPullRequestToBeMerged(pullRequest);
+    await this.promptAndWaitForPullRequestMerged(pullRequest);
     await this.publish(builtPackagesWithInfo, releaseNotes, beforeStagingSha, branchName, 'next');
     await this.cherryPickChangelogIntoNextBranch(releaseNotes, branchName);
   }

--- a/ng-dev/release/publish/actions/cut-stable.ts
+++ b/ng-dev/release/publish/actions/cut-stable.ts
@@ -44,7 +44,7 @@ export class CutStableAction extends ReleaseAction {
         branchName,
       );
 
-    await this.waitForPullRequestToBeMerged(pullRequest);
+    await this.promptAndWaitForPullRequestMerged(pullRequest);
 
     // If a new major version is published, we publish to the `next` NPM dist tag temporarily.
     // We do this because for major versions, we want all main Angular projects to have their

--- a/ng-dev/release/publish/constants.ts
+++ b/ng-dev/release/publish/constants.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/** Default interval in milliseconds to check whether a pull request has been merged. */
-export const waitForPullRequestInterval = 10000;
-
 /**
  * Maximum number of characters a Github release entry can use for its body.  This number was
  * confirmed by reaching out to Github support to confirm the character limit.

--- a/ng-dev/release/publish/prompt-merge.ts
+++ b/ng-dev/release/publish/prompt-merge.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client.js';
+import {bold, green, Log} from '../../utils/logging.js';
+import {Prompt} from '../../utils/prompt.js';
+import {GithubApiRequestError} from '../../utils/git/github.js';
+
+import {PullRequest} from './actions.js';
+import {isPullRequestMerged} from './pull-request-state.js';
+
+/**
+ * Prints the pull request to the console and informs the user about
+ * the process of getting the pull request merged.
+ *
+ * The user will then be prompted, allowing the user to initiate the
+ * merging. The tool will then attempt to merge the pull request
+ * automatically.
+ */
+export async function promptToInitiatePullRequestMerge(
+  git: AuthenticatedGitClient,
+  {id, url}: PullRequest,
+): Promise<void> {
+  Log.info();
+  Log.info();
+  Log.info(green(bold(`      Pull request #${id} is sent out for review: ${url}`)));
+  Log.warn(bold(`      Do not merge it manually. The tool will automatically merge it.`));
+  Log.info('');
+  Log.warn(`      The tool is ${bold('not')} ensuring that all tests pass. Branch protection`);
+  Log.warn('      rules always apply, but other non-required checks can be skipped.');
+  Log.info('');
+  Log.info(`      If you think it is ready (i.e. has the necessary approvals), you can continue`);
+  Log.info(`      by confirming the prompt. The tool will then auto-merge the PR if possible.`);
+  Log.info('');
+
+  // We will loop forever until the PR has been merged. If a user wants to abort,
+  // the script needs to be aborted e.g. using CTRL + C.
+  while (true) {
+    if (!(await Prompt.confirm(`Do you want to continue with merging PR #${id}?`))) {
+      continue;
+    }
+
+    Log.info(`      Attempting to merge pull request #${id}..`);
+    Log.info(``);
+
+    try {
+      // Special logic that will check if the pull request is already merged. This should never
+      // happen but there may be situations where a caretaker merged manually. We wouldn't want
+      // the process to stuck forever here but continue given the caretaker explicitly confirming
+      // that they would like to continue (assuming they expect the PR to be recognized as merged).
+      if (await gracefulCheckIfPullRequestIsMerged(git, id)) {
+        break;
+      }
+
+      const {data, status, headers} = await git.github.pulls.merge({
+        ...git.remoteParams,
+        pull_number: id,
+        merge_method: 'rebase',
+      });
+
+      // If merge is successful, break out of the loop and complete the function.
+      if (data.merged) {
+        break;
+      }
+
+      // Octokit throws for non-200 status codes, but there may be unknown cases
+      // where `merged` is false but we have a 200 status code. We handle this here
+      // and allow for the merge to be re-attempted.
+      Log.error(`  ✘   Pull request #${id} could not be merged.`);
+      Log.error(`      ${data.message} (${status})`);
+      Log.debug(data, status, headers);
+    } catch (e) {
+      if (!(e instanceof GithubApiRequestError)) {
+        throw e;
+      }
+
+      // If there is an request error, e.g. 403 permissions or insufficient permissions
+      // due to active branch protections, then we want to print the message and allow
+      // for the user to re-attempt the merge (by continuing in the loop).
+      Log.error(`  ✘   Pull request #${id} could not be merged.`);
+      Log.error(`      ${e.message} (${e.status})`);
+      Log.debug(e);
+    }
+  }
+
+  Log.info(green(`  ✓   Pull request #${id} has been merged.`));
+}
+
+/** Gracefully checks whether the given pull request has been merged. */
+async function gracefulCheckIfPullRequestIsMerged(
+  git: AuthenticatedGitClient,
+  id: number,
+): Promise<boolean> {
+  try {
+    return await isPullRequestMerged(git, id);
+  } catch (e) {
+    if (e instanceof GithubApiRequestError) {
+      Log.debug(`Unable to determine if pull request #${id} has been merged.`);
+      Log.debug(e);
+      return false;
+    }
+    throw e;
+  }
+}

--- a/ng-dev/release/publish/test/branch-off-next-branch-testing.ts
+++ b/ng-dev/release/publish/test/branch-off-next-branch-testing.ts
@@ -40,7 +40,8 @@ async function expectGithubApiRequestsForBranchOff(
     .expectCommitStatusCheck('PRE_STAGING_SHA', 'success')
     .expectFindForkRequest(fork)
     .expectPullRequestToBeCreated(expectedNewBranch, fork, expectedStagingForkBranch, 200)
-    .expectPullRequestWait(200)
+    .expectPullRequestMergeCheck(200, false)
+    .expectPullRequestMerge(200)
     .expectBranchRequest(expectedNewBranch, 'STAGING_COMMIT_SHA')
     .expectCommitRequest(
       'STAGING_COMMIT_SHA',
@@ -53,7 +54,8 @@ async function expectGithubApiRequestsForBranchOff(
     .expectTagToBeCreated(expectedTagName, 'STAGING_COMMIT_SHA')
     .expectReleaseToBeCreated(`v${expectedVersion}`, expectedTagName)
     .expectPullRequestToBeCreated('master', fork, expectedNextUpdateBranch, 100)
-    .expectPullRequestWait(100);
+    .expectPullRequestMergeCheck(100, false)
+    .expectPullRequestMerge(100);
 
   // In the fork, we make the following branches appear as non-existent,
   // so that the PRs can be created properly without collisions.

--- a/ng-dev/release/publish/test/common.spec.ts
+++ b/ng-dev/release/publish/test/common.spec.ts
@@ -334,7 +334,8 @@ describe('common release action logic', () => {
       repo
         .expectFindForkRequest(fork)
         .expectPullRequestToBeCreated('master', fork, forkBranchName, 200)
-        .expectPullRequestWait(200);
+        .expectPullRequestMergeCheck(200, false)
+        .expectPullRequestMerge(200);
 
       // Simulate that the fork branch name is available.
       fork.expectBranchRequest(forkBranchName, null);
@@ -355,6 +356,25 @@ describe('common release action logic', () => {
       `);
     });
 
+    it('should be possible to complete when pull request is merged manually', async () => {
+      const {repo, fork, instance, gitClient} = setupReleaseActionForTesting(
+        DelegateTestAction,
+        baseReleaseTrains,
+      );
+
+      repo
+        .expectFindForkRequest(fork)
+        .expectPullRequestToBeCreated('master', fork, forkBranchName, 200)
+        .expectPullRequestMergeCheck(200, true);
+
+      // Simulate that the fork branch name is available.
+      fork.expectBranchRequest(forkBranchName, null);
+
+      await instance.testCherryPickWithPullRequest(version, branchName);
+
+      expect(gitClient.pushed.length).toBe(1);
+    });
+
     it('should push changes to a fork for creating a pull request', async () => {
       const {repo, fork, instance, gitClient} = setupReleaseActionForTesting(
         DelegateTestAction,
@@ -366,7 +386,8 @@ describe('common release action logic', () => {
       repo
         .expectFindForkRequest(fork)
         .expectPullRequestToBeCreated('master', fork, forkBranchName, 200)
-        .expectPullRequestWait(200);
+        .expectPullRequestMergeCheck(200, false)
+        .expectPullRequestMerge(200);
 
       // Simulate that the fork branch name is available.
       fork.expectBranchRequest(forkBranchName, null);

--- a/ng-dev/release/publish/test/configure-next-as-major.spec.ts
+++ b/ng-dev/release/publish/test/configure-next-as-major.spec.ts
@@ -69,7 +69,9 @@ describe('configure next as major action', () => {
       .expectBranchRequest('master', 'MASTER_COMMIT_SHA')
       .expectCommitStatusCheck('MASTER_COMMIT_SHA', 'success')
       .expectFindForkRequest(fork)
-      .expectPullRequestToBeCreated('master', fork, expectedForkBranch, 200);
+      .expectPullRequestToBeCreated('master', fork, expectedForkBranch, 200)
+      .expectPullRequestMergeCheck(200, false)
+      .expectPullRequestMerge(200);
 
     // In the fork, we make the staging branch appear as non-existent,
     // so that the PR can be created properly without collisions.

--- a/ng-dev/release/publish/test/test-utils/action-mocks.ts
+++ b/ng-dev/release/publish/test/test-utils/action-mocks.ts
@@ -25,7 +25,7 @@ import {
   ReleaseConfig,
 } from '../../../config/index.js';
 import {NpmCommand} from '../../../versioning/npm-command.js';
-import {PullRequest, ReleaseAction} from '../../actions.js';
+import {ReleaseAction} from '../../actions.js';
 import {DirectoryHash} from '../../directory-hash.js';
 import {ExternalCommands} from '../../external-commands.js';
 
@@ -85,7 +85,8 @@ export function setupMocksForReleaseAction<T extends boolean>(
   setConfig({github: githubConfig, release: releaseConfig});
 
   // Fake confirm any prompts. We do not want to make any changelog edits and
-  // just proceed with the release action.
+  // just proceed with the release action. Also we immediately want to confirm
+  // when we are prompted whether the pull request should be merged.
   spyOn(Prompt, 'confirm').and.resolveTo(true);
 
   const builtPackagesWithInfo: BuiltPackageWithInfo[] = testReleasePackages.map((pkg) => ({
@@ -114,16 +115,6 @@ export function setupMocksForReleaseAction<T extends boolean>(
 
     spyOn(DirectoryHash, 'compute').and.resolveTo(fakePackageContentHash);
   }
-
-  // Override the default pull request wait interval to a number of milliseconds that can be
-  // awaited in Jasmine tests. The default interval of 10sec is too large and causes a timeout.
-  const originalWaitFn = ReleaseAction.prototype['waitForPullRequestToBeMerged'];
-  spyOn(ReleaseAction.prototype, 'waitForPullRequestToBeMerged' as any).and.callFake(function (
-    this: ReleaseAction,
-    pullRequest: PullRequest,
-  ) {
-    return originalWaitFn.call(this, pullRequest, /* interval */ 10);
-  });
 
   // Create an empty changelog and a `package.json` file so that file system
   // interactions with the project directory do not cause exceptions.

--- a/ng-dev/release/publish/test/test-utils/staging-test.ts
+++ b/ng-dev/release/publish/test/test-utils/staging-test.ts
@@ -35,7 +35,8 @@ export async function expectGithubApiRequestsForStaging(
     .expectCommitStatusCheck('PRE_STAGING_SHA', 'success')
     .expectFindForkRequest(fork)
     .expectPullRequestToBeCreated(expectedBranch, fork, expectedStagingForkBranch, 200)
-    .expectPullRequestWait(200)
+    .expectPullRequestMergeCheck(200, false)
+    .expectPullRequestMerge(200)
     .expectBranchRequest(expectedBranch, 'STAGING_COMMIT_SHA')
     .expectCommitRequest(
       'STAGING_COMMIT_SHA',
@@ -57,7 +58,8 @@ export async function expectGithubApiRequestsForStaging(
 
     repo
       .expectPullRequestToBeCreated('master', fork, expectedCherryPickForkBranch, 300)
-      .expectPullRequestWait(300);
+      .expectPullRequestMergeCheck(300, false)
+      .expectPullRequestMerge(300);
 
     // In the fork, make the cherry-pick branch appear as non-existent, so that the
     // cherry-pick PR can be created properly without collisions.

--- a/ng-dev/utils/testing/github-api-testing.ts
+++ b/ng-dev/utils/testing/github-api-testing.ts
@@ -79,10 +79,15 @@ export class GithubTestingRepo {
     return this;
   }
 
-  expectPullRequestWait(prNumber: number): this {
-    // The pull request state could be queried multiple times, so we persist
-    // this mock request. By default, nock only mocks requests once.
-    nock(this.repoApiUrl).get(`/pulls/${prNumber}`).reply(200, {merged: true}).persist();
+  expectPullRequestMergeCheck(prNumber: number, merged: boolean): this {
+    nock(this.repoApiUrl).get(`/pulls/${prNumber}`).reply(200, {merged});
+    nock(this.repoApiUrl).get(`/issues/${prNumber}/events`).reply(200, []);
+
+    return this;
+  }
+
+  expectPullRequestMerge(prNumber: number): this {
+    nock(this.repoApiUrl).put(`/pulls/${prNumber}/merge`).reply(200, {merged: true});
     return this;
   }
 


### PR DESCRIPTION
This PR introduces auto-merging for pull requests created by the release
tooling. This helps with:

* Avoids scenarios where the branches are in a state that would
  throw-off other caretaker tooling. e.g. when the next update PR is not
  merged after branching off.
* Avoiding confusion where the caretaker is not sure whether to use the
  merge tool or how to merge the staging / cherry-pick PRs.
* Uncertainity where release-tool created PRs should go into. Do they
  need a target label?
* Avoiding rate limit issues when e.g. staging PRs are left pending for
  longer durations (e.g. people left it over night already). i.e. it
  looks like Github may prevent connection if we query for PRs every 10 seconds /
  or related `ETimedout` errors. Note: We still expect stable internet
  connection as with bad connections other API requests could fail too.