### PR TITLE
feat(bazel): support explicit files in spec-entrypoint

### DIFF
--- a/bazel/spec-bundling/spec-entrypoint.bzl
+++ b/bazel/spec-bundling/spec-entrypoint.bzl
@@ -86,7 +86,7 @@ def _spec_entrypoint_impl(ctx):
 spec_entrypoint = rule(
     implementation = _spec_entrypoint_impl,
     attrs = {
-        "deps": attr.label_list(allow_files = False, mandatory = True),
-        "bootstrap": attr.label_list(allow_files = False, mandatory = True),
+        "deps": attr.label_list(allow_files = True, mandatory = True),
+        "bootstrap": attr.label_list(allow_files = True, mandatory = True),
     },
 )

--- a/bazel/spec-bundling/test/BUILD.bazel
+++ b/bazel/spec-bundling/test/BUILD.bazel
@@ -1,7 +1,7 @@
 # NOTE: We need to test with the raw jasmine rule here because our default
 # repo rule uses spec-bundling as well, with some additional defaults.
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//bazel/spec-bundling:index.bzl", "spec_bundle")
+load("//bazel/spec-bundling:index.bzl", "spec_bundle", "spec_entrypoint")
 load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
@@ -44,6 +44,16 @@ ts_library(
         ":transitive_should_not_be_loaded",
         "@npm//@angular/core",
         "@npm//@types/jasmine",
+    ],
+)
+
+spec_entrypoint(
+    name = "explicit_file_entrypoint",
+    testonly = True,
+    bootstrap = [],
+    deps = [
+        "some_spec.js",
+        ":test_lib_apf",
     ],
 )
 

--- a/bazel/spec-bundling/test/some_spec.js
+++ b/bazel/spec-bundling/test/some_spec.js
@@ -1,0 +1,5 @@
+describe('some spec no compilation', () => {
+  it('should work', () => {
+    expect(true).toBe(false);
+  });
+});


### PR DESCRIPTION
This will be helpful for using the rule in `jasmine_node_test` where explicit specs may be passed through `srcs`.