### PR TITLE
fix(bazel): spec-bundling rule should keep original names

### DIFF
--- a/bazel/spec-bundling/esbuild.config-tmpl.mjs
+++ b/bazel/spec-bundling/esbuild.config-tmpl.mjs
@@ -27,6 +27,11 @@ export default {
   mainFields: ['es2020', 'es2015', 'module', 'main'],
   // Addition of `.mjs` to the non-jsx defaults. https://esbuild.github.io/api/#resolve-extensions
   resolveExtensions: ['.mjs', '.js', '.json'],
+  // Bundling specs may result in classes being aliased to avoid collisions. e.g. when
+  // everything is bundled into a single AMD bundle. To avoid test failures for assertions
+  // on symbol names, we instruct ESBuild to keep original names. See:
+  // https://esbuild.github.io/api/#keep-names.
+  keepNames: true,
   supported,
   plugins: [
     await createEsbuildAngularOptimizePlugin({


### PR DESCRIPTION
Kudos to @josephperrott who found this back when we used ESBuild for legacy saucelabs bundle creation

https://angular-team.slack.com/archives/D0ZBU43EZ/p1636491354025800