### PR TITLE
fix(shared-scripts): properly use `isSideEffectFree` function

### DIFF
--- a/shared-scripts/angular-optimization/esbuild-plugin.mjs
+++ b/shared-scripts/angular-optimization/esbuild-plugin.mjs
@@ -82,7 +82,7 @@ export async function createEsbuildAngularOptimizePlugin(opts, additionalBabelPl
 
           // If the current file is denoted as explicit side effect free, add the pure
           // top-level functions optimization plugin for this file.
-          if (opts.optimize.isSideEffectFreeFn && opts.optimize.isSideEffectFree(args.path)) {
+          if (opts.optimize.isSideEffectFree && opts.optimize.isSideEffectFree(args.path)) {
             plugins.push(devkitOptimizePlugins.pureToplevelFunctionsPlugin);
           }
         }


### PR DESCRIPTION
There was another typo, preventing use of `isSideEffectFree`.