### PR TITLE
feat(github-actions): add label checks to unified status check

### DIFF
--- a/github-actions/unified-status-check/BUILD.bazel
+++ b/github-actions/unified-status-check/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
     ),
     deps = [
         "//github-actions:utils",
+        "//ng-dev/pr/common:labels",
         "@npm//@actions/core",
         "@npm//@actions/github",
         "@npm//@octokit/graphql-schema",

--- a/github-actions/unified-status-check/src/labels.ts
+++ b/github-actions/unified-status-check/src/labels.ts
@@ -1,0 +1,47 @@
+import {actionLabels, targetLabels} from '../../../ng-dev/pr/common/labels.js';
+import {PullRequest} from './pull-request.js';
+import {ValidationFunction} from './validation.js';
+
+export const checkForTargelLabel: ValidationFunction = (pullRequest: PullRequest) => {
+  const appliedLabel = Object.values(targetLabels).find((label) =>
+    pullRequest.labels.includes(label.name),
+  );
+  if (appliedLabel !== undefined) {
+    return {
+      state: 'success',
+      description: `Pull request has target label: "${appliedLabel.name}"`,
+    };
+  }
+  return {
+    state: 'pending',
+    description: 'Waiting for target label on the pull request',
+  };
+};
+
+export const isMergeReady: ValidationFunction = (pullRequest: PullRequest) => {
+  if (!pullRequest.labels.includes(actionLabels.ACTION_MERGE.name)) {
+    return {
+      state: 'pending',
+      description: `Waiting for "${actionLabels.ACTION_MERGE.name}" label`,
+    };
+  }
+
+  if (pullRequest.labels.includes(actionLabels.ACTION_REVIEW.name)) {
+    return {
+      state: 'failure',
+      description: `Marked for merge but still has the "${actionLabels.ACTION_REVIEW.name}" label`,
+    };
+  }
+
+  if (pullRequest.labels.includes(actionLabels.ACTION_CLEANUP.name)) {
+    return {
+      state: 'failure',
+      description: `Marked for merge but still has the "${actionLabels.ACTION_CLEANUP.name}" label`,
+    };
+  }
+
+  return {
+    state: 'success',
+    description: `Marked for merge by the "${actionLabels.ACTION_MERGE.name}" label`,
+  };
+};

--- a/github-actions/unified-status-check/src/main.ts
+++ b/github-actions/unified-status-check/src/main.ts
@@ -5,6 +5,7 @@ import {getAuthTokenFor, ANGULAR_ROBOT, revokeActiveInstallationToken} from '../
 import {getPullRequest, NormalizedState, unifiedStatusCheckName} from './pull-request.js';
 import {isDraft} from './draft-mode.js';
 import {checkOnlyPassingStatuses, checkRequiredStatuses} from './statuses.js';
+import {checkForTargelLabel, isMergeReady} from './labels.js';
 
 async function main() {
   /** A Github API instance. */
@@ -44,6 +45,12 @@ async function main() {
       return;
     }
 
+    const isMergeReadyResult = isMergeReady(pullRequest);
+    if (isMergeReadyResult.state === 'pending') {
+      await setStatus(isMergeReadyResult.state, isMergeReadyResult.description);
+      return;
+    }
+
     const requiredStatusesResult = checkRequiredStatuses(pullRequest);
     if (requiredStatusesResult.state === 'pending') {
       await setStatus(requiredStatusesResult.state, requiredStatusesResult.description);
@@ -53,6 +60,12 @@ async function main() {
     const onlyPassingStatusesResult = checkOnlyPassingStatuses(pullRequest);
     if (onlyPassingStatusesResult.state === 'pending') {
       await setStatus(onlyPassingStatusesResult.state, onlyPassingStatusesResult.description);
+      return;
+    }
+
+    const targetLabelResult = checkForTargelLabel(pullRequest);
+    if (targetLabelResult.state === 'pending') {
+      await setStatus(targetLabelResult.state, targetLabelResult.description);
       return;
     }
   } finally {

--- a/github-actions/unified-status-check/src/pull-request.ts
+++ b/github-actions/unified-status-check/src/pull-request.ts
@@ -54,6 +54,7 @@ export type PullRequest = {
   sha: string;
   isDraft: boolean;
   state: PullRequestState;
+  labels: string[];
   statuses: Statuses;
 };
 
@@ -87,6 +88,16 @@ const PR_SCHEMA = {
           isDraft: graphqlTypes.boolean,
           state: graphqlTypes.custom<PullRequestState>(),
           number: graphqlTypes.number,
+          labels: params(
+            {last: 100},
+            {
+              nodes: [
+                {
+                  name: graphqlTypes.string,
+                },
+              ],
+            },
+          ),
           commits: params(
             {last: 1},
             {
@@ -164,6 +175,7 @@ function parseGithubPullRequest({repository: {pullRequest}}: typeof PR_SCHEMA): 
   return {
     sha: pullRequest.commits.nodes[0].commit.oid,
     isDraft: pullRequest.isDraft,
+    labels: pullRequest.labels.nodes.map(({name}) => name),
     state: pullRequest.state,
     statuses,
   };


### PR DESCRIPTION
This pull requests adds the labels checks to the already established pieces, a follow up with contain the logic for checking multiple validations at a time rather than eager exiting.