### PR TITLE
refactor(ng-dev): use the graphql method from octokit instead of standalone graphql

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -48747,7 +48747,7 @@ var require_dist_node6 = __commonJS({
     var NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
     var FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
     var GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
-    function graphql2(request2, query2, options) {
+    function graphql(request2, query2, options) {
       if (options) {
         if (typeof query2 === "string" && "query" in options) {
           return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
@@ -48790,7 +48790,7 @@ var require_dist_node6 = __commonJS({
     function withDefaults(request$1, newDefaults) {
       const newRequest = request$1.defaults(newDefaults);
       const newApi = (query2, options) => {
-        return graphql2(newRequest, query2, options);
+        return graphql(newRequest, query2, options);
       };
       return Object.assign(newApi, {
         defaults: withDefaults.bind(null, newRequest),
@@ -49468,7 +49468,7 @@ var require_dist_node8 = __commonJS({
     var universalUserAgent = require_dist_node();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node5();
-    var graphql2 = require_dist_node6();
+    var graphql = require_dist_node6();
     var authToken = require_dist_node7();
     var VERSION = "4.0.5";
     var Octokit3 = class {
@@ -49496,7 +49496,7 @@ var require_dist_node8 = __commonJS({
           requestDefaults.headers["time-zone"] = options.timeZone;
         }
         this.request = request.request.defaults(requestDefaults);
-        this.graphql = graphql2.withCustomRequest(this.request).defaults(requestDefaults);
+        this.graphql = graphql.withCustomRequest(this.request).defaults(requestDefaults);
         this.log = Object.assign({
           debug: () => {
           },
@@ -61164,7 +61164,7 @@ var require_dist_node25 = __commonJS({
     var NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
     var FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
     var GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
-    function graphql2(request2, query2, options) {
+    function graphql(request2, query2, options) {
       if (options) {
         if (typeof query2 === "string" && "query" in options) {
           return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
@@ -61207,7 +61207,7 @@ var require_dist_node25 = __commonJS({
     function withDefaults(request$1, newDefaults) {
       const newRequest = request$1.defaults(newDefaults);
       const newApi = (query2, options) => {
-        return graphql2(newRequest, query2, options);
+        return graphql(newRequest, query2, options);
       };
       return Object.assign(newApi, {
         defaults: withDefaults.bind(null, newRequest),
@@ -61287,7 +61287,7 @@ var require_dist_node27 = __commonJS({
     var universalUserAgent = require_dist_node();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node24();
-    var graphql2 = require_dist_node25();
+    var graphql = require_dist_node25();
     var authToken = require_dist_node26();
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null)
@@ -61348,7 +61348,7 @@ var require_dist_node27 = __commonJS({
           requestDefaults.headers["time-zone"] = options.timeZone;
         }
         this.request = request.request.defaults(requestDefaults);
-        this.graphql = graphql2.withCustomRequest(this.request).defaults(requestDefaults);
+        this.graphql = graphql.withCustomRequest(this.request).defaults(requestDefaults);
         this.log = Object.assign({
           debug: () => {
           },
@@ -70181,7 +70181,6 @@ var DryRunError = class extends Error {
 import { spawnSync } from "child_process";
 
 // 
-var import_graphql2 = __toESM(require_dist_node6());
 var import_rest = __toESM(require_dist_node12());
 var import_typed_graphqlify4 = __toESM(require_dist2());
 var GithubClient = class {
@@ -70200,13 +70199,11 @@ var GithubClient = class {
   }
 };
 var AuthenticatedGithubClient = class extends GithubClient {
-  constructor(_token) {
-    super({ auth: _token });
-    this._token = _token;
-    this._graphql = import_graphql2.graphql.defaults({ headers: { authorization: `token ${this._token}` } });
+  constructor(token2) {
+    super({ auth: token2 });
   }
   async graphql(queryObject, params4 = {}) {
-    return await this._graphql((0, import_typed_graphqlify4.query)(queryObject).toString(), params4);
+    return await this._octokit.graphql((0, import_typed_graphqlify4.query)(queryObject).toString(), params4);
   }
 };
 

--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -9579,7 +9579,7 @@ var require_dist_node6 = __commonJS({
     var NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
     var FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
     var GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
-    function graphql2(request2, query2, options) {
+    function graphql(request2, query2, options) {
       if (options) {
         if (typeof query2 === "string" && "query" in options) {
           return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
@@ -9622,7 +9622,7 @@ var require_dist_node6 = __commonJS({
     function withDefaults(request$1, newDefaults) {
       const newRequest = request$1.defaults(newDefaults);
       const newApi = (query2, options) => {
-        return graphql2(newRequest, query2, options);
+        return graphql(newRequest, query2, options);
       };
       return Object.assign(newApi, {
         defaults: withDefaults.bind(null, newRequest),
@@ -9702,7 +9702,7 @@ var require_dist_node8 = __commonJS({
     var universalUserAgent = require_dist_node();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node5();
-    var graphql2 = require_dist_node6();
+    var graphql = require_dist_node6();
     var authToken = require_dist_node7();
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null)
@@ -9763,7 +9763,7 @@ var require_dist_node8 = __commonJS({
           requestDefaults.headers["time-zone"] = options.timeZone;
         }
         this.request = request.request.defaults(requestDefaults);
-        this.graphql = graphql2.withCustomRequest(this.request).defaults(requestDefaults);
+        this.graphql = graphql.withCustomRequest(this.request).defaults(requestDefaults);
         this.log = Object.assign({
           debug: () => {
           },
@@ -51474,7 +51474,7 @@ var require_dist_node14 = __commonJS({
     var NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
     var FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
     var GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
-    function graphql2(request2, query2, options) {
+    function graphql(request2, query2, options) {
       if (options) {
         if (typeof query2 === "string" && "query" in options) {
           return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
@@ -51517,7 +51517,7 @@ var require_dist_node14 = __commonJS({
     function withDefaults(request$1, newDefaults) {
       const newRequest = request$1.defaults(newDefaults);
       const newApi = (query2, options) => {
-        return graphql2(newRequest, query2, options);
+        return graphql(newRequest, query2, options);
       };
       return Object.assign(newApi, {
         defaults: withDefaults.bind(null, newRequest),
@@ -51597,7 +51597,7 @@ var require_dist_node16 = __commonJS({
     var universalUserAgent = require_dist_node();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node13();
-    var graphql2 = require_dist_node14();
+    var graphql = require_dist_node14();
     var authToken = require_dist_node15();
     var VERSION = "4.0.5";
     var Octokit3 = class {
@@ -51625,7 +51625,7 @@ var require_dist_node16 = __commonJS({
           requestDefaults.headers["time-zone"] = options.timeZone;
         }
         this.request = request.request.defaults(requestDefaults);
-        this.graphql = graphql2.withCustomRequest(this.request).defaults(requestDefaults);
+        this.graphql = graphql.withCustomRequest(this.request).defaults(requestDefaults);
         this.log = Object.assign({
           debug: () => {
           },
@@ -65795,7 +65795,6 @@ async function readConfigFile(configPath, returnEmptyObjectOnError = false) {
 import { spawnSync } from "child_process";
 
 // 
-var import_graphql = __toESM(require_dist_node14());
 var import_rest = __toESM(require_dist_node20());
 var import_typed_graphqlify = __toESM(require_dist2());
 var GithubClient = class {
@@ -65814,13 +65813,11 @@ var GithubClient = class {
   }
 };
 var AuthenticatedGithubClient = class extends GithubClient {
-  constructor(_token) {
-    super({ auth: _token });
-    this._token = _token;
-    this._graphql = import_graphql.graphql.defaults({ headers: { authorization: `token ${this._token}` } });
+  constructor(token) {
+    super({ auth: token });
   }
   async graphql(queryObject, params2 = {}) {
-    return await this._graphql((0, import_typed_graphqlify.query)(queryObject).toString(), params2);
+    return await this._octokit.graphql((0, import_typed_graphqlify.query)(queryObject).toString(), params2);
   }
 };
 

--- a/github-actions/create-pr-for-changes/main.js
+++ b/github-actions/create-pr-for-changes/main.js
@@ -9579,7 +9579,7 @@ var require_dist_node6 = __commonJS({
     var NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
     var FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
     var GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
-    function graphql2(request2, query2, options) {
+    function graphql(request2, query2, options) {
       if (options) {
         if (typeof query2 === "string" && "query" in options) {
           return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
@@ -9622,7 +9622,7 @@ var require_dist_node6 = __commonJS({
     function withDefaults(request$1, newDefaults) {
       const newRequest = request$1.defaults(newDefaults);
       const newApi = (query2, options) => {
-        return graphql2(newRequest, query2, options);
+        return graphql(newRequest, query2, options);
       };
       return Object.assign(newApi, {
         defaults: withDefaults.bind(null, newRequest),
@@ -9702,7 +9702,7 @@ var require_dist_node8 = __commonJS({
     var universalUserAgent = require_dist_node();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node5();
-    var graphql2 = require_dist_node6();
+    var graphql = require_dist_node6();
     var authToken = require_dist_node7();
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null)
@@ -9763,7 +9763,7 @@ var require_dist_node8 = __commonJS({
           requestDefaults.headers["time-zone"] = options.timeZone;
         }
         this.request = request.request.defaults(requestDefaults);
-        this.graphql = graphql2.withCustomRequest(this.request).defaults(requestDefaults);
+        this.graphql = graphql.withCustomRequest(this.request).defaults(requestDefaults);
         this.log = Object.assign({
           debug: () => {
           },
@@ -14668,7 +14668,7 @@ var require_dist_node14 = __commonJS({
     var NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
     var FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
     var GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
-    function graphql2(request2, query2, options) {
+    function graphql(request2, query2, options) {
       if (options) {
         if (typeof query2 === "string" && "query" in options) {
           return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
@@ -14711,7 +14711,7 @@ var require_dist_node14 = __commonJS({
     function withDefaults(request$1, newDefaults) {
       const newRequest = request$1.defaults(newDefaults);
       const newApi = (query2, options) => {
-        return graphql2(newRequest, query2, options);
+        return graphql(newRequest, query2, options);
       };
       return Object.assign(newApi, {
         defaults: withDefaults.bind(null, newRequest),
@@ -14791,7 +14791,7 @@ var require_dist_node16 = __commonJS({
     var universalUserAgent = require_dist_node();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node13();
-    var graphql2 = require_dist_node14();
+    var graphql = require_dist_node14();
     var authToken = require_dist_node15();
     var VERSION = "4.0.5";
     var Octokit2 = class {
@@ -14819,7 +14819,7 @@ var require_dist_node16 = __commonJS({
           requestDefaults.headers["time-zone"] = options.timeZone;
         }
         this.request = request.request.defaults(requestDefaults);
-        this.graphql = graphql2.withCustomRequest(this.request).defaults(requestDefaults);
+        this.graphql = graphql.withCustomRequest(this.request).defaults(requestDefaults);
         this.log = Object.assign({
           debug: () => {
           },
@@ -16953,7 +16953,6 @@ var DryRunError = class extends Error {
 import { spawnSync } from "child_process";
 
 // 
-var import_graphql = __toESM(require_dist_node14());
 var import_rest = __toESM(require_dist_node20());
 var import_typed_graphqlify2 = __toESM(require_dist2());
 var GithubClient = class {
@@ -16972,13 +16971,11 @@ var GithubClient = class {
   }
 };
 var AuthenticatedGithubClient = class extends GithubClient {
-  constructor(_token) {
-    super({ auth: _token });
-    this._token = _token;
-    this._graphql = import_graphql.graphql.defaults({ headers: { authorization: `token ${this._token}` } });
+  constructor(token) {
+    super({ auth: token });
   }
   async graphql(queryObject, params2 = {}) {
-    return await this._graphql((0, import_typed_graphqlify2.query)(queryObject).toString(), params2);
+    return await this._octokit.graphql((0, import_typed_graphqlify2.query)(queryObject).toString(), params2);
   }
 };
 

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -9586,7 +9586,7 @@ var require_dist_node6 = __commonJS({
     var NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
     var FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
     var GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
-    function graphql2(request2, query2, options) {
+    function graphql(request2, query2, options) {
       if (options) {
         if (typeof query2 === "string" && "query" in options) {
           return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
@@ -9629,7 +9629,7 @@ var require_dist_node6 = __commonJS({
     function withDefaults(request$1, newDefaults) {
       const newRequest = request$1.defaults(newDefaults);
       const newApi = (query2, options) => {
-        return graphql2(newRequest, query2, options);
+        return graphql(newRequest, query2, options);
       };
       return Object.assign(newApi, {
         defaults: withDefaults.bind(null, newRequest),
@@ -9709,7 +9709,7 @@ var require_dist_node8 = __commonJS({
     var universalUserAgent = require_dist_node();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node5();
-    var graphql2 = require_dist_node6();
+    var graphql = require_dist_node6();
     var authToken = require_dist_node7();
     function _objectWithoutPropertiesLoose(source, excluded) {
       if (source == null)
@@ -9770,7 +9770,7 @@ var require_dist_node8 = __commonJS({
           requestDefaults.headers["time-zone"] = options.timeZone;
         }
         this.request = request.request.defaults(requestDefaults);
-        this.graphql = graphql2.withCustomRequest(this.request).defaults(requestDefaults);
+        this.graphql = graphql.withCustomRequest(this.request).defaults(requestDefaults);
         this.log = Object.assign({
           debug: () => {
           },
@@ -29224,7 +29224,7 @@ var require_dist_node14 = __commonJS({
     var NON_VARIABLE_OPTIONS = ["method", "baseUrl", "url", "headers", "request", "query", "mediaType"];
     var FORBIDDEN_VARIABLE_OPTIONS = ["query", "method", "url"];
     var GHES_V3_SUFFIX_REGEX = /\/api\/v3\/?$/;
-    function graphql2(request2, query2, options) {
+    function graphql(request2, query2, options) {
       if (options) {
         if (typeof query2 === "string" && "query" in options) {
           return Promise.reject(new Error(`[@octokit/graphql] "query" cannot be used as variable name`));
@@ -29267,7 +29267,7 @@ var require_dist_node14 = __commonJS({
     function withDefaults(request$1, newDefaults) {
       const newRequest = request$1.defaults(newDefaults);
       const newApi = (query2, options) => {
-        return graphql2(newRequest, query2, options);
+        return graphql(newRequest, query2, options);
       };
       return Object.assign(newApi, {
         defaults: withDefaults.bind(null, newRequest),
@@ -29347,7 +29347,7 @@ var require_dist_node16 = __commonJS({
     var universalUserAgent = require_dist_node();
     var beforeAfterHook = require_before_after_hook();
     var request = require_dist_node13();
-    var graphql2 = require_dist_node14();
+    var graphql = require_dist_node14();
     var authToken = require_dist_node15();
     var VERSION = "4.0.5";
     var Octokit4 = class {
@@ -29375,7 +29375,7 @@ var require_dist_node16 = __commonJS({
           requestDefaults.headers["time-zone"] = options.timeZone;
         }
         this.request = request.request.defaults(requestDefaults);
-        this.graphql = graphql2.withCustomRequest(this.request).defaults(requestDefaults);
+        this.graphql = graphql.withCustomRequest(this.request).defaults(requestDefaults);
         this.log = Object.assign({
           debug: () => {
           },
@@ -63578,7 +63578,6 @@ var DryRunError = class extends Error {
 import { spawnSync } from "child_process";
 
 // 
-var import_graphql = __toESM(require_dist_node14());
 var import_rest = __toESM(require_dist_node20());
 var import_typed_graphqlify2 = __toESM(require_dist2());
 var GithubClient = class {
@@ -63597,13 +63596,11 @@ var GithubClient = class {
   }
 };
 var AuthenticatedGithubClient = class extends GithubClient {
-  constructor(_token) {
-    super({ auth: _token });
-    this._token = _token;
-    this._graphql = import_graphql.graphql.defaults({ headers: { authorization: `token ${this._token}` } });
+  constructor(token) {
+    super({ auth: token });
   }
   async graphql(queryObject, params4 = {}) {
-    return await this._graphql((0, import_typed_graphqlify2.query)(queryObject).toString(), params4);
+    return await this._octokit.graphql((0, import_typed_graphqlify2.query)(queryObject).toString(), params4);
   }
 };
 
@@ -68022,7 +68019,7 @@ var Prompt2 = class {
 
 // 
 var import_typed_graphqlify3 = __toESM(require_dist2());
-var import_graphql2 = __toESM(require_dist_node14());
+var import_graphql = __toESM(require_dist_node14());
 async function getPr(prSchema, prNumber, git) {
   var _a;
   const { owner, name } = git.remoteConfig;
@@ -68039,7 +68036,7 @@ async function getPr(prSchema, prNumber, git) {
     const result = await git.github.graphql(PR_QUERY, { number: prNumber, owner, name });
     return result.repository.pullRequest;
   } catch (e2) {
-    if (e2 instanceof import_graphql2.GraphqlResponseError && ((_a = e2.errors) == null ? void 0 : _a.every((e3) => e3.type === "NOT_FOUND"))) {
+    if (e2 instanceof import_graphql.GraphqlResponseError && ((_a = e2.errors) == null ? void 0 : _a.every((e3) => e3.type === "NOT_FOUND"))) {
       return null;
     }
     throw e2;

--- a/ng-dev/utils/git/github.ts
+++ b/ng-dev/utils/git/github.ts
@@ -8,7 +8,6 @@
 
 import type {OctokitOptions} from '@octokit/core/dist-types/types.js';
 
-import {graphql} from '@octokit/graphql';
 import {Octokit} from '@octokit/rest';
 import {RequestParameters} from '@octokit/types';
 import {RequestError} from '@octokit/request-error';
@@ -35,7 +34,7 @@ export interface GithubRepo {
 /** A Github client for interacting with the Github APIs. */
 export class GithubClient {
   /** The octokit instance actually performing API requests. */
-  private _octokit = new Octokit(this._octokitOptions);
+  protected _octokit = new Octokit(this._octokitOptions);
 
   readonly pulls = this._octokit.pulls;
   readonly repos = this._octokit.repos;
@@ -55,16 +54,13 @@ export class GithubClient {
  * to authenticated instances.
  */
 export class AuthenticatedGithubClient extends GithubClient {
-  /** The graphql instance with authentication set during construction. */
-  private _graphql = graphql.defaults({headers: {authorization: `token ${this._token}`}});
-
-  constructor(private _token: string) {
+  constructor(token: string) {
     // Set the token for the octokit instance.
-    super({auth: _token});
+    super({auth: token});
   }
 
   /** Perform a query using Github's Graphql API. */
   async graphql<T extends GraphqlQueryObject>(queryObject: T, params: RequestParameters = {}) {
-    return (await this._graphql(query(queryObject).toString(), params)) as T;
+    return (await this._octokit.graphql(query(queryObject).toString(), params)) as T;
   }
 }


### PR DESCRIPTION
Simplify what we do by just using the graphql method rather than creating our own.