### PR TITLE
fix(apps): ensure credential service login only works with `@google.com` mail

### DIFF
--- a/apps/account-functions/before-create.ts
+++ b/apps/account-functions/before-create.ts
@@ -1,8 +1,11 @@
 import {Auth, https, UserRecord} from 'gcip-cloud-functions';
 
-/** Validate accounts before their creation using google cloud before create syncronous function. */
+/**
+ * Validate accounts before their creation using google cloud before create
+ * synchronous function.
+ */
 export const beforeCreate = new Auth().functions().beforeCreateHandler((user: UserRecord) => {
-  if (user.email && user.email.indexOf('@google.com') === -1) {
+  if (user.email && !user.email.endsWith('@google.com')) {
     throw new https.HttpsError('invalid-argument', `Unauthorized email "${user.email}"`);
   }
 


### PR DESCRIPTION
Currently we just test if @google.com is part of the email. With custom
domains it looks like this could be abused to something like:

`paul@google.com.my-domain.net`