### PR TITLE
refactor(ng-dev/pr): update standard label descriptions to be <= 100 characters

### DIFF
--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -32092,7 +32092,7 @@ var actionLabels = createTypedObject()({
     label: "action: merge"
   },
   ACTION_CLEANUP: {
-    description: "The PR is in need of cleanup, either due to needing a rebase or in response to comments from a review",
+    description: "The PR is in need of cleanup, either due to needing a rebase or in response to comments from reviews",
     label: "action: cleanup"
   },
   ACTION_PRESUBMIT: {
@@ -32157,15 +32157,15 @@ var targetLabels = createTypedObject()({
 var priorityLabels = createTypedObject()({
   P0: {
     label: "P0",
-    description: "An issue that causes a full outage, breakage, or major function unavailability for everyone, without any known workaround. The issue must be fixed immediately, taking precedence over all other work. Should receive updates at least once per day"
+    description: "Issue that causes an outage, breakage, or major function to be unusable, with no known workarounds"
   },
   P1: {
     label: "P1",
-    description: "An issue that significantly impacts a large percentage of users; if there is a workaround it is partial or overly painful. The issue should be resolved before the next release"
+    description: "Impacts a large percentage of users; if a workaround exists it is partial or overly painful"
   },
   P2: {
     label: "P2",
-    description: "The issue is important to a large percentage of users, with a workaround. Issues that are significantly ugly or painful (especially first-use or install-time issues). Issues with workarounds that would otherwise be P0 or P1"
+    description: "The issue is important to a large percentage of users, with a workaround"
   },
   P3: {
     label: "P3",
@@ -32173,11 +32173,11 @@ var priorityLabels = createTypedObject()({
   },
   P4: {
     label: "P4",
-    description: "A relatively minor issue that is not relevant to core functions, or relates only to the attractiveness or pleasantness of use of the system. Good to have but not necessary changes/fixes"
+    description: "A relatively minor issue that is not relevant to core functions"
   },
   P5: {
     label: "P5",
-    description: "The team acknowledges the request but (due to any number of reasons) does not plan to work on or accept contributions for this request. The issue remains open for discussion"
+    description: "The team acknowledges the request but does not plan to address it, it remains open for discussion"
   }
 });
 

--- a/github-actions/labels-sync/main.js
+++ b/github-actions/labels-sync/main.js
@@ -23354,7 +23354,7 @@ var actionLabels = createTypedObject()({
     label: "action: merge"
   },
   ACTION_CLEANUP: {
-    description: "The PR is in need of cleanup, either due to needing a rebase or in response to comments from a review",
+    description: "The PR is in need of cleanup, either due to needing a rebase or in response to comments from reviews",
     label: "action: cleanup"
   },
   ACTION_PRESUBMIT: {
@@ -23419,15 +23419,15 @@ var targetLabels = createTypedObject()({
 var priorityLabels = createTypedObject()({
   P0: {
     label: "P0",
-    description: "An issue that causes a full outage, breakage, or major function unavailability for everyone, without any known workaround. The issue must be fixed immediately, taking precedence over all other work. Should receive updates at least once per day"
+    description: "Issue that causes an outage, breakage, or major function to be unusable, with no known workarounds"
   },
   P1: {
     label: "P1",
-    description: "An issue that significantly impacts a large percentage of users; if there is a workaround it is partial or overly painful. The issue should be resolved before the next release"
+    description: "Impacts a large percentage of users; if a workaround exists it is partial or overly painful"
   },
   P2: {
     label: "P2",
-    description: "The issue is important to a large percentage of users, with a workaround. Issues that are significantly ugly or painful (especially first-use or install-time issues). Issues with workarounds that would otherwise be P0 or P1"
+    description: "The issue is important to a large percentage of users, with a workaround"
   },
   P3: {
     label: "P3",
@@ -23435,11 +23435,11 @@ var priorityLabels = createTypedObject()({
   },
   P4: {
     label: "P4",
-    description: "A relatively minor issue that is not relevant to core functions, or relates only to the attractiveness or pleasantness of use of the system. Good to have but not necessary changes/fixes"
+    description: "A relatively minor issue that is not relevant to core functions"
   },
   P5: {
     label: "P5",
-    description: "The team acknowledges the request but (due to any number of reasons) does not plan to work on or accept contributions for this request. The issue remains open for discussion"
+    description: "The team acknowledges the request but does not plan to address it, it remains open for discussion"
   }
 });
 

--- a/ng-dev/pr/common/BUILD.bazel
+++ b/ng-dev/pr/common/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
 
 ts_library(
     name = "common",
@@ -8,6 +8,7 @@ ts_library(
         ],
         exclude = [
             "labels.ts",
+            "*.spec.ts",
         ],
     ),
     visibility = [
@@ -40,5 +41,22 @@ ts_library(
     ],
     deps = [
         "//ng-dev/pr/common/labels",
+    ],
+)
+
+ts_library(
+    name = "test_lib",
+    testonly = True,
+    srcs = glob(["*.spec.ts"]),
+    deps = [
+        ":labels",
+        "@npm//@types/jasmine",
+    ],
+)
+
+jasmine_node_test(
+    name = "test",
+    specs = [
+        ":test_lib",
     ],
 )

--- a/ng-dev/pr/common/labels/action.ts
+++ b/ng-dev/pr/common/labels/action.ts
@@ -9,7 +9,7 @@ export const actionLabels = createTypedObject<ActionLabel>()({
   },
   ACTION_CLEANUP: {
     description:
-      'The PR is in need of cleanup, either due to needing a rebase or in response to comments from a review',
+      'The PR is in need of cleanup, either due to needing a rebase or in response to comments from reviews',
     label: 'action: cleanup',
   },
   ACTION_PRESUBMIT: {

--- a/ng-dev/pr/common/labels/priority.ts
+++ b/ng-dev/pr/common/labels/priority.ts
@@ -6,17 +6,16 @@ export const priorityLabels = createTypedObject<PriorityLabel>()({
   P0: {
     label: 'P0',
     description:
-      'An issue that causes a full outage, breakage, or major function unavailability for everyone, without any known workaround. The issue must be fixed immediately, taking precedence over all other work. Should receive updates at least once per day',
+      'Issue that causes an outage, breakage, or major function to be unusable, with no known workarounds',
   },
   P1: {
     label: 'P1',
     description:
-      'An issue that significantly impacts a large percentage of users; if there is a workaround it is partial or overly painful. The issue should be resolved before the next release',
+      'Impacts a large percentage of users; if a workaround exists it is partial or overly painful',
   },
   P2: {
     label: 'P2',
-    description:
-      'The issue is important to a large percentage of users, with a workaround. Issues that are significantly ugly or painful (especially first-use or install-time issues). Issues with workarounds that would otherwise be P0 or P1',
+    description: 'The issue is important to a large percentage of users, with a workaround',
   },
   P3: {
     label: 'P3',
@@ -25,12 +24,11 @@ export const priorityLabels = createTypedObject<PriorityLabel>()({
   },
   P4: {
     label: 'P4',
-    description:
-      'A relatively minor issue that is not relevant to core functions, or relates only to the attractiveness or pleasantness of use of the system. Good to have but not necessary changes/fixes',
+    description: 'A relatively minor issue that is not relevant to core functions',
   },
   P5: {
     label: 'P5',
     description:
-      'The team acknowledges the request but (due to any number of reasons) does not plan to work on or accept contributions for this request. The issue remains open for discussion',
+      'The team acknowledges the request but does not plan to address it, it remains open for discussion',
   },
 });

--- a/ng-dev/pr/common/validate-labels.spec.ts
+++ b/ng-dev/pr/common/validate-labels.spec.ts
@@ -1,0 +1,9 @@
+import {allLabels} from './labels.js';
+
+describe('All labels:', () => {
+  for (const {label, description} of Object.values(allLabels)) {
+    it(`description for "${label}" is less than or equal to 100 characters`, () => {
+      expect(description.length).toBeLessThanOrEqual(100);
+    });
+  }
+});


### PR DESCRIPTION
Github only allows for descriptions to be 100 characters, and as such, standard labels must comply with this requirement.