### PR TITLE
build: keep `branchNameStrict` set to `true`

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -2,6 +2,7 @@ module.exports = {
   branchPrefix: 'ng-renovate/',
   gitAuthor: 'Angular Robot <angular-robot@google.com>',
   platform: 'github',
+  branchNameStrict: true,
   forkMode: true,
   onboarding: false,
   allowedPostUpgradeCommands: ['.'],


### PR DESCRIPTION
Renovate had a breaking change in v33 and reverted in v34. Since we were already on v33- we want to keep the strict branch names given that we already had new PRs sent out.

See https://github.com/renovatebot/renovate/releases/tag/34.0.0 for details.