### PR TITLE
fix(ng-dev): always include the github token option on merge.

### DIFF
--- a/ng-dev/utils/ng-dev-service.ts
+++ b/ng-dev/utils/ng-dev-service.ts
@@ -15,7 +15,10 @@ import {
   restoreNgTokenFromDiskIfValid,
 } from '../auth/shared/ng-dev-token.js';
 import {assertValidGithubConfig, getConfig} from './config.js';
-import {configureGitClientWithTokenOrFromEnvironment} from './git/github-yargs.js';
+import {
+  addGithubTokenOption,
+  configureGitClientWithTokenOrFromEnvironment,
+} from './git/github-yargs.js';
 import {Log} from './logging.js';
 
 /** Configuration for the firebase application used for ng-dev token management. */
@@ -44,7 +47,7 @@ export async function useNgDevService<T>(
   const {github} = await getConfig([assertValidGithubConfig]);
 
   if (github.useNgDevAuthService !== true) {
-    return argv;
+    return addGithubTokenOption(argv);
   }
 
   return (


### PR DESCRIPTION
During the transition from using the github token to using the ng-dev auth service, we
need to always include the github token option. If we fail to include the option, when
the `useNgDevAuthService` config value is not set to `true` no authentication mechanism
for Github will be present.