### PR TITLE
fix(ng-dev): always emit project version info as stable stamping keys

### DIFF
--- a/ng-dev/release/stamping/env-stamp.ts
+++ b/ng-dev/release/stamping/env-stamp.ts
@@ -29,8 +29,12 @@ export async function printEnvStamp(mode: EnvStampMode, includeVersion: boolean)
 
   if (includeVersion === true) {
     const {version, experimentalVersion} = getSCMVersions(git, mode);
-    console.info(`BUILD_SCM_VERSION ${version}`);
-    console.info(`BUILD_SCM_EXPERIMENTAL_VERSION ${experimentalVersion}`);
+    // Note: We need to use the `STABLE_` prefix to tell Bazel that these
+    // variables are changing rarely, and if they do- the targets relying
+    // on it should be rebuilt. e.g. the NPM package would need to be re-assembled.
+    // https://bazel.build/docs/user-manual#workspace-status-command.
+    console.info(`STABLE_PROJECT_VERSION ${version}`);
+    console.info(`STABLE_PROJECT_EXPERIMENTAL_VERSION ${experimentalVersion}`);
   }
 }
 


### PR DESCRIPTION
This fixes a long-standing issue where the project version is emitted as a volatile key in stamping. This means that everytime a new version is put into `package.json`, the NPM package will not be rebuilt if it has been built previously.

This is the typical source of outdated NPM package artifacts where the package version is accidentally still the old one. The Bazel idiomatic fix is to use a `STABLE_` stamping key so that Bazel will properly re-build dependent targets whenever the version changes.

Ideally as part of larger future Bazel refactorings we would also make sure that only necessary target configurations depend on the stable status key file. Currently `ng_package`/`pkg_npm` always depends on it, even if there is no subsitution dependency on actual stable keys.

https://github.com/bazelbuild/rules_nodejs/issues/1219#issuecomment-684074237

Angular currently always wipes the cached artifact exactly to workaround this issue. Previously it even built completely from scatch, dismissing all of the previously cached artifacts.