### PR TITLE
feat(ng-dev/caretaker): add status urls to caretaker check

### DIFF
--- a/ng-dev/caretaker/check/services.spec.ts
+++ b/ng-dev/caretaker/check/services.spec.ts
@@ -18,7 +18,11 @@ describe('ServicesModule', () => {
   let infoGroupSpy: jasmine.Spy;
   let git: AuthenticatedGitClient;
 
-  services.splice(0, Infinity, {url: 'fakeStatus.com/api.json', name: 'Service Name'});
+  services.splice(0, Infinity, {
+    url: 'fakeStatus.com/api.json',
+    prettyUrl: 'fakeStatus.com',
+    name: 'Service Name',
+  });
 
   beforeEach(async () => {
     getStatusFromStandardApiSpy = spyOn(ServicesModule.prototype, 'getStatusFromStandardApi');
@@ -35,6 +39,7 @@ describe('ServicesModule', () => {
       expect(getStatusFromStandardApiSpy).toHaveBeenCalledWith({
         url: 'fakeStatus.com/api.json',
         name: 'Service Name',
+        prettyUrl: 'fakeStatus.com',
       });
     });
   });
@@ -47,12 +52,14 @@ describe('ServicesModule', () => {
           status: 'passing',
           description: 'Everything is working great',
           lastUpdated: new Date(0),
+          statusUrl: 'http://google.com',
         },
         {
           name: 'Service 2',
           status: 'failing',
           description: 'Literally everything is broken',
           lastUpdated: new Date(0),
+          statusUrl: 'http://notgoogle.com',
         },
       ]);
 
@@ -66,6 +73,7 @@ describe('ServicesModule', () => {
         `Service 2 ❌ (Updated: ${new Date(0).toLocaleString()})`,
       );
       expect(infoSpy).toHaveBeenCalledWith('  Details: Literally everything is broken');
+      expect(infoSpy).toHaveBeenCalledWith('  Status URL: http://notgoogle.com');
     });
   });
 });

--- a/ng-dev/caretaker/check/services.ts
+++ b/ng-dev/caretaker/check/services.ts
@@ -14,6 +14,7 @@ import {BaseModule} from './base.js';
 interface ServiceConfig {
   name: string;
   url: string;
+  prettyUrl: string;
 }
 
 /**
@@ -36,23 +37,28 @@ interface StatusCheckResult {
   status: 'passing' | 'failing';
   description: string;
   lastUpdated: Date;
+  statusUrl: string;
 }
 
 /** List of services Angular relies on. */
 export const services: ServiceConfig[] = [
   {
+    prettyUrl: 'https://status.us-west-1.saucelabs.com',
     url: 'https://status.us-west-1.saucelabs.com/api/v2/status.json',
     name: 'Saucelabs',
   },
   {
+    prettyUrl: 'https://status.npmjs.org/',
     url: 'https://status.npmjs.org/api/v2/status.json',
     name: 'Npm',
   },
   {
+    prettyUrl: 'https://status.circleci.com',
     url: 'https://status.circleci.com/api/v2/status.json',
     name: 'CircleCi',
   },
   {
+    prettyUrl: 'https://www.githubstatus.com',
     url: 'https://www.githubstatus.com/api/v2/status.json',
     name: 'Github',
   },
@@ -74,6 +80,7 @@ export class ServicesModule extends BaseModule<StatusCheckResult[]> {
       } else {
         Log.info.group(`${name} ❌ (Updated: ${status.lastUpdated.toLocaleString()})`);
         Log.info(`  Details: ${status.description}`);
+        Log.info(`  Status URL: ${status.statusUrl}`);
         Log.info.groupEnd();
       }
     }
@@ -87,6 +94,7 @@ export class ServicesModule extends BaseModule<StatusCheckResult[]> {
     const status = result.status.indicator === 'none' ? 'passing' : 'failing';
     return {
       name: service.name,
+      statusUrl: service.prettyUrl,
       status,
       description: result.status.description,
       lastUpdated: new Date(result.page.updated_at),


### PR DESCRIPTION
Add the status urls to the caretaker check for failing services to allow easier detail checks of the status for caretakers.