### PR TITLE
feat(ng-dev): allow for additional custom stamping

### DIFF
--- a/ng-dev/BUILD.bazel
+++ b/ng-dev/BUILD.bazel
@@ -36,6 +36,7 @@ ts_library(
         "//ng-dev/release/config",
         "//ng-dev/release/precheck",
         "//ng-dev/release/publish",
+        "//ng-dev/release/stamping",
         "//ng-dev/release/versioning",
         "//ng-dev/ts-circular-dependencies",
         "//ng-dev/utils",

--- a/ng-dev/index.ts
+++ b/ng-dev/index.ts
@@ -25,6 +25,11 @@ export * from './release/versioning/index.js';
 // as they are needed for authoring pre-release custom checks.
 export {ReleasePrecheckError} from './release/precheck/index.js';
 
+// Expose the default Bazel workspace stamping. This might be used
+// by repositories for additional custom stamping variables.
+export {EnvStampMode} from './release/stamping/env-stamp.js';
+export {EnvStampCustomPrintFn} from './release/stamping/cli.js';
+
 // Exposes logging and console utils that can be used by consumers to e.g. add
 // messages to the dev-infra log which is stored on failures.
 export * from './utils/logging.js';

--- a/ng-dev/release/stamping/_private_main.ts
+++ b/ng-dev/release/stamping/_private_main.ts
@@ -3,7 +3,7 @@
 import yargs from 'yargs';
 import {BuildEnvStampCommand} from './cli.js';
 
-// TODO(ESM): Remove this when we use a dyanmic import for config loading.
+// TODO(ESM): Remove this when we use a dynamic import for config loading.
 import {createRequire as __cjsCompatRequire} from 'module';
 global.require = __cjsCompatRequire(import.meta.url);
 

--- a/ng-dev/release/stamping/env-stamp.ts
+++ b/ng-dev/release/stamping/env-stamp.ts
@@ -16,7 +16,7 @@ import {join} from 'path';
 export type EnvStampMode = 'snapshot' | 'release';
 
 /** Log the environment variables expected by Bazel for stamping. */
-export async function buildEnvStamp(mode: EnvStampMode, includeVersion: boolean) {
+export async function printEnvStamp(mode: EnvStampMode, includeVersion: boolean) {
   const git = await GitClient.get();
 
   console.info(`BUILD_SCM_BRANCH ${getCurrentBranch(git)}`);
@@ -32,8 +32,6 @@ export async function buildEnvStamp(mode: EnvStampMode, includeVersion: boolean)
     console.info(`BUILD_SCM_VERSION ${version}`);
     console.info(`BUILD_SCM_EXPERIMENTAL_VERSION ${experimentalVersion}`);
   }
-
-  process.exit();
 }
 
 /** Whether the repo has local changes. */


### PR DESCRIPTION
This allows downstream projects to have custom stamping properties along with the normal stamping. e.g. when a framework peer dependency variable for substitution should be computed based on the current project version.