### PR TITLE
refactor(ng-dev/format): use command module syntax for defining commands in ng-dev format commands

### DIFF
--- a/ng-dev/format/all.ts
+++ b/ng-dev/format/all.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Argv, Arguments, CommandModule} from 'yargs';
+
+import {GitClient} from '../utils/git/git-client.js';
+import {checkFiles, formatFiles} from './format.js';
+
+/** Command line options. */
+export interface Options {
+  check: boolean;
+}
+
+/** Yargs command builder for the command. */
+function builder(argv: Argv): Argv<Options> {
+  return argv.option('check', {
+    type: 'boolean',
+    default: process.env['CI'] ? true : false,
+    description: 'Run the formatter to check formatting rather than updating code format',
+  });
+}
+
+/** Yargs command handler for the command. */
+async function handler({check}: Arguments<Options>) {
+  const git = await GitClient.get();
+  const executionCmd = check ? checkFiles : formatFiles;
+  const allFiles = git.allFiles();
+  process.exitCode = await executionCmd(allFiles);
+}
+
+/** CLI command module. */
+export const AllFilesModule: CommandModule<{}, Options> = {
+  builder,
+  handler,
+  command: 'all',
+  describe: 'Run the formatter on all files in the repository',
+};

--- a/ng-dev/format/changed.ts
+++ b/ng-dev/format/changed.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Argv, Arguments, CommandModule} from 'yargs';
+
+import {GitClient} from '../utils/git/git-client.js';
+import {checkFiles, formatFiles} from './format.js';
+
+/** Command line options. */
+export interface Options {
+  shaOrRef?: string;
+  check: boolean;
+}
+
+/** Yargs command builder for the command. */
+function builder(argv: Argv): Argv<Options> {
+  return argv
+    .option('check', {
+      type: 'boolean',
+      default: process.env['CI'] ? true : false,
+      description: 'Run the formatter to check formatting rather than updating code format',
+    })
+    .positional('shaOrRef', {type: 'string'});
+}
+
+/** Yargs command handler for the command. */
+async function handler({shaOrRef, check}: Arguments<Options>) {
+  const git = await GitClient.get();
+  const sha = shaOrRef || git.mainBranchName;
+  const executionCmd = check ? checkFiles : formatFiles;
+  const allChangedFilesSince = git.allChangesFilesSince(sha);
+  process.exitCode = await executionCmd(allChangedFilesSince);
+}
+
+/** CLI command module. */
+export const ChangedModule: CommandModule<{}, Options> = {
+  builder,
+  handler,
+  command: 'changed [shaOrRef]',
+  describe: 'Run the formatter on files changed since the provided sha/ref',
+};

--- a/ng-dev/format/files.ts
+++ b/ng-dev/format/files.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Argv, Arguments, CommandModule} from 'yargs';
+
+import {checkFiles, formatFiles} from './format.js';
+
+/** Command line options. */
+export interface Options {
+  files: string[];
+  check: boolean;
+}
+
+/** Yargs command builder for the command. */
+function builder(argv: Argv): Argv<Options> {
+  return argv
+    .option('check', {
+      type: 'boolean',
+      default: process.env['CI'] ? true : false,
+      description: 'Run the formatter to check formatting rather than updating code format',
+    })
+    .positional('files', {array: true, type: 'string', demandOption: true});
+}
+
+/** Yargs command handler for the command. */
+async function handler({files, check}: Arguments<Options>) {
+  const executionCmd = check ? checkFiles : formatFiles;
+  process.exitCode = await executionCmd(files);
+}
+
+/** CLI command module. */
+export const FilesModule: CommandModule<{}, Options> = {
+  builder,
+  handler,
+  command: 'files <files..>',
+  describe: 'Run the formatter on provided files',
+};

--- a/ng-dev/format/staged.ts
+++ b/ng-dev/format/staged.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Argv, Arguments, CommandModule} from 'yargs';
+
+import {GitClient} from '../utils/git/git-client.js';
+import {checkFiles, formatFiles} from './format.js';
+
+/** Command line options. */
+export interface Options {
+  check: boolean;
+}
+
+/** Yargs command builder for the command. */
+function builder(argv: Argv): Argv<Options> {
+  return argv.option('check', {
+    type: 'boolean',
+    default: process.env['CI'] ? true : false,
+    description: 'Run the formatter to check formatting rather than updating code format',
+  });
+}
+
+/** Yargs command handler for the command. */
+async function handler({check}: Arguments<Options>) {
+  const git = await GitClient.get();
+  const executionCmd = check ? checkFiles : formatFiles;
+  const allStagedFiles = git.allStagedFiles();
+  process.exitCode = await executionCmd(allStagedFiles);
+  if (!check && process.exitCode === 0) {
+    git.runGraceful(['add', ...allStagedFiles]);
+  }
+}
+
+/** CLI command module. */
+export const StagedModule: CommandModule<{}, Options> = {
+  builder,
+  handler,
+  command: 'staged',
+  describe: 'Run the formatter on all staged files',
+};


### PR DESCRIPTION
Migrating to the command module syntax to align with the other command sets.