### PR TITLE
build: remove unused CommonJS/ESM interopability trick for stamping

### DIFF
--- a/ng-dev/release/stamping/_private_main.ts
+++ b/ng-dev/release/stamping/_private_main.ts
@@ -3,10 +3,6 @@
 import yargs from 'yargs';
 import {BuildEnvStampCommand} from './cli.js';
 
-// TODO(ESM): Remove this when we use a dynamic import for config loading.
-import {createRequire as __cjsCompatRequire} from 'module';
-global.require = __cjsCompatRequire(import.meta.url);
-
 yargs(process.argv.slice(2))
   .help()
   .strict()


### PR DESCRIPTION
We are using dynamic imports at this point for loading the ng-dev configuration, so this trick can be removed!