### PR TITLE
feat(ng-dev): automatically remove credentials generated by ng-dev auth service after use

### DIFF
--- a/ng-dev/auth/shared/ng-dev-token.ts
+++ b/ng-dev/auth/shared/ng-dev-token.ts
@@ -161,7 +161,14 @@ export function configureAuthorizedGitClientWithTemporaryToken() {
       });
 
       // Close the socket whenever the command which established it is complete.
-      registerCompletedFunction(() => socket.close());
+      registerCompletedFunction(async () => {
+        socket.close();
+
+        // After the action is done, request it to be forgotten by the local git client as it is no
+        // longer valid.
+        const git = await AuthenticatedGitClient.get();
+        git.runGraceful(['credential', 'reject'], {input: `url=${git.getRepoGitUrl()}\n\n`});
+      });
 
       // When the token is provided via the websocket message, use the token to set up
       // the AuthenticatedGitClient. The token is valid as long as the socket remains open,


### PR DESCRIPTION
After use, the credentials generated by the ng-dev auth service are automatically requested
to be removed from any git credential helper which is currently active.