### PR TITLE
ci: update concurrency group name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ci-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
Use the github ref to trigger on the fully formed ref name rather than the sha, which could theoretically appear in two pull requests.