### PR TITLE
ci: allow yarn scripts as Renovate post-upgrade tasks

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -4,6 +4,7 @@ module.exports = {
   platform: 'github',
   forkMode: true,
   onboarding: false,
+  allowedPostUpgradeCommands: ['^yarn run '],
   repositories: [
     'angular/angular',
     'angular/dev-infra',


### PR DESCRIPTION
Allow downstream repositories to define Renovate post-upgrade tasks to be run after each upgrade. To keep a balance between security and flexibility, only commands that are defined as yarn scripts are allowed to be used as post-upgrade tasks

For more info on configuring post-upgrade tasks in Renovate, see:
- [postUpgradeTasks][1]
- [allowedPostUpgradeCommands][2]
- [allowPostUpgradeCommandTemplating][3]

[1]: https://docs.renovatebot.com/configuration-options/#postupgradetasks
[2]: https://docs.renovatebot.com/self-hosted-configuration/#allowedpostupgradecommands
[3]: https://docs.renovatebot.com/self-hosted-configuration/#allowpostupgradecommandtemplating