### PR TITLE
fix(bazel): app bundle rule does not declare other files as side-effect free

### DIFF
--- a/bazel/app-bundling/esbuild.config-tmpl.mjs
+++ b/bazel/app-bundling/esbuild.config-tmpl.mjs
@@ -52,7 +52,7 @@ export default {
   plugins: [
     await createEsbuildAngularOptimizePlugin({
       optimize: {
-        isFileSideEffectFree: isFileSideEffectFree,
+        isSideEffectFree: isFileSideEffectFree,
       },
       downlevelAsyncGeneratorsIfPresent: true,
       enableLinker: {


### PR DESCRIPTION
Fixes a typo that prevented non-entry-point files from being marked as side-effect free.