### PR TITLE
fix(bazel): ensure integration test runner works on windows with short paths

### DIFF
--- a/bazel/integration/test_runner/file_system_utils.ts
+++ b/bazel/integration/test_runner/file_system_utils.ts
@@ -26,7 +26,8 @@ export async function isExecutable(filePath: string): Promise<boolean> {
  * the actual case-exact path for the current platform would be: `C:\Users\<..>`.
  */
 export async function getCaseExactRealpath(filePath: string): Promise<string> {
-  return trueCasePath(filePath);
+  // Note: Need to use `realpath` first in case the path is abbreviated on Windows via tilde.
+  return trueCasePath(fs.realpathSync.native(filePath));
 }
 
 /** Adds the `write` permission to the given file using `chmod`. */


### PR DESCRIPTION
Some Windows setups use short paths:
https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names

These throw off the true-case path detection, so we fix that by first resolving short paths to the long paths that can then be mapped to the actual true-case paths.