### PR TITLE
build: fix ng-renovate lock file after renovate

### DIFF
--- a/.github/ng-renovate/yarn.lock
+++ b/.github/ng-renovate/yarn.lock
@@ -6131,7 +6131,7 @@ __metadata:
 
 "resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
     is-core-module: ^2.9.0
     path-parse: ^1.0.7


### PR DESCRIPTION
After the recent renovate PRs the lock file broke, likely due to manual edits in the Renovate PR.