### PR TITLE
fix(ng-dev): update changelog generation templates

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -66128,13 +66128,6 @@ function compareString(a, b) {
 
 // 
 var typesToIncludeInReleaseNotes = Object.values(COMMIT_TYPES).filter((type) => type.releaseNotesLevel === ReleaseNotesLevel.Visible).map((type) => type.name);
-var botsAuthorNames = [
-  "dependabot[bot]",
-  "Renovate Bot",
-  "angular-robot",
-  "angular-robot[bot]",
-  "Angular Robot"
-];
 var RenderContext = class {
   constructor(data) {
     this.data = data;
@@ -66225,9 +66218,6 @@ var RenderContext = class {
   }
   bulletizeText(text) {
     return "- " + text.replace(/\n/g, "\n  ");
-  }
-  commitAuthors(commits) {
-    return [...new Set(commits.map((c) => c.author))].filter((a) => !botsAuthorNames.includes(a)).sort();
   }
   commitToBadge(commit) {
     let color = "yellow";
@@ -66321,27 +66311,29 @@ _%>
 }
 _%>
 
-<%_
-const authors = commitAuthors(commits);
-if (authors.length === 1) {
-_%>
-## Special Thanks
-<%- authors[0]%>
-<%_
-}
-if (authors.length > 1) {
-_%>
-## Special Thanks
-<%- authors.slice(0, -1).join(', ') %> and <%- authors.slice(-1)[0] %>
-<%_
-}
-_%>
 `;
 
 // 
 var github_release_default = `
 <a name="<%- urlFragmentForRelease %>"></a>
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
+
+<%_
+const commitsInChangelog = commits.filter(includeInReleaseNotes());
+for (const group of asCommitGroups(commitsInChangelog)) {
+_%>
+
+### <%- group.title %>
+| Commit | Description |
+| -- | -- |
+<%_
+  for (const commit of group.commits) {
+_%>
+| <%- commitToBadge(commit) %> | <%- commit.description %> |
+<%_
+  }
+}
+_%>
 
 <%_
 const breakingChanges = commits.filter(hasBreakingChanges);
@@ -66383,39 +66375,6 @@ _%>
       }
     }
   }
-}
-_%>
-
-<%_
-const commitsInChangelog = commits.filter(includeInReleaseNotes());
-for (const group of asCommitGroups(commitsInChangelog)) {
-_%>
-
-### <%- group.title %>
-| Commit | Description |
-| -- | -- |
-<%_
-  for (const commit of group.commits) {
-_%>
-| <%- commitToBadge(commit) %> | <%- commit.description %> |
-<%_
-  }
-}
-_%>
-
-<%_
-const authors = commitAuthors(commits);
-if (authors.length === 1) {
-_%>
-## Special Thanks
-<%- authors[0]%>
-<%_
-}
-if (authors.length > 1) {
-_%>
-## Special Thanks
-<%- authors.slice(0, -1).join(', ') %> and <%- authors.slice(-1)[0] %>
-<%_
 }
 _%>
 `;

--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -213,15 +213,6 @@ export class RenderContext {
   }
 
   /**
-   * Returns unique, sorted and filtered commit authors.
-   */
-  commitAuthors(commits: CategorizedCommit[]): string[] {
-    return [...new Set(commits.map((c) => c.author))]
-      .filter((a) => !botsAuthorNames.includes(a))
-      .sort();
-  }
-
-  /**
    * Convert a commit object to a Markdown linked badged.
    */
   commitToBadge(commit: CategorizedCommit): string {

--- a/ng-dev/release/notes/templates/changelog.ts
+++ b/ng-dev/release/notes/templates/changelog.ts
@@ -72,19 +72,4 @@ _%>
 }
 _%>
 
-<%_
-const authors = commitAuthors(commits);
-if (authors.length === 1) {
-_%>
-## Special Thanks
-<%- authors[0]%>
-<%_
-}
-if (authors.length > 1) {
-_%>
-## Special Thanks
-<%- authors.slice(0, -1).join(', ') %> and <%- authors.slice(-1)[0] %>
-<%_
-}
-_%>
 `;

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -11,6 +11,23 @@ export default `
 # <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
 
 <%_
+const commitsInChangelog = commits.filter(includeInReleaseNotes());
+for (const group of asCommitGroups(commitsInChangelog)) {
+_%>
+
+### <%- group.title %>
+| Commit | Description |
+| -- | -- |
+<%_
+  for (const commit of group.commits) {
+_%>
+| <%- commitToBadge(commit) %> | <%- commit.description %> |
+<%_
+  }
+}
+_%>
+
+<%_
 const breakingChanges = commits.filter(hasBreakingChanges);
 if (breakingChanges.length) {
 _%>
@@ -50,39 +67,6 @@ _%>
       }
     }
   }
-}
-_%>
-
-<%_
-const commitsInChangelog = commits.filter(includeInReleaseNotes());
-for (const group of asCommitGroups(commitsInChangelog)) {
-_%>
-
-### <%- group.title %>
-| Commit | Description |
-| -- | -- |
-<%_
-  for (const commit of group.commits) {
-_%>
-| <%- commitToBadge(commit) %> | <%- commit.description %> |
-<%_
-  }
-}
-_%>
-
-<%_
-const authors = commitAuthors(commits);
-if (authors.length === 1) {
-_%>
-## Special Thanks
-<%- authors[0]%>
-<%_
-}
-if (authors.length > 1) {
-_%>
-## Special Thanks
-<%- authors.slice(0, -1).join(', ') %> and <%- authors.slice(-1)[0] %>
-<%_
 }
 _%>
 `;

