### PR TITLE
fix(ng-dev): use `x-access-token` as username for git url

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -66941,7 +66941,7 @@ var GITHUB_TOKEN_GENERATE_URL = "https://github.com/settings/tokens/new";
 function addTokenToGitHttpsUrl(githubHttpsUrl, token) {
   const url = new URL2(githubHttpsUrl);
   url.password = token;
-  url.username = "_";
+  url.username = "x-access-token";
   return url.href;
 }
 function getRepositoryGitUrl(config2, githubToken) {

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -69256,7 +69256,7 @@ var GITHUB_TOKEN_GENERATE_URL = "https://github.com/settings/tokens/new";
 function addTokenToGitHttpsUrl(githubHttpsUrl, token) {
   const url = new URL2(githubHttpsUrl);
   url.password = token;
-  url.username = "_";
+  url.username = "x-access-token";
   return url.href;
 }
 function getRepositoryGitUrl(config, githubToken) {

--- a/ng-dev/utils/git/github-urls.ts
+++ b/ng-dev/utils/git/github-urls.ts
@@ -21,7 +21,7 @@ export const GITHUB_TOKEN_GENERATE_URL = 'https://github.com/settings/tokens/new
 export function addTokenToGitHttpsUrl(githubHttpsUrl: string, token: string) {
   const url = new URL(githubHttpsUrl);
   url.password = token;
-  url.username = '_';
+  url.username = 'x-access-token';
   return url.href;
 }
 

--- a/ng-dev/utils/testing/virtual-git-matchers.ts
+++ b/ng-dev/utils/testing/virtual-git-matchers.ts
@@ -27,13 +27,13 @@ export function getBranchPushMatcher(options: BranchPushMatchParameters) {
   const {targetRepo, targetBranch, baseBranch, baseRepo, expectedCommits} = options;
   return jasmine.objectContaining({
     remote: {
-      repoUrl: `https://_:abc123@github.com/${targetRepo.owner}/${targetRepo.name}.git`,
+      repoUrl: `https://x-access-token:abc123@github.com/${targetRepo.owner}/${targetRepo.name}.git`,
       name: `refs/heads/${targetBranch}`,
     },
     head: jasmine.objectContaining({
       newCommits: expectedCommits,
       ref: {
-        repoUrl: `https://_:abc123@github.com/${baseRepo.owner}/${baseRepo.name}.git`,
+        repoUrl: `https://x-access-token:abc123@github.com/${baseRepo.owner}/${baseRepo.name}.git`,
         name: baseBranch,
       },
     }),


### PR DESCRIPTION
When providing authentication via URL the username should be set to `x-access-token` based on
documentation for Github Apps.