### PR TITLE
build: enable org wide action to sync labels

### DIFF
--- a/.github/workflows/org-wide-actions.yml
+++ b/.github/workflows/org-wide-actions.yml
@@ -1,0 +1,22 @@
+name: Angular Org Actions
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Runs once per day.
+
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    if: github.repository == 'angular/dev-infra'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+      - run: ./github-actions/labels-sync
+        with:
+          angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
+          repos: |
+            dev-infra


### PR DESCRIPTION
Initially only set up the dev-infra repo confirm the sync works as expected.