### PR TITLE
ci: set up `GITHUB_COM_TOKEN` in renovate config

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -38,4 +38,5 @@ jobs:
           LOG_LEVEL: debug
           RENOVATE_TOKEN: ${{ secrets.NG_RENOVATE_USER_ACCESS_TOKEN }}
           RENOVATE_FORK_TOKEN: ${{ secrets.NG_RENOVATE_USER_ACCESS_TOKEN }}
+          GITHUB_COM_TOKEN: ${{ secrets.NG_RENOVATE_USER_ACCESS_TOKEN }}
           RENOVATE_CONFIG_FILE: .github/ng-renovate/runner-config.js


### PR DESCRIPTION
This value of this token is used by renovate to make authenticated calls when fetching release notes for repositories.

This should help reduce Github rate limit errors.

See: https://docs.renovatebot.com/getting-started/running/#githubcom-token-for-release-notes