### PR TITLE
fix(ng-dev/release): avoid accidentally incorporating unexpected changes in release build

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -195,11 +195,20 @@ export abstract class ReleaseAction {
 
     // Commit message for the release point.
     const commitMessage = getCommitMessageForRelease(newVersion);
+
     // Create a release staging commit including changelog and version bump.
     await this.createCommit(commitMessage, [
       workspaceRelativePackageJsonPath,
       workspaceRelativeChangelogPath,
     ]);
+
+    // The caretaker may have attempted to make additional changes. These changes would
+    // not be captured into the release commit. The working directory should remain clean,
+    // like we assume it being clean when we start the release actions.
+    if (this.git.hasUncommittedChanges()) {
+      Log.error('  ✘   Unrelated changes have been made as part of the changelog editing.');
+      throw new FatalReleaseActionError();
+    }
 
     Log.info(green(`  ✓   Created release commit for: "${newVersion}".`));
   }

--- a/ng-dev/release/publish/test/test-utils/action-mocks.ts
+++ b/ng-dev/release/publish/test/test-utils/action-mocks.ts
@@ -87,7 +87,7 @@ export function setupMocksForReleaseAction<T extends boolean>(
   // Fake confirm any prompts. We do not want to make any changelog edits and
   // just proceed with the release action. Also we immediately want to confirm
   // when we are prompted whether the pull request should be merged.
-  spyOn(Prompt, 'confirm').and.resolveTo(true);
+  const promptConfirmSpy = spyOn(Prompt, 'confirm').and.resolveTo(true);
 
   const builtPackagesWithInfo: BuiltPackageWithInfo[] = testReleasePackages.map((pkg) => ({
     ...pkg,
@@ -136,5 +136,5 @@ export function setupMocksForReleaseAction<T extends boolean>(
     );
   }
 
-  return {gitClient, builtPackagesWithInfo};
+  return {gitClient, builtPackagesWithInfo, promptConfirmSpy};
 }

--- a/ng-dev/release/publish/test/test-utils/test-action.ts
+++ b/ng-dev/release/publish/test/test-utils/test-action.ts
@@ -7,6 +7,7 @@
  */
 
 import {GithubConfig} from '../../../../utils/config.js';
+import {Prompt} from '../../../../utils/prompt.js';
 import {
   GithubTestingRepo,
   SandboxGitClient,
@@ -57,6 +58,7 @@ export interface TestReleaseAction<
   projectDir: string;
   githubConfig: GithubConfig;
   releaseConfig: ReleaseConfig;
+  promptConfirmSpy: jasmine.Spy<typeof Prompt['confirm']>;
   builtPackagesWithInfo: BuiltPackageWithInfo[];
   gitClient: O['useSandboxGitClient'] extends true ? SandboxGitClient : VirtualGitClient;
 }

--- a/ng-dev/release/publish/test/test-utils/test-utils.ts
+++ b/ng-dev/release/publish/test/test-utils/test-utils.ts
@@ -61,7 +61,7 @@ export function setupReleaseActionForTesting<
   });
 
   // Setup mocks for release action.
-  const {gitClient, builtPackagesWithInfo} = setupMocksForReleaseAction<
+  const {gitClient, builtPackagesWithInfo, promptConfirmSpy} = setupMocksForReleaseAction<
     OptionsWithDefaults['useSandboxGitClient']
   >(
     githubConfig,
@@ -81,6 +81,7 @@ export function setupReleaseActionForTesting<
     githubConfig,
     releaseConfig,
     gitClient,
+    promptConfirmSpy,
     builtPackagesWithInfo,
   };
 }


### PR DESCRIPTION
There is an interesting scenario where the caretaker may make unexpected non-changelog changes as part of the short prompt where we allow manual polishing to the changelog.

If the caretaker modified other files there, they will NOT be part of the release cutting PR (and also shouldn't be) - but currently the changes are not discarded/or detected and WILL influence the release output building. This could cause subtle differences and confusion because the release output is different than what we committed (because the release cut commits will not incorporate the other non-changelog changes).

The fix is to properly detect other modifications and abort properly. Other changes should be made beforehand, go through review process and should not be part of the release cut commit.