### PR TITLE
ci: limit concurrent requests to `api.github.com`

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -16,6 +16,12 @@ module.exports = {
     'angular/vscode-ng-language-service',
     'angular/.github',
   ],
+  hostRules: [
+    {
+      matchHost: 'api.github.com',
+      concurrentRequestLimit: 1,
+    },
+  ],
   productLinks: {
     documentation: 'https://docs.renovatebot.com/',
     help: 'https://github.com/angular/dev-infra',


### PR DESCRIPTION
A recommended approach to deal with github api secondary rate limit is to make requests concurrently.

See: https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28#dealing-with-secondary-rate-limits