### PR TITLE
feat(shared-scripts): support only running linker on subset of files

### DIFF
--- a/shared-scripts/angular-optimization/esbuild-plugin.d.ts
+++ b/shared-scripts/angular-optimization/esbuild-plugin.d.ts
@@ -9,6 +9,7 @@
 export interface OptimizationOptions {
   enableLinker?: {
     ensureNoPartialDeclaration: boolean;
+    filterPaths?: RegExp;
     linkerOptions?: object;
   };
   optimize?: {

--- a/shared-scripts/angular-optimization/esbuild-plugin.mjs
+++ b/shared-scripts/angular-optimization/esbuild-plugin.mjs
@@ -87,7 +87,11 @@ export async function createEsbuildAngularOptimizePlugin(opts, additionalBabelPl
           }
         }
 
-        if (opts.enableLinker) {
+        const shouldRunLinker =
+          opts.enableLinker &&
+          (opts.enableLinker.filterPaths == null || opts.enableLinker.filterPaths.test(args.path));
+
+        if (shouldRunLinker) {
           plugins.push(
             linkerCreator.babel.createEs2015LinkerPlugin({
               ...(opts.enableLinker.linkerOptions ?? {}),


### PR DESCRIPTION
This can help up speeding builds as we wouldn't setup Babel if the linker is not needed for certain files.