### PR TITLE
ci: run renovate every 60 instead of 30 minutes

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -3,7 +3,9 @@ name: Angular-Org Renovate
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0/30 * * * *' # Runs every 30 minutes.
+    # Runs every 60 minutes.
+    # This is the recommanded running time https://github.com/renovatebot/renovate/discussions/16658
+    - cron: '0/60 * * * *'
 
 # Declare default permissions as read only.
 permissions:


### PR DESCRIPTION
This is an effort to reduce `rate-limit-exceeded` errors and is also what is recommanded by Renovate folks.

See: https://github.com/renovatebot/renovate/discussions/16658