### PR TITLE
feat(github-actions): provide preview url as an output of the firebase previews action

### DIFF
--- a/github-actions/deploy-previews/upload-artifacts-to-firebase/action.yml
+++ b/github-actions/deploy-previews/upload-artifacts-to-firebase/action.yml
@@ -46,6 +46,11 @@ inputs:
     description: |
       TRUSTED: Contents of a Firebase service key authorizing the deployment.
 
+outputs:
+  url:
+    description: 'The base url of the preview deployed to firebase'
+    value: ${{ steps.deploy.outputs.details_url }}
+
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Provide the url to the preview server as an output of the deploy-previews action. This url can then be used to extend functionality of the preview server for things such as lighthouse testing.