### PR TITLE
feat(ng-dev): support autosquashing fixup commits for the API merge strategy

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -69529,14 +69529,22 @@ var PR_SCHEMA = {
     name: import_typed_graphqlify2.types.string,
     repository: {
       url: import_typed_graphqlify2.types.string,
-      nameWithOwner: import_typed_graphqlify2.types.string
+      nameWithOwner: import_typed_graphqlify2.types.string,
+      name: import_typed_graphqlify2.types.string,
+      owner: {
+        login: import_typed_graphqlify2.types.string
+      }
     }
   },
   baseRef: {
     name: import_typed_graphqlify2.types.string,
     repository: {
       url: import_typed_graphqlify2.types.string,
-      nameWithOwner: import_typed_graphqlify2.types.string
+      nameWithOwner: import_typed_graphqlify2.types.string,
+      name: import_typed_graphqlify2.types.string,
+      owner: {
+        login: import_typed_graphqlify2.types.string
+      }
     }
   },
   baseRefName: import_typed_graphqlify2.types.string,
@@ -70064,6 +70072,14 @@ async function loadAndValidatePullRequest({ git, config }, prNumber, validationC
   if (prData === null) {
     throw new FatalMergeToolError("Pull request could not be found.");
   }
+  const headRef = {
+    name: prData.headRef.name,
+    repo: {
+      owner: prData.headRef.repository.owner.login,
+      name: prData.headRef.repository.name
+    }
+  };
+  const commits = prData.commits.nodes.map(({ commit }) => parseCommitMessage(commit.message));
   const labels = prData.labels.nodes.map((l) => l.name);
   const githubTargetBranch = prData.baseRefName;
   const { mainBranchName: mainBranchName2, name, owner: owner2 } = config.github;
@@ -70098,8 +70114,10 @@ async function loadAndValidatePullRequest({ git, config }, prNumber, validationC
     hasCaretakerNote,
     validationFailures,
     targetBranches: target.branches,
+    commits,
+    headRef,
     title: prData.title,
-    commitCount: prData.commits.totalCount,
+    commitCount: commits.length,
     headSha: prData.headRefOid
   };
 }

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -68099,14 +68099,22 @@ var PR_SCHEMA = {
     name: import_typed_graphqlify4.types.string,
     repository: {
       url: import_typed_graphqlify4.types.string,
-      nameWithOwner: import_typed_graphqlify4.types.string
+      nameWithOwner: import_typed_graphqlify4.types.string,
+      name: import_typed_graphqlify4.types.string,
+      owner: {
+        login: import_typed_graphqlify4.types.string
+      }
     }
   },
   baseRef: {
     name: import_typed_graphqlify4.types.string,
     repository: {
       url: import_typed_graphqlify4.types.string,
-      nameWithOwner: import_typed_graphqlify4.types.string
+      nameWithOwner: import_typed_graphqlify4.types.string,
+      name: import_typed_graphqlify4.types.string,
+      owner: {
+        login: import_typed_graphqlify4.types.string
+      }
     }
   },
   baseRefName: import_typed_graphqlify4.types.string,

--- a/ng-dev/pr/common/fetch-pull-request.ts
+++ b/ng-dev/pr/common/fetch-pull-request.ts
@@ -86,6 +86,10 @@ export const PR_SCHEMA = {
     repository: {
       url: graphqlTypes.string,
       nameWithOwner: graphqlTypes.string,
+      name: graphqlTypes.string,
+      owner: {
+        login: graphqlTypes.string,
+      },
     },
   },
   baseRef: {
@@ -93,6 +97,10 @@ export const PR_SCHEMA = {
     repository: {
       url: graphqlTypes.string,
       nameWithOwner: graphqlTypes.string,
+      name: graphqlTypes.string,
+      owner: {
+        login: graphqlTypes.string,
+      },
     },
   },
   baseRefName: graphqlTypes.string,


### PR DESCRIPTION
Add support for autosquashing fixup commits before using the Github API to merge pull requests with the API merge strategy, for non-squash usage.

The pull request is updated with the rebased commits and then immediately merged as the statuses can be safely skipped as they will match the previous run with only an autosquash changing.