### PR TITLE
fix(shared-scripts): cut down on dependencies from `@angular-devkit/build-angular`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@angular-devkit/build-angular": "15.0.0-rc.0",
     "@angular/benchpress": "0.3.0",
     "@babel/core": "^7.16.0",
+    "@babel/helper-annotate-as-pure": "^7.18.6",
     "@bazel/buildifier": "5.1.0",
     "@bazel/concatjs": "5.7.0",
     "@bazel/esbuild": "5.7.0",

--- a/shared-scripts/angular-optimization/BUILD.bazel
+++ b/shared-scripts/angular-optimization/BUILD.bazel
@@ -7,11 +7,32 @@ filegroup(
     srcs = glob(["*"]),
 )
 
+# This is a re-export of the Babel plugin code of `@angular-devkit/build-angular`. The
+# package has lots of dependencies which are not relevant for the Babel plugins so we
+# want to expose a more optimized `js_library` where all transitive unused dependencies
+# are not accidentally collected- speeding up and avoiding RBE input limits.
+js_library(
+    name = "angular_devkit_plugins",
+    package_name = "@angular-devkit/build-angular/src/babel/plugins",
+    srcs = [
+        "@npm//:node_modules/@angular-devkit/build-angular/src/babel/plugins/adjust-static-class-members.js",
+        "@npm//:node_modules/@angular-devkit/build-angular/src/babel/plugins/adjust-typescript-enums.js",
+        "@npm//:node_modules/@angular-devkit/build-angular/src/babel/plugins/elide-angular-metadata.js",
+        "@npm//:node_modules/@angular-devkit/build-angular/src/babel/plugins/pure-toplevel-functions.js",
+    ],
+    deps = [
+        "@npm//@babel/core",
+        "@npm//@babel/helper-annotate-as-pure",
+    ],
+)
+
 # Exposed `js_library` targets need to copy files to `bazel-out`. More details here:
 # https://github.com/bazelbuild/rules_nodejs/pull/3083.
 copy_to_bin(
     name = "js_lib_files",
-    srcs = ["esbuild-plugin.mjs"],
+    srcs = [
+        "esbuild-plugin.mjs",
+    ],
 )
 
 js_library(
@@ -19,7 +40,7 @@ js_library(
     package_name = "@angular/build-tooling/shared-scripts/angular-optimization",
     srcs = [":js_lib_files"],
     deps = [
-        "@npm//@angular-devkit/build-angular",
+        ":angular_devkit_plugins",
         "@npm//@babel/core",
     ],
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,6 +332,7 @@ __metadata:
     "@angular/platform-browser-dynamic": 15.0.0-rc.0
     "@angular/router": 15.0.0-rc.0
     "@babel/core": ^7.16.0
+    "@babel/helper-annotate-as-pure": ^7.18.6
     "@bazel/bazelisk": ^1.11.0
     "@bazel/buildifier": 5.1.0
     "@bazel/concatjs": 5.7.0


### PR DESCRIPTION
The devkit brings in a lot of transitive dependencies and files, potentially pushing us over the RBE input file limit

As seen here:
https://app.circleci.com/pipelines/github/angular/angular/52508/workflows/a8803c49-42cc-455e-b06a-803f6ef2edca/jobs/1246870

We can reduce this by fine-grain selecting the files we need and managing its dependencies. These are only two dependencies and it's acceptable taking responsibility for it- especially since we have test coverage for it.