### PR TITLE
feat(bazel): allow for benchmark driver utilities to be linked

### DIFF
--- a/bazel/benchmark/driver-utilities/BUILD.bazel
+++ b/bazel/benchmark/driver-utilities/BUILD.bazel
@@ -4,6 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 ts_library(
     name = "driver-utilities",
+    package_name = "@angular/build-tooling/bazel/benchmark/driver-utilities",
     srcs = glob(["*.ts"]),
     module_name = "@angular/build-tooling/bazel/benchmark/driver-utilities",
     tsconfig = "//bazel/benchmark/component_benchmark:tsconfig-e2e.json",


### PR DESCRIPTION
`module_name` only has an effect for TS resolution and for the patched Bazel NodeJS resolution. The `package_name` equivalent is needed so that ESBuild or the Bazel NodeJS linker can map the name to the target.