### PR TITLE
ci: hard-code allowed commands for Renovate post-upgrade tasks

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -4,7 +4,10 @@ module.exports = {
   platform: 'github',
   forkMode: true,
   onboarding: false,
-  allowedPostUpgradeCommands: ['^yarn run '],
+  allowedPostUpgradeCommands: [
+    // See https://github.com/angular/angular/pull/47040.
+    '^yarn --cwd=aio/tools/examples/shared run sync-deps$',
+  ],
   repositories: [
     'angular/angular',
     'angular/dev-infra',


### PR DESCRIPTION
The [allowedPostUpgradeCommands][1] pattern list is used to determine whether a [post-upgrade task][2] command is allowed to be run by Renovate. Using a regex to try and limit the type of commands that can be run is not a viable strategy.

This commit hard-codes the exact command that needs to run for angular.io docs examples dependencies (see angular/angular#47040).

Hard-coding commands requires updates in multiple places when a post-upgrade task is added/modified, but adds one more layer of protection against running unwanted commands as part of the Renovate update process.

[1]: https://docs.renovatebot.com/self-hosted-configuration/#allowedpostupgradecommands
[2]: https://docs.renovatebot.com/configuration-options/#postupgradetasks