### PR TITLE
Fix caretaker check failures

### DIFF
--- a/ng-dev/caretaker/check/services.ts
+++ b/ng-dev/caretaker/check/services.ts
@@ -43,8 +43,8 @@ interface StatusCheckResult {
 /** List of services Angular relies on. */
 export const services: ServiceConfig[] = [
   {
-    prettyUrl: 'https://status.us-west-1.saucelabs.com',
-    url: 'https://status.us-west-1.saucelabs.com/api/v2/status.json',
+    prettyUrl: 'https://status.saucelabs.com',
+    url: 'https://status.saucelabs.com/api/v2/status.json',
     name: 'Saucelabs',
   },
   {

--- a/ng-dev/caretaker/check/services.ts
+++ b/ng-dev/caretaker/check/services.ts
@@ -90,14 +90,24 @@ export class ServicesModule extends BaseModule<StatusCheckResult[]> {
 
   /** Retrieve the status information for a service which uses a standard API response. */
   async getStatusFromStandardApi(service: ServiceConfig): Promise<StatusCheckResult> {
-    const result = (await fetch(service.url).then((r) => r.json())) as StatusHttpResponse;
-    const status = result.status.indicator === 'none' ? 'passing' : 'failing';
-    return {
-      name: service.name,
-      statusUrl: service.prettyUrl,
-      status,
-      description: result.status.description,
-      lastUpdated: new Date(result.page.updated_at),
-    };
+    try {
+      const result = (await fetch(service.url).then((r) => r.json())) as StatusHttpResponse;
+      const status = result.status.indicator === 'none' ? 'passing' : 'failing';
+      return {
+        name: service.name,
+        statusUrl: service.prettyUrl,
+        status,
+        description: result.status.description,
+        lastUpdated: new Date(result.page.updated_at),
+      };
+    } catch {
+      return {
+        name: service.name,
+        statusUrl: service.prettyUrl,
+        status: 'failing',
+        description: `Unable to retrieve status from ${service.name}`,
+        lastUpdated: new Date(),
+      };
+    }
   }
 }


### PR DESCRIPTION
Split into individual commits, fix the failing URL and gracefully handle failures in the future.