### PR TITLE
fix(bazel): spec-bundle rule should never consider transitive files

### DIFF
--- a/bazel/spec-bundling/test/BUILD.bazel
+++ b/bazel/spec-bundling/test/BUILD.bazel
@@ -5,10 +5,16 @@ load("//bazel/spec-bundling:index.bzl", "spec_bundle")
 load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
+    name = "transitive_should_not_be_loaded",
+    srcs = ["should_not_be_picked_up.spec.ts"],
+)
+
+ts_library(
     name = "test_async_await_lib",
     testonly = True,
     srcs = ["async-await.spec.ts"],
     deps = [
+        ":transitive_should_not_be_loaded",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
@@ -24,6 +30,7 @@ ts_library(
     testonly = True,
     srcs = ["core_apf_esm_test.ts"],
     deps = [
+        ":transitive_should_not_be_loaded",
         "@npm//@angular/core",
         "@npm//@types/jasmine",
     ],
@@ -34,6 +41,7 @@ ts_library(
     testonly = True,
     srcs = ["core_invalid_linker_decl.spec.ts"],
     deps = [
+        ":transitive_should_not_be_loaded",
         "@npm//@angular/core",
         "@npm//@types/jasmine",
     ],

--- a/bazel/spec-bundling/test/should_not_be_picked_up.spec.ts
+++ b/bazel/spec-bundling/test/should_not_be_picked_up.spec.ts
@@ -1,0 +1,1 @@
+throw new Error('this file should not be loaded at all!');


### PR DESCRIPTION
Only specs part of the direct sources, or only direct init files should be considered by the rule.

Consider an example where one init file relies on another. The second init file should not be picked up as bootstrap file, but instead should just be loaded based on the direct `.init` file.