### PR TITLE
fix(github-actions): close superseded PRs when using create-pr-for-changes

### DIFF
--- a/github-actions/create-pr-for-changes/lib/main.ts
+++ b/github-actions/create-pr-for-changes/lib/main.ts
@@ -191,13 +191,16 @@ async function main(): Promise<void> {
           body: `Superseded by PR #${createdPr.number}.`,
         });
 
-        // TODO(gkalpak):
-        //   Do we want to add/remove labels on superseded PRs?
-        //   For example, we could add `state: blocked` and remove `action: merge[-assistance]` by
-        //   default (or we could make these configurable).
+        // Close superseded PR.
+        await git.github.issues.update({
+          owner: repo.owner,
+          repo: repo.name,
+          issue_number: pr.number,
+          state: 'closed',
+        });
       }
 
-      core.info(`Commented on ${supersededPrs.length} superseded PRs.`);
+      core.info(`Commented and closed ${supersededPrs.length} superseded PRs.`);
     }
   } catch (err: any) {
     core.setOutput('result', ActionResult.failed);

--- a/github-actions/create-pr-for-changes/main.js
+++ b/github-actions/create-pr-for-changes/main.js
@@ -17307,8 +17307,14 @@ ${prBody}`;
           issue_number: pr.number,
           body: `Superseded by PR #${createdPr.number}.`
         });
+        await git.github.issues.update({
+          owner: repo.owner,
+          repo: repo.name,
+          issue_number: pr.number,
+          state: "closed"
+        });
       }
-      core.info(`Commented on ${supersededPrs.length} superseded PRs.`);
+      core.info(`Commented and closed ${supersededPrs.length} superseded PRs.`);
     }
   } catch (err) {
     core.setOutput("result", "failed");


### PR DESCRIPTION

Prior to this change superseded PRs remained open, now they are closed.