### PR TITLE
ci: allow any command for Renovate post-upgrade tasks

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -4,10 +4,7 @@ module.exports = {
   platform: 'github',
   forkMode: true,
   onboarding: false,
-  allowedPostUpgradeCommands: [
-    // See https://github.com/angular/angular/pull/47040.
-    '^yarn --cwd=aio/tools/examples/shared run sync-deps$',
-  ],
+  allowedPostUpgradeCommands: ['.'],
   repositories: [
     'angular/angular',
     'angular/dev-infra',


### PR DESCRIPTION
The [allowedPostUpgradeCommands][1] pattern list is used to determine whether a [post-upgrade task][2] command is allowed to be run by Renovate. Having to explicitly allow each command creates unnecessary friction.

This commit allows any command to be run in a post-upgrade task, which saves us the trouble of having to update the allowed commands pattern list every time we want to add a new post-upgrade task.
Since adding/modifying Renovate post-upgrade tasks is subject to the regular PR review workflow, unwanted commands will be caught there.

##
_INFO: [Internal discussion][3]_

[1]: https://docs.renovatebot.com/self-hosted-configuration/#allowedpostupgradecommands
[2]: https://docs.renovatebot.com/configuration-options/#postupgradetasks
[3]: https://angular-team.slack.com/archives/C029MM6RS4B/p1659605197808499
