### PR TITLE
build: set top level permissions to read only for ng-renovate config

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -1,8 +1,14 @@
 name: Angular-Org Renovate
+
 on:
   workflow_dispatch:
   schedule:
     - cron: '0/30 * * * *' # Runs every 30 minutes.
+
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
since we don't use the github actions robot account for permissions, we can just use
read only access here


Fixes https://github.com/angular/dev-infra/security/code-scanning/16