### PR TITLE
fix(github-actions): only change temporary directory to ensure write access

### DIFF
--- a/github-actions/deploy-previews/pack-and-upload-artifact/action.yml
+++ b/github-actions/deploy-previews/pack-and-upload-artifact/action.yml
@@ -42,7 +42,7 @@ runs:
         dir="$RUNNER_TEMP/pack-and-upload-tmp-dir"
         mkdir -p $dir
         cp -R "${{inputs.deploy-directory}}" "$dir"
-        chmod -R 644 "$dir"
+        chmod -R u+w "$dir"
         echo "deploy-dir=$dir" >> $GITHUB_OUTPUT
 
     - name: Injecting artifact metadata


### PR DESCRIPTION
Using `644` without the `x` bit for directories means that the directory cannot be modified. i.e. no files can be created. We should not modify this bit but rather just ensure the folder is writeable and individual files have the `w` bit.