### PR TITLE
fix(ng-dev/pr): remove unncessary `any` types from validators

### DIFF
--- a/ng-dev/pr/common/validation/assert-allowed-target-label.ts
+++ b/ng-dev/pr/common/validation/assert-allowed-target-label.ts
@@ -16,7 +16,7 @@ import {createPullRequestValidation, PullRequestValidation} from './validation-c
 
 /** Assert the commits provided are allowed to merge to the provided target label. */
 // TODO: update typings to make sure portability is properly handled for windows build.
-export const changesAllowForTargetLabelValidation: any = createPullRequestValidation(
+export const changesAllowForTargetLabelValidation = createPullRequestValidation(
   {name: 'assertChangesAllowForTargetLabel', canBeForceIgnored: true},
   () => Validation,
 );

--- a/ng-dev/pr/common/validation/assert-breaking-change-info.ts
+++ b/ng-dev/pr/common/validation/assert-breaking-change-info.ts
@@ -12,7 +12,7 @@ import {createPullRequestValidation, PullRequestValidation} from './validation-c
 
 /** Assert the pull request is properly denoted if it contains breaking changes. */
 // TODO: update typings to make sure portability is properly handled for windows build.
-export const breakingChangeInfoValidation: any = createPullRequestValidation(
+export const breakingChangeInfoValidation = createPullRequestValidation(
   {name: 'assertPending', canBeForceIgnored: false},
   () => Validation,
 );

--- a/ng-dev/pr/common/validation/assert-merge-ready.ts
+++ b/ng-dev/pr/common/validation/assert-merge-ready.ts
@@ -12,7 +12,7 @@ import {createPullRequestValidation, PullRequestValidation} from './validation-c
 
 /** Assert the pull request is merge ready. */
 // TODO: update typings to make sure portability is properly handled for windows build.
-export const mergeReadyValidation: any = createPullRequestValidation(
+export const mergeReadyValidation = createPullRequestValidation(
   {name: 'assertMergeReady', canBeForceIgnored: false},
   () => Validation,
 );

--- a/ng-dev/pr/common/validation/assert-passing-ci.ts
+++ b/ng-dev/pr/common/validation/assert-passing-ci.ts
@@ -15,7 +15,7 @@ import {createPullRequestValidation, PullRequestValidation} from './validation-c
 
 /** Assert the pull request has a passing combined CI status. */
 // TODO: update typings to make sure portability is properly handled for windows build.
-export const passingCiValidation: any = createPullRequestValidation(
+export const passingCiValidation = createPullRequestValidation(
   {name: 'assertPassingCi', canBeForceIgnored: true},
   () => Validation,
 );

--- a/ng-dev/pr/common/validation/assert-pending.ts
+++ b/ng-dev/pr/common/validation/assert-pending.ts
@@ -11,7 +11,7 @@ import {createPullRequestValidation, PullRequestValidation} from './validation-c
 
 /** Assert the pull request is pending, not closed, merged or in draft. */
 // TODO: update typings to make sure portability is properly handled for windows build.
-export const pendingStateValidation: any = createPullRequestValidation(
+export const pendingStateValidation = createPullRequestValidation(
   {name: 'assertPending', canBeForceIgnored: false},
   () => Validation,
 );

--- a/ng-dev/pr/common/validation/assert-signed-cla.ts
+++ b/ng-dev/pr/common/validation/assert-signed-cla.ts
@@ -15,7 +15,7 @@ import {createPullRequestValidation, PullRequestValidation} from './validation-c
 
 /** Assert the pull request has a signed CLA. */
 // TODO: update typings to make sure portability is properly handled for windows build.
-export const signedClaValidation: any = createPullRequestValidation(
+export const signedClaValidation = createPullRequestValidation(
   // CLA check can be force-ignored but the caretaker needs to make sure
   // the target pull requests has a signed CLA or is authored by another Googler.
   {name: 'assertSignedCla', canBeForceIgnored: true},


### PR DESCRIPTION
Remove the `any` types put in place as they no longer seem to cause issue with most recent octokit updates

Fixes #1186