### PR TITLE
fix(ng-dev): properly encode URLs for GitHub queries in caretaker check

### DIFF
--- a/ng-dev/caretaker/check/github.spec.ts
+++ b/ng-dev/caretaker/check/github.spec.ts
@@ -54,18 +54,33 @@ describe('GithubQueriesModule', () => {
           issueCount: 1,
           nodes: [{url: 'http://github.com/owner/name/issue/1'}],
         },
+        'query_with_colon': {
+          issueCount: 0,
+          nodes: [],
+        },
       });
       const module = new GithubQueriesModule(git, {
         ...mockNgDevConfig,
-        caretaker: {githubQueries: [{name: 'key name with spaces', query: 'issue: yes'}]},
+        caretaker: {
+          githubQueries: [
+            {name: 'key name with spaces', query: 'issue: yes'},
+            {name: 'query_with_colon', query: 'is:milestone'},
+          ],
+        },
       });
 
       expect(await module.data).toEqual([
         {
           queryName: 'key name with spaces',
           count: 1,
-          queryUrl: 'https://github.com/owner/name/issues?q=issue:%20yes',
+          queryUrl: 'https://github.com/owner/name/issues?q=issue%3A%20yes',
           matchedUrls: ['http://github.com/owner/name/issue/1'],
+        },
+        {
+          queryName: 'query_with_colon',
+          count: 0,
+          queryUrl: 'https://github.com/owner/name/issues?q=is%3Amilestone',
+          matchedUrls: [],
         },
       ]);
     });

--- a/ng-dev/caretaker/check/github.ts
+++ b/ng-dev/caretaker/check/github.ts
@@ -66,10 +66,13 @@ export class GithubQueriesModule extends BaseModule<GithubQueryResults | void> {
     const {owner, name: repo} = this.git.remoteConfig;
 
     return results.map((result, i) => {
+      const query = queries[i];
+      const queryURLParam = encodeURIComponent(query.query);
+
       return {
-        queryName: queries[i].name,
+        queryName: query.name,
         count: result.issueCount,
-        queryUrl: encodeURI(`https://github.com/${owner}/${repo}/issues?q=${queries[i].query}`),
+        queryUrl: `https://github.com/${owner}/${repo}/issues?q=${queryURLParam}`,
         matchedUrls: result.nodes.map((node) => node.url),
       };
     });


### PR DESCRIPTION
The URLs constructed by `caretaker/github.ts` were incorrectly escaped
and ended up e.g. not escaping a colon in URLs.