### PR TITLE
Refactor validations

### DIFF
--- a/ng-dev/pr/common/validation/validate-pull-request.ts
+++ b/ng-dev/pr/common/validation/validate-pull-request.ts
@@ -19,6 +19,7 @@ import {passingCiValidation} from './assert-passing-ci.js';
 import {pendingStateValidation} from './assert-pending.js';
 import {signedClaValidation} from './assert-signed-cla.js';
 import {PullRequestValidationConfig} from './validation-config.js';
+import {PullRequestValidationFailure} from './validation-failure.js';
 
 /**
  * Asserts that the given pull request is valid. Certain non-fatal validations
@@ -35,27 +36,38 @@ export async function assertValidPullRequest(
   ngDevConfig: NgDevConfig<{pullRequest: PullRequestConfig; github: GithubConfig}>,
   activeReleaseTrains: ActiveReleaseTrains | null,
   target: PullRequestTarget,
-): Promise<void> {
+): Promise<PullRequestValidationFailure[]> {
   const labels = pullRequest.labels.nodes.map((l) => l.name);
   const commitsInPr = pullRequest.commits.nodes.map((n) => {
     return parseCommitMessage(n.commit.message);
   });
 
-  await mergeReadyValidation.run(validationConfig, pullRequest);
-  await signedClaValidation.run(validationConfig, pullRequest);
-  await pendingStateValidation.run(validationConfig, pullRequest);
+  const validationResults = [
+    mergeReadyValidation.run(validationConfig, pullRequest),
+    signedClaValidation.run(validationConfig, pullRequest),
+    pendingStateValidation.run(validationConfig, pullRequest),
+    breakingChangeInfoValidation.run(validationConfig, commitsInPr, labels),
+    passingCiValidation.run(validationConfig, pullRequest),
+  ];
 
   if (activeReleaseTrains !== null) {
-    await changesAllowForTargetLabelValidation.run(
-      validationConfig,
-      commitsInPr,
-      target.labelName,
-      ngDevConfig.pullRequest,
-      activeReleaseTrains,
-      labels,
+    validationResults.push(
+      changesAllowForTargetLabelValidation.run(
+        validationConfig,
+        commitsInPr,
+        target.labelName,
+        ngDevConfig.pullRequest,
+        activeReleaseTrains,
+        labels,
+      ),
     );
   }
 
-  await breakingChangeInfoValidation.run(validationConfig, commitsInPr, labels);
-  await passingCiValidation.run(validationConfig, pullRequest);
+  return Promise.all(validationResults).then((results) => {
+    return results.filter(
+      <(result: null | PullRequestValidationFailure) => result is PullRequestValidationFailure>(
+        ((result) => result !== null)
+      ),
+    );
+  });
 }

--- a/ng-dev/pr/common/validation/validate-pull-request.ts
+++ b/ng-dev/pr/common/validation/validate-pull-request.ts
@@ -41,16 +41,21 @@ export async function assertValidPullRequest(
     return parseCommitMessage(n.commit.message);
   });
 
-  await mergeReadyValidation.run(validationConfig, (v) => v.assert(pullRequest));
-  await signedClaValidation.run(validationConfig, (v) => v.assert(pullRequest));
-  await pendingStateValidation.run(validationConfig, (v) => v.assert(pullRequest));
+  await mergeReadyValidation.run(validationConfig, pullRequest);
+  await signedClaValidation.run(validationConfig, pullRequest);
+  await pendingStateValidation.run(validationConfig, pullRequest);
 
   if (activeReleaseTrains !== null) {
-    await changesAllowForTargetLabelValidation.run(validationConfig, (v) =>
-      v.assert(commitsInPr, target.labelName, ngDevConfig.pullRequest, activeReleaseTrains, labels),
+    await changesAllowForTargetLabelValidation.run(
+      validationConfig,
+      commitsInPr,
+      target.labelName,
+      ngDevConfig.pullRequest,
+      activeReleaseTrains,
+      labels,
     );
   }
 
-  await breakingChangeInfoValidation.run(validationConfig, (v) => v.assert(commitsInPr, labels));
-  await passingCiValidation.run(validationConfig, (v) => v.assert(pullRequest));
+  await breakingChangeInfoValidation.run(validationConfig, commitsInPr, labels);
+  await passingCiValidation.run(validationConfig, pullRequest);
 }

--- a/ng-dev/pr/common/validation/validate-pull-request.ts
+++ b/ng-dev/pr/common/validation/validate-pull-request.ts
@@ -22,13 +22,10 @@ import {PullRequestValidationConfig} from './validation-config.js';
 import {PullRequestValidationFailure} from './validation-failure.js';
 
 /**
- * Asserts that the given pull request is valid. Certain non-fatal validations
- * can be disabled through the validation config.
+ * Runs all valiations that the given pull request is valid, returning a list of all failing
+ * validations.
  *
  * Active release trains may be available for additional checks or not.
- *
- * @throws {PullRequestValidationFailure} A validation failure will be raised when
- *   an activated validation failed.
  */
 export async function assertValidPullRequest(
   pullRequest: PullRequestFromGithub,

--- a/ng-dev/pr/common/validation/validation-config.ts
+++ b/ng-dev/pr/common/validation/validation-config.ts
@@ -55,7 +55,7 @@ export function createPullRequestValidation<T extends PullRequestValidation>(
           (message) => new PullRequestValidationFailure(message, name, canBeForceIgnored),
         );
         try {
-          validation.assert(args);
+          validation.assert(...args);
         } catch (e) {
           if (e instanceof PullRequestValidationFailure) {
             return e;

--- a/ng-dev/pr/common/validation/validation-failure.ts
+++ b/ng-dev/pr/common/validation/validation-failure.ts
@@ -12,8 +12,10 @@ import {PullRequestValidationConfig} from './validation-config.js';
 export class PullRequestValidationFailure {
   constructor(
     /** Human-readable message for the failure */
-    public message: string,
+    public readonly message: string,
     /** Validation config name for the failure. */
-    public validationName: keyof PullRequestValidationConfig,
+    public readonly validationName: keyof PullRequestValidationConfig,
+    /** Validation config name for the failure. */
+    public readonly canBeForceIgnored: boolean,
   ) {}
 }

--- a/ng-dev/pr/merge/failures.ts
+++ b/ng-dev/pr/merge/failures.ts
@@ -13,8 +13,11 @@ export class FatalMergeToolError extends Error {
   }
 }
 
-/** Error class that can be thrown when the user aborted the merge manually. */
-export class UserAbortedMergeToolError extends Error {}
+export class UserAbortedMergeToolError extends FatalMergeToolError {
+  constructor() {
+    super('Tool exited due to user aborting merge attempt.');
+  }
+}
 
 export class MismatchedTargetBranchFatalError extends FatalMergeToolError {
   constructor(allowedBranches: string[]) {
@@ -40,5 +43,11 @@ export class MergeConflictsFatalError extends FatalMergeToolError {
       `Could not merge pull request into the following branches due to merge ` +
         `conflicts: ${failedBranches.join(', ')}. Please rebase the PR or update the target label.`,
     );
+  }
+}
+
+export class PullRequestValidationError extends FatalMergeToolError {
+  constructor() {
+    super('Tool exited as at least one pull request validation error was discovered.');
   }
 }

--- a/ng-dev/pr/merge/merge-pull-request.ts
+++ b/ng-dev/pr/merge/merge-pull-request.ts
@@ -20,7 +20,6 @@ import {
   UserAbortedMergeToolError,
 } from './failures.js';
 import {PullRequestValidationConfig} from '../common/validation/validation-config.js';
-import {PullRequestValidationFailure} from '../common/validation/validation-failure.js';
 
 /**
  * Merges a given pull request based on labels configured in the given merge configuration.

--- a/ng-dev/pr/merge/merge-pull-request.ts
+++ b/ng-dev/pr/merge/merge-pull-request.ts
@@ -69,8 +69,7 @@ export async function mergePullRequest(prNumber: number, flags: PullRequestMerge
         return false;
       }
       if (e instanceof PullRequestValidationFailure) {
-        Log.error(`Pull request did not pass validation check. Error:`);
-        Log.error(` -> ${bold(e.message)}`);
+        Log.error(`Pull request did not pass validation check. See above for specific errors`);
         return false;
       }
 

--- a/ng-dev/pr/merge/merge-tool.ts
+++ b/ng-dev/pr/merge/merge-tool.ts
@@ -98,15 +98,16 @@ export class MergeTool {
         Log.error(` -> ${bold(failure.message)}`);
       }
       Log.info();
-      if (pullRequest.validationFailures.some((failure) => !failure.canBeForceIgnored)) {
-        Log.info(yellow(`All discovered validations are non-fatal and can be forcibly ignored.`));
 
-        if (await Prompt.confirm('Do you want to forcibly ignore these validation failures?')) {
-          return;
-        }
+      if (pullRequest.validationFailures.some((failure) => !failure.canBeForceIgnored)) {
+        Log.debug('Discovered a fatal error, which cannot be forced');
+        throw new PullRequestValidationError();
       }
 
-      throw new PullRequestValidationError();
+      Log.info(yellow(`All discovered validations are non-fatal and can be forcibly ignored.`));
+      if (!(await Prompt.confirm('Do you want to forcibly ignore these validation failures?'))) {
+        throw new PullRequestValidationError();
+      }
     }
 
     if (this.flags.forceManualBranches) {

--- a/ng-dev/pr/merge/merge-tool.ts
+++ b/ng-dev/pr/merge/merge-tool.ts
@@ -28,7 +28,11 @@ import {
   getNextBranchName,
 } from '../../release/versioning/index.js';
 import {Prompt} from '../../utils/prompt.js';
-import {FatalMergeToolError, UserAbortedMergeToolError} from './failures.js';
+import {
+  FatalMergeToolError,
+  PullRequestValidationError,
+  UserAbortedMergeToolError,
+} from './failures.js';
 import {PullRequestValidationConfig} from '../common/validation/validation-config.js';
 import {PullRequestValidationFailure} from '../common/validation/validation-failure.js';
 
@@ -94,7 +98,7 @@ export class MergeTool {
         Log.error(` -> ${bold(failure.message)}`);
       }
       Log.info();
-      if (pullRequest.validationFailures.find((failure) => !failure.canBeForceIgnored)) {
+      if (pullRequest.validationFailures.some((failure) => !failure.canBeForceIgnored)) {
         Log.info(yellow(`All discovered validations are non-fatal and can be forcibly ignored.`));
 
         if (await Prompt.confirm('Do you want to forcibly ignore these validation failures?')) {
@@ -102,7 +106,7 @@ export class MergeTool {
         }
       }
 
-      throw pullRequest.validationFailures[0];
+      throw new PullRequestValidationError();
     }
 
     if (this.flags.forceManualBranches) {

--- a/ng-dev/pr/merge/pull-request.ts
+++ b/ng-dev/pr/merge/pull-request.ts
@@ -47,7 +47,7 @@ export interface PullRequest {
   baseSha: string;
   /** Git revision range that matches the pull request commits. */
   revisionRange: string;
-
+  /** A list of validation failures found for the pull request, empty if no failures are discovered. */
   validationFailures: PullRequestValidationFailure[];
 }
 
@@ -55,8 +55,6 @@ export interface PullRequest {
  * Loads and validates the specified pull request against the given configuration.
  * If the pull requests fails, a pull request failure is returned.
  *
- * @throws {PullRequestValidationFailure} A pull request failure if the pull request does not
- *   pass the validation.
  * @throws {FatalMergeToolError} A fatal error might be thrown when e.g. the pull request
  *   does not exist upstream.
  */

--- a/ng-dev/pr/merge/pull-request.ts
+++ b/ng-dev/pr/merge/pull-request.ts
@@ -19,6 +19,7 @@ import {PullRequestValidationConfig} from '../common/validation/validation-confi
 import {assertValidPullRequest} from '../common/validation/validate-pull-request.js';
 import {TEMP_PR_HEAD_BRANCH} from './strategies/strategy.js';
 import {mergeLabels} from '../common/labels.js';
+import {PullRequestValidationFailure} from '../common/validation/validation-failure.js';
 
 /** Interface that describes a pull request. */
 export interface PullRequest {
@@ -46,6 +47,8 @@ export interface PullRequest {
   baseSha: string;
   /** Git revision range that matches the pull request commits. */
   revisionRange: string;
+
+  validationFailures: PullRequestValidationFailure[];
 }
 
 /**
@@ -99,7 +102,13 @@ export async function loadAndValidatePullRequest(
     );
   }
 
-  await assertValidPullRequest(prData, validationConfig, config, activeReleaseTrains, target);
+  const validationFailures = await assertValidPullRequest(
+    prData,
+    validationConfig,
+    config,
+    activeReleaseTrains,
+    target,
+  );
 
   const requiredBaseSha =
     config.pullRequest.requiredBaseCommits &&
@@ -127,6 +136,7 @@ export async function loadAndValidatePullRequest(
     baseSha,
     revisionRange,
     hasCaretakerNote,
+    validationFailures,
     targetBranches: target.branches,
     title: prData.title,
     commitCount: prData.commits.totalCount,


### PR DESCRIPTION
Part of the intent here is to separate our pull request validation from pull request merging so we can perform validations outside of actual merges.