### PR TITLE
feat(ng-dev/ts-circular-dependencies): support ignoring type only imports/exports for circular dependency checks

### DIFF
--- a/ng-dev/ts-circular-dependencies/analyzer.ts
+++ b/ng-dev/ts-circular-dependencies/analyzer.ts
@@ -40,7 +40,7 @@ export class Analyzer {
 
   constructor(
     public resolveModuleFn?: ModuleResolver,
-    {ignoreTypeOnlyChecks}: CircularDependenciesParserOptions = {},
+    ignoreTypeOnlyChecks: boolean = false,
     public extensions: string[] = DEFAULT_EXTENSIONS,
   ) {
     this._ignoreTypeOnlyChecks = !!ignoreTypeOnlyChecks;

--- a/ng-dev/ts-circular-dependencies/analyzer.ts
+++ b/ng-dev/ts-circular-dependencies/analyzer.ts
@@ -9,6 +9,7 @@
 import {readFileSync} from 'fs';
 import {dirname, join, resolve} from 'path';
 import ts from 'typescript';
+import {CircularDependenciesParserOptions} from './config.js';
 
 import {getFileStatus} from './file_system.js';
 import {getModuleReferences} from './parser.js';
@@ -32,13 +33,18 @@ const DEFAULT_EXTENSIONS = ['ts', 'js', 'd.ts'];
 export class Analyzer {
   private _sourceFileCache = new Map<string, ts.SourceFile>();
 
+  private _ignoreTypeOnlyChecks: boolean;
+
   unresolvedModules = new Set<string>();
   unresolvedFiles = new Map<string, string[]>();
 
   constructor(
     public resolveModuleFn?: ModuleResolver,
+    {ignoreTypeOnlyChecks}: CircularDependenciesParserOptions = {},
     public extensions: string[] = DEFAULT_EXTENSIONS,
-  ) {}
+  ) {
+    this._ignoreTypeOnlyChecks = !!ignoreTypeOnlyChecks;
+  }
 
   /** Finds all cycles in the specified source file. */
   findCycles(
@@ -61,7 +67,7 @@ export class Analyzer {
     visited.add(sf);
     // Go through all edges, which are determined through import/exports, and collect cycles.
     const result: ReferenceChain[] = [];
-    for (const ref of getModuleReferences(sf)) {
+    for (const ref of getModuleReferences(sf, this._ignoreTypeOnlyChecks)) {
       const targetFile = this._resolveImport(ref, sf.fileName);
       if (targetFile !== null) {
         result.push(...this.findCycles(this.getSourceFile(targetFile), visited, path.slice()));

--- a/ng-dev/ts-circular-dependencies/config.ts
+++ b/ng-dev/ts-circular-dependencies/config.ts
@@ -12,8 +12,14 @@ import {Log} from '../utils/logging.js';
 
 import {ModuleResolver} from './analyzer.js';
 
+/** Options used at runtime by the parser.  */
+export interface CircularDependenciesParserOptions {
+  /** Whether to ignore type only imports in circular dependency checks. */
+  ignoreTypeOnlyChecks?: true;
+}
+
 /** Configuration for a circular dependencies test. */
-export interface CircularDependenciesTestConfig {
+export interface CircularDependenciesTestConfig extends CircularDependenciesParserOptions {
   /** Base directory used for shortening paths in the golden file. */
   baseDir: string;
   /** Path to the golden file that is used for checking and approving. */

--- a/ng-dev/ts-circular-dependencies/index.ts
+++ b/ng-dev/ts-circular-dependencies/index.ts
@@ -68,7 +68,7 @@ export function main(
   printWarnings: boolean,
 ): number {
   const {baseDir, goldenFile, glob: globPattern, resolveModule, approveCommand} = config;
-  const analyzer = new Analyzer(resolveModule);
+  const analyzer = new Analyzer(resolveModule, config);
   const cycles: ReferenceChain[] = [];
   const checkedNodes = new WeakSet<ts.SourceFile>();
 

--- a/ng-dev/ts-circular-dependencies/index.ts
+++ b/ng-dev/ts-circular-dependencies/index.ts
@@ -67,8 +67,15 @@ export function main(
   config: CircularDependenciesTestConfig,
   printWarnings: boolean,
 ): number {
-  const {baseDir, goldenFile, glob: globPattern, resolveModule, approveCommand} = config;
-  const analyzer = new Analyzer(resolveModule, config);
+  const {
+    baseDir,
+    goldenFile,
+    glob: globPattern,
+    resolveModule,
+    approveCommand,
+    ignoreTypeOnlyChecks,
+  } = config;
+  const analyzer = new Analyzer(resolveModule, ignoreTypeOnlyChecks);
   const cycles: ReferenceChain[] = [];
   const checkedNodes = new WeakSet<ts.SourceFile>();
 


### PR DESCRIPTION
By setting a configuration, imports/exports which use the `type` keyword to indicate they are type-only imports/exports
are ignored with respect to circular dependency checks.



This circular dependency would be considered a circular dependency by the tool:

**File 1:**
```ts
import type {symbol} from './file-2';

export const coolSymbol: boolean = true;
...
```

**File 2:**
```ts
import {coolSymbol} from './file-1';

export const symbol: Symbol =  Symbol();
...
```


By enabling `ignoreTypeOnlyChecks`, the `type` import is ignored, resulting in no circular dependency.