### PR TITLE
fix(github-actions): do Github requests serially in branch manager

### DIFF
--- a/github-actions/branch-manager/main.js
+++ b/github-actions/branch-manager/main.js
@@ -23537,7 +23537,9 @@ async function run() {
     core.info(`Evaluating pull requests as a result of a push to '${ref}'`);
     const prs = await github().then((api) => api.paginate(api.pulls.list, { ...import_github2.context.repo, state: "open", labels: actionLabels.ACTION_MERGE.name }, (pulls) => pulls.data.map((pull) => `${pull.number}`)));
     core.info(`Triggering ${prs.length} prs to be evaluated`);
-    await Promise.all([...prs.map((pr) => createWorkflowForPullRequest({ pr }))]);
+    for (const pr of prs) {
+      await createWorkflowForPullRequest({ pr });
+    }
   }
   if (import_github2.context.eventName === "pull_request_target") {
     if (["opened", "synchronize", "reopened", "ready_for_review"].includes(import_github2.context.payload.action)) {


### PR DESCRIPTION
Branch manager occasionally fails due to secondary rate limit. Sometimes, almost 200 concurrent requests were performed.

Github recommends to make requests for a single user or client ID serially. See: https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28#dealing-with-secondary-rate-limits

Closes #961

---

**NB:** Currently, this workflow is disabled in [angular/angular](https://github.com/angular/angular/actions/workflows/assistant-to-the-branch-manager.yml), not sure if the limits was the reason behind this. 