--- a/ng-dev/release/publish/test/common.spec.ts
+++ b/ng-dev/release/publish/test/common.spec.ts
@@ -249,7 +249,6 @@ describe('common release action logic', () => {
             | -- | -- |
             | <..> | first commit |
             | <..> | second commit |
-            ## Special Thanks
           `,
         );
 

--- a/ng-dev/release/publish/test/cut-lts-patch.spec.ts
+++ b/ng-dev/release/publish/test/cut-lts-patch.spec.ts
@@ -128,7 +128,6 @@ describe('cut an LTS patch action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *1 |
       | <..> | feat | not yet released *2 |
-      ## Special Thanks
     `);
   });
 

--- a/ng-dev/release/publish/test/cut-new-patch.spec.ts
+++ b/ng-dev/release/publish/test/cut-new-patch.spec.ts
@@ -114,7 +114,6 @@ describe('cut new patch action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *1 |
       | <..> | feat | not yet released *2 |
-      ## Special Thanks
     `);
   });
 });

--- a/ng-dev/release/publish/test/cut-npm-next-prerelease.spec.ts
+++ b/ng-dev/release/publish/test/cut-npm-next-prerelease.spec.ts
@@ -123,7 +123,7 @@ describe('cut npm next pre-release action', () => {
           | <..> | feat | not released yet, but cherry-picked |
           | <..> | feat | only in next, not released yet *1 |
           | <..> | feat | only in next, not released yet *2 |
-          ## Special Thanks
+
         `);
       },
     );
@@ -181,7 +181,6 @@ describe('cut npm next pre-release action', () => {
         | -- | -- | -- |
         | <..> | feat | not released yet *1 |
         | <..> | feat | not released yet *2 |
-        ## Special Thanks
       `);
     });
   });
@@ -238,7 +237,6 @@ describe('cut npm next pre-release action', () => {
         | -- | -- | -- |
         | <..> | feat | not released yet *1 |
         | <..> | feat | not released yet *2 |
-        ## Special Thanks
       `);
     });
   });

--- a/ng-dev/release/publish/test/cut-npm-next-release-candidate.spec.ts
+++ b/ng-dev/release/publish/test/cut-npm-next-release-candidate.spec.ts
@@ -109,7 +109,6 @@ describe('cut npm next release candidate action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *1 |
       | <..> | fix | not yet released *2 |
-      ## Special Thanks
     `);
   });
 });

--- a/ng-dev/release/publish/test/cut-stable.spec.ts
+++ b/ng-dev/release/publish/test/cut-stable.spec.ts
@@ -231,7 +231,6 @@ describe('cut stable action', () => {
       | <..> | fix | released first next pre-release *2 |
       | <..> | fix | released release-candidate *1 |
       | <..> | fix | released release-candidate *2 |
-      ## Special Thanks
     `);
     },
   );
