### PR TITLE
fix(github-actions): only create a single preview channel per PR

### DIFF
--- a/github-actions/deploy-previews/upload-artifacts-to-firebase/action.yml
+++ b/github-actions/deploy-previews/upload-artifacts-to-firebase/action.yml
@@ -81,15 +81,15 @@ runs:
         # comment. We use our own sticky non-spam comments below.
         repoToken: ''
         firebaseServiceAccount: '${{inputs.firebase-service-key}}'
-        expires: 20d
+        expires: 10d
         projectId: '${{inputs.firebase-project-id}}'
         entryPoint: '${{inputs.firebase-config-dir}}'
-        channelId: pr-${{github.repository}}-${{steps.artifact-info.outputs.unsafe-pull-number}}-${{steps.artifact-info.outputs.unsafe-build-revision}}
+        channelId: pr-${{github.repository}}-${{steps.artifact-info.outputs.unsafe-pull-number}}
 
     - uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # tag=v2
       with:
         message: |
-          Deployed ${{inputs.workflow-artifact-name}} to: ${{steps.deploy.outputs.details_url}}
+          Deployed ${{inputs.workflow-artifact-name}} for ${{steps.artifact-info.outputs.unsafe-build-revision}} to: ${{steps.deploy.outputs.details_url}}
 
           _**Note**: As new commits are pushed to this pull request, this link is updated after the preview is rebuilt._
         number: ${{steps.artifact-info.outputs.unsafe-pull-number}}


### PR DESCRIPTION
This reduces the amount of preview channels we create, avoiding
quota issues. See: https://b.corp.google.com/issues/261985459