### PR TITLE
ci: reduce renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,10 @@
       "groupName": "angular dependencies"
     },
     {
+      "matchPackageNames": "renovate",
+      "schedule": ["after 10:00pm", "before 5:00am"]
+    },
+    {
       "matchPackageNames": ["typescript"],
       "updateTypes": ["major"],
       "enabled": false


### PR DESCRIPTION
Renovate publishes on a per commit basis. We should try reducing PRs being merged in this repo as it would otherwise cause unnecessary PRs in downstream repos like framework.