### PR TITLE
fix(github-actions): do not nest deploy directory in final tmp dir

### DIFF
--- a/github-actions/deploy-previews/pack-and-upload-artifact/action.yml
+++ b/github-actions/deploy-previews/pack-and-upload-artifact/action.yml
@@ -39,8 +39,7 @@ runs:
       id: copy
       shell: bash
       run: |
-        dir="$RUNNER_TEMP/pack-and-upload-tmp-dir"
-        mkdir -p $dir
+        dir="$RUNNER_TEMP/pack-and-upload-tmp-dir/"
         cp -R "${{inputs.deploy-directory}}" "$dir"
         chmod -R u+w "$dir"
         echo "deploy-dir=$dir" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The github action creates a temporary directory for adding the metadata files. Right now the cp logic is incorrect and nestes the base folder inside it. We can ensure the deploy folder becomes the tmp dir 1:1 by not creating it before copying.