### PR TITLE
ci: disable renovate for ngcc-validation repository

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -14,9 +14,6 @@ module.exports = {
     'angular/universal',
     'angular/vscode-ng-language-service',
     'angular/.github',
-    // Disable fork-mode for ngcc validation to support auto-merging
-    // and multiple base branches.
-    {repository: 'angular/ngcc-validation', forkMode: false},
   ],
   productLinks: {
     documentation: 'https://docs.renovatebot.com/',


### PR DESCRIPTION
This commit disable Renovate from running on the `ngcc-validation` repository.

 This is for a number of reasons including:
- NGCC is mainly in maintenance mode
- Failing Renovate PRs in these repo are not being checked
- This repo accounts for like 15% of our CircleCI credit usage
- This should help to reduce Github API `rate-limit-exceeded` errors