### PR TITLE
refactor: resolve TODO to remove type non-null cast

### DIFF
--- a/ng-dev/pr/check-target-branches/check-target-branches.ts
+++ b/ng-dev/pr/check-target-branches/check-target-branches.ts
@@ -26,12 +26,8 @@ async function getTargetBranchesForPr(
   /** The current state of the pull request from Github. */
   const prData = (await git.github.pulls.get({owner, repo, pull_number: prNumber})).data;
   /** The list of labels on the PR as strings. */
-  // Note: The `name` property of labels is always set but the Github OpenAPI spec is incorrect
-  // here.
-  // TODO(devversion): Remove the non-null cast once
-  // https://github.com/github/rest-api-description/issues/169 is fixed.
-  const labels = prData.labels.map((l) => l.name!);
-  /** The branch targetted via the Github UI. */
+  const labels = prData.labels.map((l) => l.name);
+  /** The branch targeted via the Github UI. */
   const githubTargetBranch = prData.base.ref;
 
   const activeReleaseTrains = await ActiveReleaseTrains.fetch({


### PR DESCRIPTION
The octokit types for `PullRequest.labels` were incorrect for quite a while, but it looks like this is now resolved. This commit removes the cast as we can rely on actual proper typings now.