### PR TITLE
fix(github-actions): branch manager incorrectly syncs all PRs

### DIFF
--- a/github-actions/branch-manager/lib/main.ts
+++ b/github-actions/branch-manager/lib/main.ts
@@ -27,11 +27,20 @@ async function run() {
     }
 
     core.info(`Evaluating pull requests as a result of a push to '${ref}'`);
+
+    const mergeReadyPrQuery =
+      `repo:${context.repo.owner}/${context.repo.repo} ` +
+      `is:pr ` +
+      `is:open ` +
+      `label:"${actionLabels.ACTION_MERGE.name}"`;
+
     const prs = await github().then((api) =>
       api.paginate(
-        api.pulls.list,
-        {...context.repo, state: 'open', labels: actionLabels.ACTION_MERGE.name},
-        (pulls) => pulls.data.map((pull) => `${pull.number}`),
+        api.search.issuesAndPullRequests,
+        {
+          q: mergeReadyPrQuery,
+        },
+        (issues) => issues.data.map((i) => `${i.number}`),
       ),
     );
     core.info(`Triggering ${prs.length} prs to be evaluated`);

--- a/github-actions/branch-manager/main.js
+++ b/github-actions/branch-manager/main.js
@@ -23535,7 +23535,10 @@ async function run() {
       return;
     }
     core.info(`Evaluating pull requests as a result of a push to '${ref}'`);
-    const prs = await github().then((api) => api.paginate(api.pulls.list, { ...import_github2.context.repo, state: "open", labels: actionLabels.ACTION_MERGE.name }, (pulls) => pulls.data.map((pull) => `${pull.number}`)));
+    const mergeReadyPrQuery = `repo:${import_github2.context.repo.owner}/${import_github2.context.repo.repo} is:pr is:open label:"${actionLabels.ACTION_MERGE.name}"`;
+    const prs = await github().then((api) => api.paginate(api.search.issuesAndPullRequests, {
+      q: mergeReadyPrQuery
+    }, (issues) => issues.data.map((i) => `${i.number}`)));
     core.info(`Triggering ${prs.length} prs to be evaluated`);
     for (const pr of prs) {
       await createWorkflowForPullRequest({ pr });


### PR DESCRIPTION
The branch manager logic for syncing merge ready PRs is flawed and currently always causes all PRs to be synced. This can be quite a lot, especially in repos like FW.

This caused queueing of GitHub actions in the dev-infra repo and slowed down updates of the mergeability status.

Related to: #998