### PR TITLE
refactor(ng-dev): clean-up merge tool error handling in preparation for fixes

### DIFF
--- a/ng-dev/pr/common/targeting/target-label.ts
+++ b/ng-dev/pr/common/targeting/target-label.ts
@@ -11,7 +11,7 @@ import {getTargetLabelsForActiveReleaseTrains} from './labels.js';
 import {GithubConfig, NgDevConfig} from '../../../utils/config.js';
 import {Commit} from '../../../commit-message/parse.js';
 import {assertChangesAllowForTargetLabel} from '../validation/validations.js';
-import {PullRequestFailure} from '../validation/failures.js';
+import {PullRequestFailure} from '../validation/pull-request-failure.js';
 import {GithubClient} from '../../../utils/git/github.js';
 import {ActiveReleaseTrains} from '../../../release/versioning/index.js';
 

--- a/ng-dev/pr/common/validation/pull-request-failure.ts
+++ b/ng-dev/pr/common/validation/pull-request-failure.ts
@@ -10,16 +10,17 @@ import {breakingChangeLabel} from '../../config/index.js';
 import {TargetLabel} from '../targeting/target-label.js';
 
 /**
- * Class that can be used to describe pull request failures. A failure
- * is described through a human-readable message and a flag indicating
- * whether it is non-fatal or not.
+ * Class that can be used to describe pull request failures.
+ *
+ * A failure is described by a human-readable message and a flag indicating
+ * whether the failure can be forcibly ignore or not.
  */
 export class PullRequestFailure {
   constructor(
     /** Human-readable message for the failure */
     public message: string,
     /** Whether the failure is non-fatal and can be forcibly ignored. */
-    public nonFatal = false,
+    public canBeIgnoredForcibly = false,
   ) {}
 
   static claUnsigned() {
@@ -80,17 +81,6 @@ export class PullRequestFailure {
       `Unable to fixup commit message of pull request. Commit message can only be ` +
         `modified if the PR is merged using squash.`,
     );
-  }
-
-  static notFound() {
-    return new this(`Pull request could not be found upstream.`);
-  }
-
-  static insufficientPermissionsToMerge(
-    message = `Insufficient Github API permissions to merge pull request. Please ensure that ` +
-      `your auth token has write access.`,
-  ) {
-    return new this(message);
   }
 
   static hasBreakingChanges(label: TargetLabel) {

--- a/ng-dev/pr/common/validation/pull-request-failure.ts
+++ b/ng-dev/pr/common/validation/pull-request-failure.ts
@@ -20,7 +20,7 @@ export class PullRequestFailure {
     /** Human-readable message for the failure */
     public message: string,
     /** Whether the failure is non-fatal and can be forcibly ignored. */
-    public canBeIgnoredForcibly = false,
+    public canBeIgnoredNonFatal = false,
   ) {}
 
   static claUnsigned() {

--- a/ng-dev/pr/common/validation/validations.ts
+++ b/ng-dev/pr/common/validation/validations.ts
@@ -9,7 +9,7 @@
 import {Commit} from '../../../commit-message/parse.js';
 import {TargetLabel, TargetLabelName} from '../targeting/target-label.js';
 import {breakingChangeLabel, PullRequestConfig} from '../../config/index.js';
-import {PullRequestFailure} from './failures.js';
+import {PullRequestFailure} from './pull-request-failure.js';
 import {Log, red} from '../../../utils/logging.js';
 import {
   getStatusesForPullRequest,

--- a/ng-dev/pr/merge/cli.ts
+++ b/ng-dev/pr/merge/cli.ts
@@ -10,7 +10,7 @@ import {Argv, Arguments, CommandModule} from 'yargs';
 
 import {addGithubTokenOption} from '../../utils/git/github-yargs.js';
 
-import {mergePullRequest} from './index.js';
+import {mergePullRequest} from './merge-pull-request.js';
 
 /** The options available to the merge command via CLI. */
 export interface MergeCommandOptions {

--- a/ng-dev/pr/merge/failures.ts
+++ b/ng-dev/pr/merge/failures.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** Error class that indicates a fatal merge tool error that cannot be ignored. */
+export class FatalMergeToolError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/** Error class that can be thrown the user aborted the merge manually. */
+export class UserAbortedMergeToolError extends Error {}

--- a/ng-dev/pr/merge/merge-pull-request.ts
+++ b/ng-dev/pr/merge/merge-pull-request.ts
@@ -73,7 +73,7 @@ export async function mergePullRequest(prNumber: number, flags: PullRequestMerge
 
         // If the failure can be ignored forcibly and we didn't attempt the current
         // merge forcibly already, we can prompt and ask for force attempting.
-        if (e.canBeIgnoredForcibly && !ignoreFatalErrors) {
+        if (e.canBeIgnoredNonFatal && !ignoreFatalErrors) {
           Log.info();
           Log.info(yellow('The pull request above failed due to non-critical errors.'));
           Log.info(yellow(`This error can be forcibly ignored if desired.`));

--- a/ng-dev/pr/merge/messages.ts
+++ b/ng-dev/pr/merge/messages.ts
@@ -16,7 +16,7 @@ export function getCaretakerNotePromptMessage(pullRequest: PullRequest): string 
   );
 }
 
-export function getTargettedBranchesConfirmationPromptMessage(pullRequest: PullRequest): string {
+export function getTargetedBranchesConfirmationPromptMessage(pullRequest: PullRequest): string {
   const targetBranchListAsString = pullRequest.targetBranches.map((b) => ` - ${b}\n`).join('');
   return `Pull request #${pullRequest.prNumber} will merge into:\n${targetBranchListAsString}\nDo you want to proceed merging?`;
 }

--- a/ng-dev/pr/merge/pull-request.ts
+++ b/ng-dev/pr/merge/pull-request.ts
@@ -7,7 +7,7 @@
  */
 
 import {parseCommitMessage} from '../../commit-message/parse.js';
-import {PullRequestMergeTask} from './task.js';
+import {MergeTool} from './merge-tool.js';
 import {getTargetBranchesForPullRequest} from '../common/targeting/target-label.js';
 import {
   assertCorrectBreakingChangeLabeling,
@@ -17,7 +17,6 @@ import {
   assertPassingCi,
 } from '../common/validation/validations.js';
 import {fetchPullRequestFromGithub} from '../common/fetch-pull-request.js';
-import {PullRequestFailure} from '../common/validation/pull-request-failure.js';
 import {FatalMergeToolError} from './failures.js';
 
 /** Interface that describes a pull request. */
@@ -54,7 +53,7 @@ export interface PullRequest {
  *   does not exist upstream.
  */
 export async function loadAndValidatePullRequest(
-  {git, config}: PullRequestMergeTask,
+  {git, config}: MergeTool,
   prNumber: number,
   ignoreNonFatalFailures = false,
 ): Promise<PullRequest> {

--- a/ng-dev/pr/merge/strategies/autosquash-merge.ts
+++ b/ng-dev/pr/merge/strategies/autosquash-merge.ts
@@ -8,7 +8,7 @@
 
 import {dirname, join} from 'path';
 import {fileURLToPath} from 'url';
-import {PullRequestFailure} from '../../common/validation/failures.js';
+import {PullRequestFailure} from '../../common/validation/pull-request-failure.js';
 import {PullRequest} from '../pull-request.js';
 import {MergeStrategy, TEMP_PR_HEAD_BRANCH} from './strategy.js';
 
@@ -27,9 +27,10 @@ export class AutosquashMergeStrategy extends MergeStrategy {
    * would causes unnecessary multiple fetch requests when multiple PRs are merged.
    * @throws {GitCommandError} An unknown Git command error occurred that is not
    *   specific to the pull request merge.
-   * @returns A pull request failure or null in case of success.
+   * @throws {PullRequestFailure} A pull request failure if the the pull request could not
+   *   be merged and the pull request is misconfigured.
    */
-  override async merge(pullRequest: PullRequest): Promise<PullRequestFailure | null> {
+  override async merge(pullRequest: PullRequest): Promise<void> {
     const {prNumber, targetBranches, requiredBaseSha, needsCommitMessageFixup, githubTargetBranch} =
       pullRequest;
     // In case a required base is specified for this pull request, check if the pull
@@ -38,7 +39,7 @@ export class AutosquashMergeStrategy extends MergeStrategy {
     // a commit that changes the codeowner ship validation. PRs which are not rebased
     // could bypass new codeowner ship rules.
     if (requiredBaseSha && !this.git.hasCommit(TEMP_PR_HEAD_BRANCH, requiredBaseSha)) {
-      return PullRequestFailure.unsatisfiedBaseSha();
+      throw PullRequestFailure.unsatisfiedBaseSha();
     }
 
     // SHA for the first commit the pull request is based on. Usually we would able
@@ -86,7 +87,7 @@ export class AutosquashMergeStrategy extends MergeStrategy {
     const failedBranches = this.cherryPickIntoTargetBranches(revisionRange, targetBranches);
 
     if (failedBranches.length) {
-      return PullRequestFailure.mergeConflicts(failedBranches);
+      throw PullRequestFailure.mergeConflicts(failedBranches);
     }
 
     this.pushTargetBranchesUpstream(targetBranches);
@@ -116,8 +117,6 @@ export class AutosquashMergeStrategy extends MergeStrategy {
         state: 'closed',
       });
     }
-
-    return null;
   }
 }
 

--- a/ng-dev/pr/merge/strategies/strategy.ts
+++ b/ng-dev/pr/merge/strategies/strategy.ts
@@ -7,7 +7,6 @@
  */
 
 import {AuthenticatedGitClient} from '../../../utils/git/authenticated-git-client.js';
-import {PullRequestFailure} from '../../common/validation/failures.js';
 import {PullRequest} from '../pull-request.js';
 
 /**
@@ -38,8 +37,13 @@ export abstract class MergeStrategy {
   /**
    * Performs the merge of the given pull request. This needs to be implemented
    * by individual merge strategies.
+   *
+   * @throws {PullRequestFailure} A pull request failure if the the pull request could not
+   *   be merged and the pull request is misconfigured.
+   * @throws {FatalMergeToolError} A fatal error has occurred when attempting to merge the
+   *   pull request.
    */
-  abstract merge(pullRequest: PullRequest): Promise<null | PullRequestFailure>;
+  abstract merge(pullRequest: PullRequest): Promise<void>;
 
   /** Cleans up the pull request merge. e.g. deleting temporary local branches. */
   async cleanup(pullRequest: PullRequest) {


### PR DESCRIPTION
Cleans up the merge tool error handling by not passing through failures
and having uncaught errors at the same time. This results in confusion
and easily results in errors accidentally not being caught/handled
correctly.

Instead, we always use error try/catch and throwing similar to how its
done in the release tool. This is more safe, predictable and readable.

This is in preparation of fixing some of the force skip behavior of
the merge tool. This does currently not seem to work and broke at
some point..