### PR TITLE
fix(ng-dev): use token to determine if the AuthenticatedGitClient has been configured

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -68650,7 +68650,7 @@ Alternatively, a new token can be created at: ${GITHUB_TOKEN_GENERATE_URL}
     return AuthenticatedGitClient._authenticatedInstance;
   }
   static configure(token, userType = "user") {
-    if (AuthenticatedGitClient._authenticatedInstance) {
+    if (AuthenticatedGitClient._token) {
       throw Error("Unable to configure `AuthenticatedGitClient` as it has been configured already.");
     }
     AuthenticatedGitClient._token = token;

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -70023,7 +70023,7 @@ Alternatively, a new token can be created at: ${GITHUB_TOKEN_GENERATE_URL}
     return AuthenticatedGitClient._authenticatedInstance;
   }
   static configure(token, userType = "user") {
-    if (AuthenticatedGitClient._authenticatedInstance) {
+    if (AuthenticatedGitClient._token) {
       throw Error("Unable to configure `AuthenticatedGitClient` as it has been configured already.");
     }
     AuthenticatedGitClient._token = token;

--- a/ng-dev/utils/git/authenticated-git-client.ts
+++ b/ng-dev/utils/git/authenticated-git-client.ts
@@ -188,7 +188,7 @@ export class AuthenticatedGitClient extends GitClient {
 
   /** Configures an authenticated git client. */
   static configure(token: string, userType: UserType = 'user'): void {
-    if (AuthenticatedGitClient._authenticatedInstance) {
+    if (AuthenticatedGitClient._token) {
       throw Error(
         'Unable to configure `AuthenticatedGitClient` as it has been configured already.',
       );


### PR DESCRIPTION
Previously we allowed for the AuthenticatedGitClient to be configured multiple times before
it `get` was called, however this is incorrect as only one configuration is to be allowed.