### PR TITLE
ci: update the generated files in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
   "ignoreDeps": ["rules_pkg"],
   "enabledManagers": ["npm", "bazel", "github-actions"],
   "baseBranches": ["main"],
+  "postUpgradeTasks": {
+    "commands": ["yarn update-generated-files"],
+    "fileFilters": ["**/*"]
+  },
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
Update the generated files in renovate to automatically update the generated github actions during dependency updates.