@@ -466,7 +465,6 @@ describe('cut stable action', () => {
         | <..> | fix | released first -next pre-release *2 |
         | <..> | fix | released second -next pre-release *1 |
         | <..> | fix | released second -next pre-release *2 |
-        ## Special Thanks
       `);
       },
     );

--- a/ng-dev/release/publish/test/exceptional-minor/cut-exceptional-minor-prerelease.spec.ts
+++ b/ng-dev/release/publish/test/exceptional-minor/cut-exceptional-minor-prerelease.spec.ts
@@ -114,7 +114,7 @@ describe('cut exceptional minor pre-release action', () => {
           | -- | -- | -- |
           | <..> | feat | not released yet *1 |
           | <..> | feat | not released yet *2 |
-          ## Special Thanks
+
         `);
     });
   });
@@ -175,7 +175,6 @@ describe('cut exceptional minor pre-release action', () => {
         | -- | -- | -- |
         | <..> | feat | not released yet *1 |
         | <..> | feat | not released yet *2 |
-        ## Special Thanks
       `);
     });
   });
@@ -236,7 +235,6 @@ describe('cut exceptional minor pre-release action', () => {
         | -- | -- | -- |
         | <..> | feat | not released yet *1 |
         | <..> | feat | not released yet *2 |
-        ## Special Thanks
       `);
     });
   });

--- a/ng-dev/release/publish/test/exceptional-minor/cut-exceptional-minor-release-candidate.spec.ts
+++ b/ng-dev/release/publish/test/exceptional-minor/cut-exceptional-minor-release-candidate.spec.ts
@@ -111,7 +111,6 @@ describe('cut exceptional minor next release candidate action', () => {
       | Commit | Type | Description |
       | -- | -- | -- |
       | <..> | fix | not yet released *2 |
-      ## Special Thanks
     `);
   });
 
@@ -153,7 +152,6 @@ describe('cut exceptional minor next release candidate action', () => {
       | -- | -- | -- |
       | <..> | feat | patch, not released |
       | <..> | fix | not yet released *2 |
-      ## Special Thanks
     `);
     },
   );

--- a/ng-dev/release/publish/test/move-next-into-feature-freeze.spec.ts
+++ b/ng-dev/release/publish/test/move-next-into-feature-freeze.spec.ts
@@ -181,7 +181,6 @@ describe('move next into feature-freeze action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *1 |
       | <..> | fix | not yet released *2 |
-      ## Special Thanks
     `);
   });
 });

--- a/ng-dev/release/publish/test/move-next-into-release-candidate.spec.ts
+++ b/ng-dev/release/publish/test/move-next-into-release-candidate.spec.ts
@@ -162,7 +162,6 @@ describe('move next into release-candidate action', () => {
       | -- | -- | -- |
       | <..> | feat | not yet released *1 |
       | <..> | fix | not yet released *2 |
-      ## Special Thanks
     `);
   });
 

--- a/ng-dev/release/publish/test/release-notes/generation.spec.ts
+++ b/ng-dev/release/publish/test/release-notes/generation.spec.ts
@@ -69,7 +69,6 @@ describe('release notes generation', () => {
           | -- | -- | -- |
           | <..> | fix | commit *3 |
           | <..> | fix | commit *4 |
-          ## Special Thanks
         `);
       });
 
@@ -105,7 +104,6 @@ describe('release notes generation', () => {
           | -- | -- | -- |
           | <..> | fix | commit *3 |
           | <..> | fix | commit *4 |
-          ## Special Thanks
         `);
       });
 
@@ -143,7 +141,6 @@ describe('release notes generation', () => {
           | Commit | Type | Description |
           | -- | -- | -- |
           | <..> | fix | platform: fix detection of chromium |
-          ## Special Thanks
         `);
       });
 
@@ -187,7 +184,6 @@ describe('release notes generation', () => {
           | Commit | Type | Description |
           | -- | -- | -- |
           | <..> | fix | slider/testing: missing stabilization |
-          ## Special Thanks
         `);
       });
     });
