### PR TITLE
fix(ng-dev): filter alternate angular robot name from changelogs

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -66322,7 +66322,13 @@ function compareString(a, b) {
 
 // 
 var typesToIncludeInReleaseNotes = Object.values(COMMIT_TYPES).filter((type) => type.releaseNotesLevel === ReleaseNotesLevel.Visible).map((type) => type.name);
-var botsAuthorNames = ["dependabot[bot]", "Renovate Bot", "angular-robot", "Angular Robot"];
+var botsAuthorNames = [
+  "dependabot[bot]",
+  "Renovate Bot",
+  "angular-robot",
+  "angular-robot[bot]",
+  "Angular Robot"
+];
 var RenderContext = class {
   constructor(data) {
     this.data = data;

--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -18,7 +18,13 @@ const typesToIncludeInReleaseNotes = Object.values(COMMIT_TYPES)
   .map((type) => type.name);
 
 /** List of commit authors which are bots. */
-const botsAuthorNames = ['dependabot[bot]', 'Renovate Bot', 'angular-robot', 'Angular Robot'];
+const botsAuthorNames = [
+  'dependabot[bot]',
+  'Renovate Bot',
+  'angular-robot',
+  'angular-robot[bot]',
+  'Angular Robot',
+];
 
 /** Data used for context during rendering. */
 export interface RenderContextData {


### PR DESCRIPTION
The Angular robot can also use the name `angular-robot[bot]`. This name is now also included in the list of changelog robots and will be filter from changelogs.