### PR TITLE
fix(ng-dev): order results of forks when searching for user owned forks

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -65437,7 +65437,7 @@ var findOwnedForksOfRepoQuery = (0, import_typed_graphqlify2.params)({
   $name: "String!"
 }, {
   repository: (0, import_typed_graphqlify2.params)({ owner: "$owner", name: "$name" }, {
-    forks: (0, import_typed_graphqlify2.params)({ affiliations: "OWNER", first: 1 }, {
+    forks: (0, import_typed_graphqlify2.params)({ affiliations: "OWNER", first: 1, orderBy: { field: "NAME", direction: "ASC" } }, {
       nodes: [
         {
           owner: {

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -63521,7 +63521,7 @@ var findOwnedForksOfRepoQuery = (0, import_typed_graphqlify.params)({
   $name: "String!"
 }, {
   repository: (0, import_typed_graphqlify.params)({ owner: "$owner", name: "$name" }, {
-    forks: (0, import_typed_graphqlify.params)({ affiliations: "OWNER", first: 1 }, {
+    forks: (0, import_typed_graphqlify.params)({ affiliations: "OWNER", first: 1, orderBy: { field: "NAME", direction: "ASC" } }, {
       nodes: [
         {
           owner: {

--- a/ng-dev/utils/git/graphql-queries.ts
+++ b/ng-dev/utils/git/graphql-queries.ts
@@ -22,7 +22,7 @@ export const findOwnedForksOfRepoQuery = params(
       {owner: '$owner', name: '$name'},
       {
         forks: params(
-          {affiliations: 'OWNER', first: 1},
+          {affiliations: 'OWNER', first: 1, orderBy: {field: 'NAME', direction: 'ASC'}},
           {
             nodes: [
               {


### PR DESCRIPTION
It appears that Github has made a change, or has introduced a bug in which unsorted results of forks for a repository with OWNER affiliation are returned as empty.  Once ordering is provided the results show again as expected.  While this should not be necessary, it is an innocuous change for us that is fine to remain indefinitely.