### PR TITLE
fix(ng-dev): ignore all credential helpers when using the git client

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -70260,6 +70260,7 @@ var GitClient = class {
       Log.debug(`"git push" is not able to be run in dryRun mode.`);
       throw new DryRunError();
     }
+    args = ["-c", "credential.helper=", ...args];
     Log.debug("Executing: git", this.sanitizeConsoleOutput(args.join(" ")));
     const result = spawnSync(this.gitBinPath, args, {
       cwd: this.baseDir,

--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -65874,6 +65874,7 @@ var GitClient = class {
       Log.debug(`"git push" is not able to be run in dryRun mode.`);
       throw new DryRunError();
     }
+    args = ["-c", "credential.helper=", ...args];
     Log.debug("Executing: git", this.sanitizeConsoleOutput(args.join(" ")));
     const result = spawnSync(this.gitBinPath, args, {
       cwd: this.baseDir,

--- a/github-actions/create-pr-for-changes/main.js
+++ b/github-actions/create-pr-for-changes/main.js
@@ -17032,6 +17032,7 @@ var GitClient = class {
       Log.debug(`"git push" is not able to be run in dryRun mode.`);
       throw new DryRunError();
     }
+    args = ["-c", "credential.helper=", ...args];
     Log.debug("Executing: git", this.sanitizeConsoleOutput(args.join(" ")));
     const result = spawnSync(this.gitBinPath, args, {
       cwd: this.baseDir,

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -63657,6 +63657,7 @@ var GitClient = class {
       Log.debug(`"git push" is not able to be run in dryRun mode.`);
       throw new DryRunError();
     }
+    args = ["-c", "credential.helper=", ...args];
     Log.debug("Executing: git", this.sanitizeConsoleOutput(args.join(" ")));
     const result = spawnSync(this.gitBinPath, args, {
       cwd: this.baseDir,

--- a/ng-dev/auth/shared/ng-dev-token.ts
+++ b/ng-dev/auth/shared/ng-dev-token.ts
@@ -157,14 +157,7 @@ export function configureAuthorizedGitClientWithTemporaryToken() {
       });
 
       // Close the socket whenever the command which established it is complete.
-      registerCompletedFunction(async () => {
-        socket.close();
-
-        // After the action is done, request it to be forgotten by the local git client as it is no
-        // longer valid.
-        const git = await AuthenticatedGitClient.get();
-        git.runGraceful(['credential', 'reject'], {input: `url=${git.getRepoGitUrl()}\n\n`});
-      });
+      registerCompletedFunction(() => socket.close());
 
       // When the token is provided via the websocket message, use the token to set up
       // the AuthenticatedGitClient. The token is valid as long as the socket remains open,

--- a/ng-dev/utils/git/git-client.ts
+++ b/ng-dev/utils/git/git-client.ts
@@ -90,6 +90,9 @@ export class GitClient {
       throw new DryRunError();
     }
 
+    // Clear the credential helper that is used, preventing the temporary token from being saved as a
+    // valid token for future use.
+    args = ['-c', 'credential.helper=', ...args];
     // To improve the debugging experience in case something fails, we print all executed Git
     // commands at the DEBUG level to better understand the git actions occurring.
     // Note that we sanitize the command before printing it to the console. We do not want to


### PR DESCRIPTION
Since all authentication is done via URL when using the GitClient, we can safely prepend all git subcommands with `-c credential.helper=` to prevent any credential helper from being used.  This will have the benefit of preventing the temporary credentials created by ng-dev auth from being stored, rather than our previous method of attempting to remove them automatically.