### PR TITLE
fix(bazel/browsers): exclude a log file that chromium writes to on linux causing cache misses

### DIFF
--- a/bazel/browsers/chromium/chromium.bzl
+++ b/bazel/browsers/chromium/chromium.bzl
@@ -21,6 +21,11 @@ def define_chromium_repositories():
         named_files = {
             "CHROMIUM": "chrome-linux/chrome",
         },
+        exclude_patterns = [
+            # Exclude a log file that chromium writes to each run, causing remote cache
+            # misses in downstream targets.
+            "chrome-linux/chrome_debug.log",
+        ],
     )
 
     browser_archive(


### PR DESCRIPTION
@devversion I think this is the source of cache misses I'm seeing in https://github.com/angular/angular/pull/47161. In unsandboxed execution (which is the case for targets run under RBE, right?) chromium will write to this log file each run in under the `external` dir causing remote cache misses on successive builds.