### PR TITLE
fix(bazel): resolve generated temporary directory

### DIFF
--- a/bazel/integration/test_runner/runner.ts
+++ b/bazel/integration/test_runner/runner.ts
@@ -119,7 +119,7 @@ export class TestRunner {
           // manually and need full control over the directory persistence.
           keep: true,
         },
-        (err, tmpPath) => (err ? reject(err) : resolve(tmpPath)),
+        (err, tmpPath) => (err ? reject(err) : resolve(path.resolve(tmpPath))),
       );
     });
   }


### PR DESCRIPTION
Resolve temporary generated directory to absolute. This is needed to fix https://app.circleci.com/pipelines/github/angular/components/51670/workflows/1e0353a2-29ab-41ee-b237-8be7bc3970a8/jobs/465493