### PR TITLE
fix(github-actions): use proper variable names when accessing deploy metadata

### DIFF
--- a/github-actions/deploy-previews/upload-artifacts-to-firebase/action.yml
+++ b/github-actions/deploy-previews/upload-artifacts-to-firebase/action.yml
@@ -78,10 +78,10 @@ runs:
         expires: 20d
         projectId: '${{inputs.firebase-project-id}}'
         entryPoint: '${{inputs.firebase-config-dir}}'
-        channelId: pr-${{steps.artifact-info.outputs.pull-number}}-${{steps.artifact-info.outputs.build-revision}}
+        channelId: pr-${{steps.artifact-info.outputs.unsafe-pull-number}}-${{steps.artifact-info.outputs.unsafe-build-revision}}
 
     - uses: marocchino/sticky-pull-request-comment@f3bbb8300013c686241004a1c1b5d4045b10bc30 # tag=v2.0.0
       with:
         message: |
           Deployed ${{inputs.workflow-artifact-name}} to: ${{steps.deploy.outputs.details_url}}
-        number: ${{steps.artifact-info.outputs.pull-number}}
+        number: ${{steps.artifact-info.outputs.unsafe-pull-number}}


### PR DESCRIPTION
TL;DR: There is no way to test GitHub actions directly 😓 

The wrong variables were used and the GitHub action did not even fail, but instead use some undefined value, causing the Firebase URLs to include some non-deterministic string.

Also the comment did not get posted because the PR number was not a valid one. Even here, the action did not print a failure..