### PR TITLE
build: add exports_files attribute to browser_archive for use downstream

### DIFF
--- a/bazel/browsers/browser_archive_repo.bzl
+++ b/bazel/browsers/browser_archive_repo.bzl
@@ -37,10 +37,13 @@ browser_configure(
   named_files = %s,
   visibility = ["//visibility:public"],
 )
+
+exports_files(%s)
 """ % (
         str(ctx.attr.licenses),
         str(ctx.attr.exclude_patterns),
         str(ctx.attr.named_files),
+        str(ctx.attr.exports_files),
     ))
 
 """
@@ -103,6 +106,17 @@ browser_archive = repository_rule(
               This is useful for example when files with spaces are shipped as part of the
               archives of browsers. Runfiles with spaces cause issues within Bazel and if
               these files are not strictly needed, they should be omitted.
+            """,
+        ),
+        "exports_files": attr.string_list(
+            default = [],
+            doc = """Patterns of files which should be added to exports_files.
+
+              This is useful for example when files with spaces are shipped as part of the
+              archives of browsers. Instead of individual files, the top-level source directory
+              can be depended on which resolves the runfiles with spaces issue. NB: source
+              directories are not compatible with remote execution so a target that uses sources
+              directory inputs should be tagged "local".
             """,
         ),
     },

--- a/bazel/browsers/chromium/chromium.bzl
+++ b/bazel/browsers/chromium/chromium.bzl
@@ -26,6 +26,7 @@ def define_chromium_repositories():
             # misses in downstream targets.
             "chrome-linux/chrome_debug.log",
         ],
+        exports_files = ["chrome-linux"],
     )
 
     browser_archive(
@@ -40,6 +41,7 @@ def define_chromium_repositories():
         named_files = {
             "CHROMIUM": "chrome-mac/Chromium.app/Contents/MacOS/Chromium",
         },
+        exports_files = ["chrome-mac"],
     )
 
     browser_archive(
@@ -54,6 +56,7 @@ def define_chromium_repositories():
         named_files = {
             "CHROMIUM": "chrome-mac/Chromium.app/Contents/MacOS/Chromium",
         },
+        exports_files = ["chrome-mac"],
     )
 
     browser_archive(
@@ -72,6 +75,7 @@ def define_chromium_repositories():
             # Exclude files with spaces to prevent errors when symlinked as runfiles (https://github.com/bazelbuild/bazel/issues/4327).
             "chrome-win/First Run",
         ],
+        exports_files = ["chrome-win"],
     )
 
     browser_archive(


### PR DESCRIPTION
This is a pre-req to the angular/universal Bazel migration underway in https://github.com/angular/universal/pull/2787
