### PR TITLE
feat(ng-dev): support `target: feature` in merge tooling

### DIFF
--- a/ng-dev/pr/common/targeting/labels.ts
+++ b/ng-dev/pr/common/targeting/labels.ts
@@ -137,6 +137,17 @@ export async function getTargetLabelsForActiveReleaseTrains(
         return [nextBranchName, releaseCandidate.branchName];
       },
     },
+    {
+      name: TargetLabelName.FEATURE_BRANCH,
+      branches: (githubTargetBranch) => {
+        if (isVersionBranch(githubTargetBranch) || githubTargetBranch === nextBranchName) {
+          throw new InvalidTargetBranchError(
+            '"target: feature" pull requests cannot target a releasable branch',
+          );
+        }
+        return [githubTargetBranch];
+      },
+    },
   ];
 
   // LTS branches can only be determined if the release configuration is defined, and must be added

--- a/ng-dev/pr/common/targeting/target-label.ts
+++ b/ng-dev/pr/common/targeting/target-label.ts
@@ -33,6 +33,7 @@ export enum TargetLabelName {
   PATCH = 'target: patch',
   RELEASE_CANDIDATE = 'target: rc',
   LONG_TERM_SUPPORT = 'target: lts',
+  FEATURE_BRANCH = 'target: feature',
 }
 
 /**


### PR DESCRIPTION
Support the usage of a target label for feature branches `target: feature`.