### PR TITLE
fix(ng-dev): properly catch errors for finding the ng-dev token in the filesystem

### DIFF
--- a/ng-dev/auth/shared/ng-dev-token.ts
+++ b/ng-dev/auth/shared/ng-dev-token.ts
@@ -106,7 +106,11 @@ async function saveTokenToFileSystem(data: NgDevUserWithToken) {
 
 /** Retrieve the token from the file system. */
 async function retrieveTokenFromFileSystem(): Promise<NgDevUserWithToken | null> {
-  if (!(await stat(tokenPath))) {
+  try {
+    if (!(await stat(tokenPath))) {
+      return null;
+    }
+  } catch {
     return null;
   }
 


### PR DESCRIPTION
Run the stat call inside of a try catch so that it properly fails as null