### PR TITLE
build: do not use test-results grather command in platform CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,6 @@ jobs:
       # TODO: Remove this once https://bugzilla.mozilla.org/show_bug.cgi?id=1754821#c3 is resolved.
       - run: mkdir "$HOME/Library/Application Support/Firefox"
       - run: yarn bazel test --test_tag_filters=macos --build_tests_only -- //... -//bazel/remote-execution/...
-      - prepare_and_store_test_results
       - *save_cache
 
   test_windows_x64:
@@ -148,7 +147,6 @@ jobs:
       - *restore_cache
       - yarn_install
       - run: yarn bazel test --test_tag_filters=windows --build_tests_only -- ... -bazel/remote-execution/...
-      - prepare_and_store_test_results
       - *save_cache
 
   lint:


### PR DESCRIPTION
Currently we end up building all of ng-dev in the Windows/MacOS job-even though we only are interested in some fine-grained selected targets. Also the ng-dev gather build fails on Windows likely due to no full windows Bazel setup. 

It's not worth investigating- our windows-specific tests run as expected and pass.