### PR TITLE
feat(create-pr-for-changes): allow specifying a base branch

### DIFF
--- a/github-actions/create-pr-for-changes/action.yml
+++ b/github-actions/create-pr-for-changes/action.yml
@@ -8,6 +8,15 @@ description: |
 author: Angular
 
 inputs:
+  base-branch:
+    required: false
+    default: ${{ github.ref_name }}
+    description: |
+      The base branch of the pull request (if one is created).
+
+      Defaults to the branch that the workflow was triggered on.
+
+      Example: `base-branch: my-patch-branch`
   branch-prefix:
     required: true
     description: |

--- a/github-actions/create-pr-for-changes/lib/main.ts
+++ b/github-actions/create-pr-for-changes/lib/main.ts
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
 
     // Unless configured otherwise, clean up obsolete branches.
     const branchPrefix = `${core.getInput('branch-prefix', {required: true})}-`;
-    const cleanUpBranches = core.getInput('clean-up-branches', {required: false}) === 'true';
+    const cleanUpBranches = core.getInput('clean-up-branches', {required: true}) === 'true';
     const forkRepo = await git.getForkOfAuthenticatedUser();
 
     if (cleanUpBranches) {
@@ -79,7 +79,7 @@ async function main(): Promise<void> {
     //   Hashing the contents of the changed files is a heuristic to uniquely-ish represent a
     //   particular set of changes. It is not 100% accurate (and could result in both false
     //   positives and false negatives), but should be good enough for our purposes.
-    const baseBranch = context.ref.replace(/^refs\/heads\//, '');
+    const baseBranch = core.getInput('base-branch', {required: true});
     const branchName = `${branchPrefix}${repo.owner}-${repo.name}-${baseBranch}-${hashFiles(
       touchedFiles,
     )}`;

--- a/github-actions/create-pr-for-changes/main.js
+++ b/github-actions/create-pr-for-changes/main.js
@@ -24749,7 +24749,7 @@ async function main() {
     git.run(["config", "user.name", "Angular Robot"]);
     core.info("Initialized git/GitHub client.");
     const branchPrefix = `${core.getInput("branch-prefix", { required: true })}-`;
-    const cleanUpBranches = core.getInput("clean-up-branches", { required: false }) === "true";
+    const cleanUpBranches = core.getInput("clean-up-branches", { required: true }) === "true";
     const forkRepo = await git.getForkOfAuthenticatedUser();
     if (cleanUpBranches) {
       await cleanUpObsoleteBranches(git, repo, forkRepo, branchPrefix);
@@ -24761,7 +24761,7 @@ async function main() {
     } else {
       core.info(`Found ${touchedFiles.length} affected file(s).`);
     }
-    const baseBranch = import_github4.context.ref.replace(/^refs\/heads\//, "");
+    const baseBranch = core.getInput("base-branch", { required: true });
     const branchName = `${branchPrefix}${repo.owner}-${repo.name}-${baseBranch}-${hashFiles(touchedFiles)}`;
     const { data: matchingPrs } = await git.github.pulls.list({
       owner: repo.owner,


### PR DESCRIPTION
Previously, the `create-pr-for-changes` GitHub action would use the branch that the workflow was triggered on as the base branch. This prevented the action from being used on other branches as part of a [scheduled workflow][1], since scheduled workflows are only triggered on the default branch of a repository.

This commit adds the ability to specify a different base branch. If not specified, this defaults to the branch the workflow was triggered on, as before.

[1]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule