### PR TITLE
feat(bazel): always consider transitive specs for spec-entrypoint

### DIFF
--- a/bazel/spec-bundling/spec-entrypoint.bzl
+++ b/bazel/spec-bundling/spec-entrypoint.bzl
@@ -60,8 +60,8 @@ def _spec_entrypoint_impl(ctx):
 
     # Note: `to_list()` is an expensive operation but we need to do this for every
     # dependency here in order to be able to filter out spec files from depsets.
-    direct_spec_files = depset(transitive = spec_direct_deps).to_list()
-    spec_files = _filter_files(direct_spec_files, ["spec", "test"])
+    all_spec_files = depset(transitive = spec_all_deps).to_list()
+    spec_files = _filter_files(all_spec_files, ["spec", "test"])
 
     # Note: `to_list()` is an expensive operation but we need to do this for every
     # dependency here in order to be able to filter out spec files from depsets.

--- a/bazel/spec-bundling/test/BUILD.bazel
+++ b/bazel/spec-bundling/test/BUILD.bazel
@@ -5,8 +5,12 @@ load("//bazel/spec-bundling:index.bzl", "spec_bundle", "spec_entrypoint")
 load("//tools:defaults.bzl", "ts_library")
 
 ts_library(
-    name = "transitive_should_not_be_loaded",
-    srcs = ["should_not_be_picked_up.spec.ts"],
+    name = "transitive_should_be_loaded",
+    srcs = ["should_be_picked_up.spec.ts"],
+    deps = [
+        "@npm//@types/jasmine",
+        "@npm//@types/node",
+    ],
 )
 
 ts_library(
@@ -14,7 +18,6 @@ ts_library(
     testonly = True,
     srcs = ["async-await.spec.ts"],
     deps = [
-        ":transitive_should_not_be_loaded",
         "@npm//@angular/core",
         "@npm//@angular/platform-browser-dynamic",
         "@npm//@types/jasmine",
@@ -26,11 +29,21 @@ ts_library(
 )
 
 ts_library(
+    name = "ensure_transitive_loaded_lib",
+    testonly = True,
+    srcs = ["ensure-transitive-loaded.spec.ts"],
+    deps = [
+        ":transitive_should_be_loaded",
+        "@npm//@types/jasmine",
+        "@npm//@types/node",
+    ],
+)
+
+ts_library(
     name = "test_lib_apf",
     testonly = True,
     srcs = ["core_apf_esm_test.ts"],
     deps = [
-        ":transitive_should_not_be_loaded",
         "@npm//@angular/core",
         "@npm//@types/jasmine",
     ],
@@ -41,7 +54,6 @@ ts_library(
     testonly = True,
     srcs = ["core_invalid_linker_decl.spec.ts"],
     deps = [
-        ":transitive_should_not_be_loaded",
         "@npm//@angular/core",
         "@npm//@types/jasmine",
     ],
@@ -61,7 +73,10 @@ spec_bundle(
     name = "test_bundle",
     platform = "node",
     run_angular_linker = True,
-    deps = [":test_lib_apf"],
+    deps = [
+        ":ensure_transitive_loaded_lib",
+        ":test_lib_apf",
+    ],
 )
 
 spec_bundle(

--- a/bazel/spec-bundling/test/ensure-transitive-loaded.spec.ts
+++ b/bazel/spec-bundling/test/ensure-transitive-loaded.spec.ts
@@ -1,0 +1,8 @@
+// Note: This should be overridden by the `should_be_picked_up.spec`.
+(global as any).iWillAlwaysFail = true;
+
+describe('some spec no compilation', () => {
+  it('should work', () => {
+    expect((global as any).iWillAlwaysFail).toBe(false);
+  });
+});

--- a/bazel/spec-bundling/test/should_be_picked_up.spec.ts
+++ b/bazel/spec-bundling/test/should_be_picked_up.spec.ts
@@ -1,0 +1,9 @@
+// See `ensure-transitive-loaded` for explanation. This verifies this
+// file is actually loaded.
+(global as any).iWillAlwaysFail = false;
+
+describe('should be picked up', () => {
+  it('should work', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/bazel/spec-bundling/test/should_not_be_picked_up.spec.ts
+++ b/bazel/spec-bundling/test/should_not_be_picked_up.spec.ts
@@ -1,1 +1,0 @@
-throw new Error('this file should not be loaded at all!');


### PR DESCRIPTION
We recently switched all from transitive to just direct. We should keep this for the bootstrap code as there is a legitimate ordering issue if a bootstrap file depends on another and they would then be brought into with an unexpected order.

For specs we should consider all transitive ones too, just to be on the safe side of never missing any specs.