@@ -207,7 +203,6 @@ describe('release notes generation', () => {
         | -- | -- | -- |
         | <..> | fix | commit ([#2](<..>/pull/2)) |
         | <..> | fix | commit [#1](<..>/pull/1) |
-        ## Special Thanks
       `);
     });
 
@@ -238,7 +233,6 @@ describe('release notes generation', () => {
         | -- | -- | -- |
         | <..> | fix | not yet released *1 |
         | <..> | refactor | with breaking change |
-        ## Special Thanks
       `);
     });
 
@@ -271,7 +265,6 @@ describe('release notes generation', () => {
         | -- | -- | -- |
         | <..> | fix | not yet released *1 |
         | <..> | refactor | with breaking change |
-        ## Special Thanks
       `);
     });
 
@@ -307,7 +300,6 @@ describe('release notes generation', () => {
         | -- | -- | -- |
         | <..> | fix | not yet released *1 |
         | <..> | refactor | with breaking change |
-        ## Special Thanks
       `);
     });
 
@@ -337,7 +329,6 @@ describe('release notes generation', () => {
         | -- | -- | -- |
         | <..> | fix | not yet released *1 |
         | <..> | refactor | with deprecation |
-        ## Special Thanks
       `);
     });
 
@@ -370,7 +361,6 @@ describe('release notes generation', () => {
         | -- | -- | -- |
         | <..> | fix | not yet released *1 |
         | <..> | refactor | with deprecation |
-        ## Special Thanks
       `);
     });
   });
@@ -404,7 +394,6 @@ describe('release notes generation', () => {
           | -- | -- |
           | <..> | commit *3 |
           | <..> | commit *4 |
-          ## Special Thanks
         `);
       });
 
@@ -440,7 +429,6 @@ describe('release notes generation', () => {
           | -- | -- |
           | <..> | commit *3 |
           | <..> | commit *4 |
-          ## Special Thanks
         `);
       });
 
@@ -478,7 +466,6 @@ describe('release notes generation', () => {
           | Commit | Description |
           | -- | -- |
           | <..> | platform: fix detection of chromium |
-          ## Special Thanks
         `);
       });
 
@@ -522,7 +509,6 @@ describe('release notes generation', () => {
           | Commit | Description |
           | -- | -- |
           | <..> | slider/testing: missing stabilization |
-          ## Special Thanks
         `);
       });
     });
@@ -546,15 +532,14 @@ describe('release notes generation', () => {
 
       expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
         # 13.0.0 <..>
-        ## Breaking Changes
-        ### cdk/a11y
-        - Description of breaking change.
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
         | <..> | not yet released *1 |
         | <..> | with breaking change |
-        ## Special Thanks
+        ## Breaking Changes
+        ### cdk/a11y
+        - Description of breaking change.
       `);
     });
 
@@ -578,16 +563,15 @@ describe('release notes generation', () => {
 
       expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
         # 13.0.0 <..>
-        ## Breaking Changes
-        ### cdk/a11y
-        - Description of breaking change.
-        - Description of breaking change 2.
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
         | <..> | not yet released *1 |
         | <..> | with breaking change |
-        ## Special Thanks
+        ## Breaking Changes
+        ### cdk/a11y
+        - Description of breaking change.
+        - Description of breaking change 2.
       `);
     });
 
@@ -609,15 +593,14 @@ describe('release notes generation', () => {
 
       expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
         # 13.0.0 <..>
-        ## Deprecations
-        ### cdk/a11y
-        - Description of deprecation.
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
         | <..> | not yet released *1 |
         | <..> | with deprecation |
-        ## Special Thanks
+        ## Deprecations
+        ### cdk/a11y
+        - Description of deprecation.
       `);
     });
   });
@@ -642,16 +625,15 @@ describe('release notes generation', () => {
 
     expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
       # 13.0.0 <..>
-      ## Deprecations
-      ### cdk/a11y
-      - Description of deprecation.
-      - Description of deprecation 2.
       ### cdk/a11y
       | Commit | Description |
       | -- | -- |
       | <..> | not yet released *1 |
       | <..> | with deprecation |
-      ## Special Thanks
+      ## Deprecations
+      ### cdk/a11y
+      - Description of deprecation.
+      - Description of deprecation 2.
     `);
   });
 


### PR DESCRIPTION
Remove the special thanks section and reorder the github release notes for better banner generation.