### PR TITLE
fix(circleci-orb): support empty input parameters when e.g. running in cronjob

### DIFF
--- a/circleci-orb/BUILD.bazel
+++ b/circleci-orb/BUILD.bazel
@@ -2,7 +2,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 ORB_NAME = "angular/dev-infra"
 
-ORB_VERSION = "1.0.2"
+ORB_VERSION = "1.0.3"
 
 nodejs_binary(
     name = "pack_orb_script",

--- a/circleci-orb/commands/rebase-pr-on-target-branch.yml
+++ b/circleci-orb/commands/rebase-pr-on-target-branch.yml
@@ -3,14 +3,16 @@ description: Rebase PR on the target branch
 parameters:
   head_revision:
     type: string
+    default: ''
     description: The `pipeline.git.revision` pipeline value.
   base_revision:
     type: string
+    default: ''
     description: The `pipeline.git.base_revision` pipeline value.
   primary_branch_name:
     type: string
-    description: The primary branch for the repository.
     default: 'main'
+    description: The primary branch for the repository.
   shell:
     type: string
     default: ''

--- a/circleci-orb/scripts/rebase-pr-on-target-branch/ref-branch-list.ts
+++ b/circleci-orb/scripts/rebase-pr-on-target-branch/ref-branch-list.ts
@@ -25,7 +25,11 @@ export function getRefFromBranchList(gitOutput: string, primaryBranchName: strin
     return b.split('/').slice(1).join('/').trim();
   });
 
-  const sorted = branches.sort((a: string, b: string) => {
+  if (branches.length === 0) {
+    throw new Error(`Could not find ref from branch list: ${gitOutput}`);
+  }
+
+  branches.sort((a: string, b: string) => {
     if (a === primaryBranchName) {
       return -1;
     }
@@ -56,8 +60,5 @@ export function getRefFromBranchList(gitOutput: string, primaryBranchName: strin
     return 0;
   });
 
-  if (sorted.length === 0) {
-    throw new Error(`Could not find ref from branch list: ${gitOutput}`);
-  }
-  return sorted[0];
+  return branches[0];
 }


### PR DESCRIPTION
CircleCI cronjobs do not have the base revision or revision pipeline variables, so they may be empty. To avoid using empty variables which would then cause errors in our shared command- we support the empty string fallback. The command will be a noop anyway since we check for these variables in the actual script.

See: https://app.circleci.com/pipelines/github/angular/components/44462.