### PR TITLE
feat(bazel/remote-execution): expose exec_properties constant to enable networking on remote exec platform

### DIFF
--- a/bazel/remote-execution/BUILD.bazel
+++ b/bazel/remote-execution/BUILD.bazel
@@ -1,3 +1,5 @@
+load(":index.bzl", "ENABLE_NETWORK")
+
 package(default_visibility = ["//visibility:public"])
 
 platform(
@@ -31,16 +33,14 @@ platform(
 
 platform(
     name = "platform_with_network",
-    exec_properties = {
-        # By default we have network access disabled with the `:platform` target. This is an
-        # additional platform that extends from the default one but enables network access.
-        # Network is generally not recommended, but for some exceptions, like integration tests
-        # running a Yarn install, network access is reasonable. In such special cases, Bazel can
-        # be invoked to run with this platform. It is recommended that exec platforms with network
-        # access are used in combination with `--sandbox_default_allow_network=false` as this allows
-        # specific targets to be granted network access, while others will not have access.
-        "dockerNetwork": "standard",
-    },
+    # By default we have network access disabled with the `:platform` target. This is an
+    # additional platform that extends from the default one but enables network access.
+    # Network is generally not recommended, but for some exceptions, like integration tests
+    # running a Yarn install, network access is reasonable. In such special cases, Bazel can
+    # be invoked to run with this platform. It is recommended that exec platforms with network
+    # access are used in combination with `--sandbox_default_allow_network=false` as this allows
+    # specific targets to be granted network access, while others will not have access.
+    exec_properties = ENABLE_NETWORK,
     parents = [":platform"],
 )
 
@@ -48,6 +48,7 @@ filegroup(
     name = "files",
     srcs = [
         "BUILD.bazel",
+        "index.bzl",
         "//bazel/remote-execution/cpp:files",
     ],
 )

--- a/bazel/remote-execution/index.bzl
+++ b/bazel/remote-execution/index.bzl
@@ -1,0 +1,3 @@
+# Value for exec_properties that can be added to any target to enable
+# networking when `:platform` is used, which disables networking by default.
+ENABLE_NETWORK = {"dockerNetwork": "standard"}


### PR DESCRIPTION
@devversion 