### PR TITLE
fix(shared-scripts): update paths to babel plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "packageManager": "yarn@3.6.0",
   "dependencies": {
-    "@angular-devkit/build-angular": "16.1.0-rc.0",
+    "@angular-devkit/build-angular": "16.1.0",
     "@angular/benchpress": "0.3.0",
     "@babel/core": "^7.16.0",
     "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -54,20 +54,20 @@
   "devDependencies": {
     "@actions/core": "^1.4.0",
     "@actions/github": "^5.0.0",
-    "@angular/animations": "16.1.0-rc.0",
+    "@angular/animations": "16.1.0",
     "@angular/bazel": "patch:@angular/bazel@npm:14.1.0-next.2#.yarn/patches/@angular-bazel-npm.patch",
     "@angular/cdk": "16.1.0-rc.0",
-    "@angular/cli": "16.1.0-rc.0",
-    "@angular/common": "16.1.0-rc.0",
-    "@angular/compiler": "16.1.0-rc.0",
-    "@angular/compiler-cli": "16.1.0-rc.0",
-    "@angular/core": "16.1.0-rc.0",
+    "@angular/cli": "16.1.0",
+    "@angular/common": "16.1.0",
+    "@angular/compiler": "16.1.0",
+    "@angular/compiler-cli": "16.1.0",
+    "@angular/core": "16.1.0",
     "@angular/fire": "^7.1.0-rc",
-    "@angular/forms": "16.1.0-rc.0",
+    "@angular/forms": "16.1.0",
     "@angular/material": "16.1.0-rc.0",
-    "@angular/platform-browser": "16.1.0-rc.0",
-    "@angular/platform-browser-dynamic": "16.1.0-rc.0",
-    "@angular/router": "16.1.0-rc.0",
+    "@angular/platform-browser": "16.1.0",
+    "@angular/platform-browser-dynamic": "16.1.0",
+    "@angular/router": "16.1.0",
     "@bazel/bazelisk": "^1.11.0",
     "@bazel/ibazel": "^0.16.2",
     "@bazel/jasmine": "5.8.1",
@@ -162,6 +162,6 @@
     }
   },
   "resolutions": {
-    "@angular/benchpress/@angular/core": "16.1.0-rc.0"
+    "@angular/benchpress/@angular/core": "16.1.0"
   }
 }

--- a/shared-scripts/angular-optimization/BUILD.bazel
+++ b/shared-scripts/angular-optimization/BUILD.bazel
@@ -15,10 +15,10 @@ js_library(
     name = "angular_devkit_plugins",
     package_name = "@angular-devkit/build-angular/src/babel/plugins",
     srcs = [
-        "@npm//:node_modules/@angular-devkit/build-angular/src/babel/plugins/adjust-static-class-members.js",
-        "@npm//:node_modules/@angular-devkit/build-angular/src/babel/plugins/adjust-typescript-enums.js",
-        "@npm//:node_modules/@angular-devkit/build-angular/src/babel/plugins/elide-angular-metadata.js",
-        "@npm//:node_modules/@angular-devkit/build-angular/src/babel/plugins/pure-toplevel-functions.js",
+        "@npm//:node_modules/@angular-devkit/build-angular/src/tools/babel/plugins/adjust-static-class-members.js",
+        "@npm//:node_modules/@angular-devkit/build-angular/src/tools/babel/plugins/adjust-typescript-enums.js",
+        "@npm//:node_modules/@angular-devkit/build-angular/src/tools/babel/plugins/elide-angular-metadata.js",
+        "@npm//:node_modules/@angular-devkit/build-angular/src/tools/babel/plugins/pure-toplevel-functions.js",
     ],
     deps = [
         "@npm//@babel/core",

--- a/shared-scripts/angular-optimization/esbuild-plugin.mjs
+++ b/shared-scripts/angular-optimization/esbuild-plugin.mjs
@@ -37,17 +37,23 @@ export async function createEsbuildAngularOptimizePlugin(opts, additionalBabelPl
     devkitOptimizePlugins = {
       adjustStaticClassMembersPlugin: (
         await import(
-          '@angular-devkit/build-angular/src/babel/plugins/adjust-static-class-members.js'
+          '@angular-devkit/build-angular/src/tools/babel/plugins/adjust-static-class-members.js'
         )
       ).default,
       elideAngularMetadataPlugin: (
-        await import('@angular-devkit/build-angular/src/babel/plugins/elide-angular-metadata.js')
+        await import(
+          '@angular-devkit/build-angular/src/tools/babel/plugins/elide-angular-metadata.js'
+        )
       ).default,
       adjustTypeScriptEnumsPlugin: (
-        await import('@angular-devkit/build-angular/src/babel/plugins/adjust-typescript-enums.js')
+        await import(
+          '@angular-devkit/build-angular/src/tools/babel/plugins/adjust-typescript-enums.js'
+        )
       ).default,
       pureToplevelFunctionsPlugin: (
-        await import('@angular-devkit/build-angular/src/babel/plugins/pure-toplevel-functions.js')
+        await import(
+          '@angular-devkit/build-angular/src/tools/babel/plugins/pure-toplevel-functions.js'
+        )
       ).default,
     };
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,36 +46,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/architect@npm:0.1601.0-rc.0":
-  version: 0.1601.0-rc.0
-  resolution: "@angular-devkit/architect@npm:0.1601.0-rc.0"
+"@angular-devkit/architect@npm:0.1601.0":
+  version: 0.1601.0
+  resolution: "@angular-devkit/architect@npm:0.1601.0"
   dependencies:
-    "@angular-devkit/core": 16.1.0-rc.0
+    "@angular-devkit/core": 16.1.0
     rxjs: 7.8.1
-  checksum: 741e3220e96e7d684c919c77775f2d6b8851a00fd9149089f595ff2057adc3ba4a2c3ba68e6dd7740bef680f3fe73b9235dae35df516186c1863c73b8951aa95
+  checksum: 64119cf304f121810ef143b23dbb69116be611c8a6c7ca7748b854d00a748b4a061fd52100b852f3d595c80bd67c4a1c7203ab3665d8e8d0fb54480c9b36c3b5
   languageName: node
   linkType: hard
 
-"@angular-devkit/build-angular@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular-devkit/build-angular@npm:16.1.0-rc.0"
+"@angular-devkit/build-angular@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular-devkit/build-angular@npm:16.1.0"
   dependencies:
     "@ampproject/remapping": 2.2.1
-    "@angular-devkit/architect": 0.1601.0-rc.0
-    "@angular-devkit/build-webpack": 0.1601.0-rc.0
-    "@angular-devkit/core": 16.1.0-rc.0
-    "@babel/core": 7.22.1
-    "@babel/generator": 7.22.3
-    "@babel/helper-annotate-as-pure": 7.18.6
-    "@babel/helper-split-export-declaration": 7.18.6
+    "@angular-devkit/architect": 0.1601.0
+    "@angular-devkit/build-webpack": 0.1601.0
+    "@angular-devkit/core": 16.1.0
+    "@babel/core": 7.22.5
+    "@babel/generator": 7.22.5
+    "@babel/helper-annotate-as-pure": 7.22.5
+    "@babel/helper-split-export-declaration": 7.22.5
     "@babel/plugin-proposal-async-generator-functions": 7.20.7
-    "@babel/plugin-transform-async-to-generator": 7.20.7
-    "@babel/plugin-transform-runtime": 7.22.4
-    "@babel/preset-env": 7.22.4
-    "@babel/runtime": 7.22.3
-    "@babel/template": 7.21.9
+    "@babel/plugin-transform-async-to-generator": 7.22.5
+    "@babel/plugin-transform-runtime": 7.22.5
+    "@babel/preset-env": 7.22.5
+    "@babel/runtime": 7.22.5
+    "@babel/template": 7.22.5
     "@discoveryjs/json-ext": 0.5.7
-    "@ngtools/webpack": 16.1.0-rc.0
+    "@ngtools/webpack": 16.1.0
     "@vitejs/plugin-basic-ssl": 1.0.1
     ansi-colors: 4.1.3
     autoprefixer: 10.4.14
@@ -110,7 +110,7 @@ __metadata:
     postcss-loader: 7.3.2
     resolve-url-loader: 5.0.0
     rxjs: 7.8.1
-    sass: 1.62.1
+    sass: 1.63.2
     sass-loader: 13.3.1
     semver: 7.5.1
     source-map-loader: 4.0.1
@@ -120,20 +120,20 @@ __metadata:
     tree-kill: 1.2.2
     tslib: 2.5.3
     vite: 4.3.9
-    webpack: 5.85.1
+    webpack: 5.86.0
     webpack-dev-middleware: 6.1.1
     webpack-dev-server: 4.15.0
     webpack-merge: 5.9.0
     webpack-subresource-integrity: 5.1.0
   peerDependencies:
-    "@angular/compiler-cli": ^16.0.0 || ^16.1.0-next.0
-    "@angular/localize": ^16.0.0 || ^16.1.0-next.0
-    "@angular/platform-server": ^16.0.0 || ^16.1.0-next.0
-    "@angular/service-worker": ^16.0.0 || ^16.1.0-next.0
+    "@angular/compiler-cli": ^16.1.0
+    "@angular/localize": ^16.1.0
+    "@angular/platform-server": ^16.1.0
+    "@angular/service-worker": ^16.1.0
     jest: ^29.5.0
     jest-environment-jsdom: ^29.5.0
     karma: ^6.3.0
-    ng-packagr: ^16.0.0 || ^16.1.0-next.0
+    ng-packagr: ^16.1.0
     protractor: ^7.0.0
     tailwindcss: ^2.0.0 || ^3.0.0
     typescript: ">=4.9.3 <5.2"
@@ -159,20 +159,20 @@ __metadata:
       optional: true
     tailwindcss:
       optional: true
-  checksum: b3441f4c89e22deebe0d8d333175e33f8c5badaa5510393fbe0b4085b70a52fb8ec1194f6f3b39465a354cf2c0f04782986024257d5640152e6c8f625ac1b723
+  checksum: 44d0e7b31605d56ccc5830a75d9dc47ab5d6b41f54fb8d69036c6171f6b5c06ff16763b93c4b6ca7e026ceb4d9d24a2e441b184bbcd7f03bfc841a6c9c1259b0
   languageName: node
   linkType: hard
 
-"@angular-devkit/build-webpack@npm:0.1601.0-rc.0":
-  version: 0.1601.0-rc.0
-  resolution: "@angular-devkit/build-webpack@npm:0.1601.0-rc.0"
+"@angular-devkit/build-webpack@npm:0.1601.0":
+  version: 0.1601.0
+  resolution: "@angular-devkit/build-webpack@npm:0.1601.0"
   dependencies:
-    "@angular-devkit/architect": 0.1601.0-rc.0
+    "@angular-devkit/architect": 0.1601.0
     rxjs: 7.8.1
   peerDependencies:
     webpack: ^5.30.0
     webpack-dev-server: ^4.0.0
-  checksum: f054d22967a21fe1b0ce0534e8c93ba6850dabcba6f818cad7a69cbe6214181a879855c71f6442cd29521270a25aa8bb39137bd96248e400fcd4ea901bc04df7
+  checksum: f63d387f0e7c658ebb8a331d8f47313d38e50c385813cdeedcce1d07d1bbd8eff1a7c27ea9065a657338a485acf4519076071264a30ad2fd36cac5ed5ba87d67
   languageName: node
   linkType: hard
 
@@ -194,9 +194,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/core@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular-devkit/core@npm:16.1.0-rc.0"
+"@angular-devkit/core@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular-devkit/core@npm:16.1.0"
   dependencies:
     ajv: 8.12.0
     ajv-formats: 2.1.1
@@ -208,7 +208,7 @@ __metadata:
   peerDependenciesMeta:
     chokidar:
       optional: true
-  checksum: 6c10c4b056bd031654e21a657990b30986c014e3a1f3e5295e5f541510f0f1ad2163977641d2241ecf08e4ad1f0296cae687ac1a4202ef86ca06abcf321fd083
+  checksum: 6f9719e7d082b0437cd5eae3162eed1b84192900d1571d8a05792285b51d532b827e5dbfc90410181f2a5fdf8cd0e621b207ef3ff9e2927312783980c0e493ec
   languageName: node
   linkType: hard
 
@@ -225,27 +225,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular-devkit/schematics@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular-devkit/schematics@npm:16.1.0-rc.0"
+"@angular-devkit/schematics@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular-devkit/schematics@npm:16.1.0"
   dependencies:
-    "@angular-devkit/core": 16.1.0-rc.0
+    "@angular-devkit/core": 16.1.0
     jsonc-parser: 3.2.0
     magic-string: 0.30.0
     ora: 5.4.1
     rxjs: 7.8.1
-  checksum: 7082c2dfc335c3c880e61bcbc90d4b1f3d7e05dd7c7309503f4e01f498240e3a98d4cf5e46f664daf99fa2bbcbb7a0c851195557d2350f139e7be09077566c87
+  checksum: 03fc8fcd7bed8cdef51696a9b5aaee5244f0e92395e0d6089ee7c212c457423166574760414ae53575ff01a5f30cf2716cfeab3ad3ac09658823e00f80fdfd04
   languageName: node
   linkType: hard
 
-"@angular/animations@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/animations@npm:16.1.0-rc.0"
+"@angular/animations@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/animations@npm:16.1.0"
   dependencies:
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/core": 16.1.0-rc.0
-  checksum: 73a75ce21706459169210d71efbde7e90946fe4bb84aabb3054def04c32a68dfd830408e74a847acd95df7624c2bf8a97e4608b5039e558ec724166ed9ac36bc
+    "@angular/core": 16.1.0
+  checksum: cd9232389e84f47c00b236453301aedfef1a4ace56a6264a1916e2b5a4d9c0118068becf92f8e31da4b9729c2217098b52a54a7858a337078d2517e6a4ffee80
   languageName: node
   linkType: hard
 
@@ -325,22 +325,22 @@ __metadata:
   dependencies:
     "@actions/core": ^1.4.0
     "@actions/github": ^5.0.0
-    "@angular-devkit/build-angular": 16.1.0-rc.0
-    "@angular/animations": 16.1.0-rc.0
+    "@angular-devkit/build-angular": 16.1.0
+    "@angular/animations": 16.1.0
     "@angular/bazel": "patch:@angular/bazel@npm:14.1.0-next.2#.yarn/patches/@angular-bazel-npm.patch"
     "@angular/benchpress": 0.3.0
     "@angular/cdk": 16.1.0-rc.0
-    "@angular/cli": 16.1.0-rc.0
-    "@angular/common": 16.1.0-rc.0
-    "@angular/compiler": 16.1.0-rc.0
-    "@angular/compiler-cli": 16.1.0-rc.0
-    "@angular/core": 16.1.0-rc.0
+    "@angular/cli": 16.1.0
+    "@angular/common": 16.1.0
+    "@angular/compiler": 16.1.0
+    "@angular/compiler-cli": 16.1.0
+    "@angular/core": 16.1.0
     "@angular/fire": ^7.1.0-rc
-    "@angular/forms": 16.1.0-rc.0
+    "@angular/forms": 16.1.0
     "@angular/material": 16.1.0-rc.0
-    "@angular/platform-browser": 16.1.0-rc.0
-    "@angular/platform-browser-dynamic": 16.1.0-rc.0
-    "@angular/router": 16.1.0-rc.0
+    "@angular/platform-browser": 16.1.0
+    "@angular/platform-browser-dynamic": 16.1.0
+    "@angular/router": 16.1.0
     "@babel/core": ^7.16.0
     "@babel/helper-annotate-as-pure": ^7.18.6
     "@babel/plugin-proposal-async-generator-functions": ^7.20.1
@@ -483,14 +483,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/cli@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/cli@npm:16.1.0-rc.0"
+"@angular/cli@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/cli@npm:16.1.0"
   dependencies:
-    "@angular-devkit/architect": 0.1601.0-rc.0
-    "@angular-devkit/core": 16.1.0-rc.0
-    "@angular-devkit/schematics": 16.1.0-rc.0
-    "@schematics/angular": 16.1.0-rc.0
+    "@angular-devkit/architect": 0.1601.0
+    "@angular-devkit/core": 16.1.0
+    "@angular-devkit/schematics": 16.1.0
+    "@schematics/angular": 16.1.0
     "@yarnpkg/lockfile": 1.1.0
     ansi-colors: 4.1.3
     ini: 4.1.1
@@ -507,25 +507,25 @@ __metadata:
     yargs: 17.7.2
   bin:
     ng: bin/ng.js
-  checksum: a7e16d4e6309b0508ee0541ed9120c4ef817c85559faedb21a726f760cef109df618ed1d598b6ffddb8a2813074bb72a7505e2e5d5ec56f567155b6b274edcd2
+  checksum: 99e4cdd5da4fbefb05180ed601c3906d6fdc76d739cee67e7133fa692f82f31a87a5e283e23396c076d7f2847bd34724f18ce16af07cc48656b543a4fab5a365
   languageName: node
   linkType: hard
 
-"@angular/common@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/common@npm:16.1.0-rc.0"
+"@angular/common@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/common@npm:16.1.0"
   dependencies:
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/core": 16.1.0-rc.0
+    "@angular/core": 16.1.0
     rxjs: ^6.5.3 || ^7.4.0
-  checksum: 78f216b835caf7e18f1a7e3dfabdd4cea0117c02075d5eb535727553e4ce82297f10279f99a1fa9730b1b6df8d5d03971d2f6ed25a213894b7f3afc4651093cb
+  checksum: d9fff5a535da3c33b68cea11c5693c826e7caba8b62e6312c45ce8b0cb573fb573b526bee4cb2e4e842de359fe38f6bb80cbeee02688cdfceed209e00f7e1306
   languageName: node
   linkType: hard
 
-"@angular/compiler-cli@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/compiler-cli@npm:16.1.0-rc.0"
+"@angular/compiler-cli@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/compiler-cli@npm:16.1.0"
   dependencies:
     "@babel/core": 7.21.8
     "@jridgewell/sourcemap-codec": ^1.4.14
@@ -536,39 +536,39 @@ __metadata:
     tslib: ^2.3.0
     yargs: ^17.2.1
   peerDependencies:
-    "@angular/compiler": 16.1.0-rc.0
+    "@angular/compiler": 16.1.0
     typescript: ">=4.9.3 <5.2"
   bin:
     ng-xi18n: bundles/src/bin/ng_xi18n.js
     ngc: bundles/src/bin/ngc.js
     ngcc: bundles/ngcc/index.js
-  checksum: 6ee160ae4293f7789d134a5b730abcce1b3d3e7786708e275425872adec4e06ca602bce27e9b02930e63f9e1c68e80b62866dc8dbe38425daa8c4646fd6b1e86
+  checksum: 697993c8408160717d1d0ab793be567d9ed6bad9a8a0699a9806e124f657fdc7056013caf65d44da90001d2036e9047b72eb57f6be426de0b0b9c405fb54c63c
   languageName: node
   linkType: hard
 
-"@angular/compiler@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/compiler@npm:16.1.0-rc.0"
+"@angular/compiler@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/compiler@npm:16.1.0"
   dependencies:
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/core": 16.1.0-rc.0
+    "@angular/core": 16.1.0
   peerDependenciesMeta:
     "@angular/core":
       optional: true
-  checksum: e3d328974e2e86d7b6238e4179aefd8eb56496b72370bc5abae497745c491db5af9b1604469cb000cc76cde4b08ff94c0b449ca1fe1ec4cd1435ed896d659360
+  checksum: 6dd6a18bbd05251e6b433d2e9db2218fb6d64427ed049c487899c08ca606912c5db94d94c79390157df69b119446748d9df648a5ac6a81b01ddc4f8b88adab4e
   languageName: node
   linkType: hard
 
-"@angular/core@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/core@npm:16.1.0-rc.0"
+"@angular/core@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/core@npm:16.1.0"
   dependencies:
     tslib: ^2.3.0
   peerDependencies:
     rxjs: ^6.5.3 || ^7.4.0
     zone.js: ~0.13.0
-  checksum: 996b772f6834e2cf57ab3aaf88697636dbe41e4dd3451a34611920804bab057ad491ca66df3ae0effe56bc394511300d75bfc907bd8d802bff9b018c67ba3fe9
+  checksum: fa5df5a7696e454be1f3e4a596e32fd72c1f9ea0a73b7f145c3aca2717e651edb479f63521367fb3e394b3cc8868cad241af76d26f450dc4cbc2a676cb3ede6a
   languageName: node
   linkType: hard
 
@@ -606,17 +606,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/forms@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/forms@npm:16.1.0-rc.0"
+"@angular/forms@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/forms@npm:16.1.0"
   dependencies:
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/common": 16.1.0-rc.0
-    "@angular/core": 16.1.0-rc.0
-    "@angular/platform-browser": 16.1.0-rc.0
+    "@angular/common": 16.1.0
+    "@angular/core": 16.1.0
+    "@angular/platform-browser": 16.1.0
     rxjs: ^6.5.3 || ^7.4.0
-  checksum: bf1312165d053c4232cba90fb006b1cb1a1c52fe6d7299bfc34a92acbd774d4312b78a069a250dad10ad50c82d9830b8581a43da89d690bc51c732ace3312b90
+  checksum: b43d120344baf0d034e47fe8ab42feb3cadb543a898666fb86c2dfc7ec2f1b6c4be9f4f8740f2d4c05b391b772f42a8888cbb93afc91e3788893d009850055da
   languageName: node
   linkType: hard
 
@@ -684,47 +684,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/platform-browser-dynamic@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/platform-browser-dynamic@npm:16.1.0-rc.0"
+"@angular/platform-browser-dynamic@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/platform-browser-dynamic@npm:16.1.0"
   dependencies:
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/common": 16.1.0-rc.0
-    "@angular/compiler": 16.1.0-rc.0
-    "@angular/core": 16.1.0-rc.0
-    "@angular/platform-browser": 16.1.0-rc.0
-  checksum: 65733dbc3beb0a89bcd9a042c8d0f0dbb74db2e467fb06fde38354c079d4c5d72ae8d32287fa8f3d3e8d936a5f298a7fc96a5bf273b3d37a98fb862e22af1c5b
+    "@angular/common": 16.1.0
+    "@angular/compiler": 16.1.0
+    "@angular/core": 16.1.0
+    "@angular/platform-browser": 16.1.0
+  checksum: c83897cb2b455975f7b3852e5c3ac6eae047b4b8c37d6e6287f5d99af9264030ae20bed3cbe0a81b0c15eb9b039bd312770d925c9499ef3cffc0346751e9abe5
   languageName: node
   linkType: hard
 
-"@angular/platform-browser@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/platform-browser@npm:16.1.0-rc.0"
+"@angular/platform-browser@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/platform-browser@npm:16.1.0"
   dependencies:
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/animations": 16.1.0-rc.0
-    "@angular/common": 16.1.0-rc.0
-    "@angular/core": 16.1.0-rc.0
+    "@angular/animations": 16.1.0
+    "@angular/common": 16.1.0
+    "@angular/core": 16.1.0
   peerDependenciesMeta:
     "@angular/animations":
       optional: true
-  checksum: 39c73e3d8decaeae4d3699a133854bb663a20902c2a1ee2c34b2d4ef25e83579114d7327ef585f4c4aeb72cd895840b6e35d4f36d401a3703174fa05d6f4b181
+  checksum: 2c1b25d69f4cbe909997ccba4a2f3e0d7c34a3e81386dcedeea6c241e4bb62e6ff24c1a745729329bfc1167f0d6d69f4dac0dca9c515d01dc7b59f23fb0c7272
   languageName: node
   linkType: hard
 
-"@angular/router@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@angular/router@npm:16.1.0-rc.0"
+"@angular/router@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@angular/router@npm:16.1.0"
   dependencies:
     tslib: ^2.3.0
   peerDependencies:
-    "@angular/common": 16.1.0-rc.0
-    "@angular/core": 16.1.0-rc.0
-    "@angular/platform-browser": 16.1.0-rc.0
+    "@angular/common": 16.1.0
+    "@angular/core": 16.1.0
+    "@angular/platform-browser": 16.1.0
     rxjs: ^6.5.3 || ^7.4.0
-  checksum: e987e5a8b26268750407b12e8e569fde04a650e182c2071dcca6acc9417e478d57d8c85abfa6aacb07c46d8c17d8c2a6de3ca8be5bc05c1f3b2889688f04ae47
+  checksum: 3d68dbac71db224efd0e33d1ac92f74fa0e8d41eb121e01aeea12676878363168ebb52706969ee80038a50753dedd39a62d04da72303b5509249e785614dc2eb
   languageName: node
   linkType: hard
 
@@ -756,7 +756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.22.3, @babel/compat-data@npm:^7.22.5":
+"@babel/compat-data@npm:^7.17.7, @babel/compat-data@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/compat-data@npm:7.22.5"
   checksum: eb1a47ebf79ae268b4a16903e977be52629339806e248455eb9973897c503a04b701f36a9de64e19750d6e081d0561e77a514c8dc470babbeba59ae94298ed18
@@ -786,30 +786,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.22.1":
-  version: 7.22.1
-  resolution: "@babel/core@npm:7.22.1"
-  dependencies:
-    "@ampproject/remapping": ^2.2.0
-    "@babel/code-frame": ^7.21.4
-    "@babel/generator": ^7.22.0
-    "@babel/helper-compilation-targets": ^7.22.1
-    "@babel/helper-module-transforms": ^7.22.1
-    "@babel/helpers": ^7.22.0
-    "@babel/parser": ^7.22.0
-    "@babel/template": ^7.21.9
-    "@babel/traverse": ^7.22.1
-    "@babel/types": ^7.22.0
-    convert-source-map: ^1.7.0
-    debug: ^4.1.0
-    gensync: ^1.0.0-beta.2
-    json5: ^2.2.2
-    semver: ^6.3.0
-  checksum: bbe45e791f223a7e692d2ea6597a73f48050abd24b119c85c48ac6504c30ce63343a2ea3f79b5847bf4b409ddd8a68b6cdc4f0272ded1d2ef6f6b1e9663432f0
-  languageName: node
-  linkType: hard
-
-"@babel/core@npm:^7.12.3, @babel/core@npm:^7.16.0":
+"@babel/core@npm:7.22.5, @babel/core@npm:^7.12.3, @babel/core@npm:^7.16.0":
   version: 7.22.5
   resolution: "@babel/core@npm:7.22.5"
   dependencies:
@@ -832,19 +809,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:7.22.3":
-  version: 7.22.3
-  resolution: "@babel/generator@npm:7.22.3"
-  dependencies:
-    "@babel/types": ^7.22.3
-    "@jridgewell/gen-mapping": ^0.3.2
-    "@jridgewell/trace-mapping": ^0.3.17
-    jsesc: ^2.5.1
-  checksum: ccb6426ca5b5a38f0d47a3ac9628e223d2aaaa489cbf90ffab41468795c22afe86855f68a58667f0f2673949f1810d4d5a57b826c17984eab3e28fdb34a909e6
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.21.5, @babel/generator@npm:^7.22.0, @babel/generator@npm:^7.22.5":
+"@babel/generator@npm:7.22.5, @babel/generator@npm:^7.21.5, @babel/generator@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/generator@npm:7.22.5"
   dependencies:
@@ -856,16 +821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-annotate-as-pure@npm:7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-annotate-as-pure@npm:7.18.6"
-  dependencies:
-    "@babel/types": ^7.18.6
-  checksum: 88ccd15ced475ef2243fdd3b2916a29ea54c5db3cd0cfabf9d1d29ff6e63b7f7cd1c27264137d7a40ac2e978b9b9a542c332e78f40eb72abe737a7400788fc1b
-  languageName: node
-  linkType: hard
-
-"@babel/helper-annotate-as-pure@npm:^7.18.6, @babel/helper-annotate-as-pure@npm:^7.22.5":
+"@babel/helper-annotate-as-pure@npm:7.22.5, @babel/helper-annotate-as-pure@npm:^7.18.6, @babel/helper-annotate-as-pure@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-annotate-as-pure@npm:7.22.5"
   dependencies:
@@ -883,7 +839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.17.7, @babel/helper-compilation-targets@npm:^7.21.5, @babel/helper-compilation-targets@npm:^7.22.1, @babel/helper-compilation-targets@npm:^7.22.5":
+"@babel/helper-compilation-targets@npm:^7.17.7, @babel/helper-compilation-targets@npm:^7.21.5, @babel/helper-compilation-targets@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-compilation-targets@npm:7.22.5"
   dependencies:
@@ -898,7 +854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-create-class-features-plugin@npm:^7.21.0, @babel/helper-create-class-features-plugin@npm:^7.22.5":
+"@babel/helper-create-class-features-plugin@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-create-class-features-plugin@npm:7.22.5"
   dependencies:
@@ -981,7 +937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.21.4, @babel/helper-module-imports@npm:^7.22.5":
+"@babel/helper-module-imports@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-module-imports@npm:7.22.5"
   dependencies:
@@ -990,7 +946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.21.5, @babel/helper-module-transforms@npm:^7.22.1, @babel/helper-module-transforms@npm:^7.22.5":
+"@babel/helper-module-transforms@npm:^7.21.5, @babel/helper-module-transforms@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-module-transforms@npm:7.22.5"
   dependencies:
@@ -1015,7 +971,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.16.7, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.20.2, @babel/helper-plugin-utils@npm:^7.21.5, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.16.7, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.20.2, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
   version: 7.22.5
   resolution: "@babel/helper-plugin-utils@npm:7.22.5"
   checksum: c0fc7227076b6041acd2f0e818145d2e8c41968cc52fb5ca70eed48e21b8fe6dd88a0a91cbddf4951e33647336eb5ae184747ca706817ca3bef5e9e905151ff5
@@ -1068,16 +1024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-split-export-declaration@npm:7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-split-export-declaration@npm:7.18.6"
-  dependencies:
-    "@babel/types": ^7.18.6
-  checksum: c6d3dede53878f6be1d869e03e9ffbbb36f4897c7cc1527dc96c56d127d834ffe4520a6f7e467f5b6f3c2843ea0e81a7819d66ae02f707f6ac057f3d57943a2b
-  languageName: node
-  linkType: hard
-
-"@babel/helper-split-export-declaration@npm:^7.22.5":
+"@babel/helper-split-export-declaration@npm:7.22.5, @babel/helper-split-export-declaration@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-split-export-declaration@npm:7.22.5"
   dependencies:
@@ -1100,7 +1047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-option@npm:^7.21.0, @babel/helper-validator-option@npm:^7.22.5":
+"@babel/helper-validator-option@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-validator-option@npm:7.22.5"
   checksum: bbeca8a85ee86990215c0424997438b388b8d642d69b9f86c375a174d3cdeb270efafd1ff128bc7a1d370923d13b6e45829ba8581c027620e83e3a80c5c414b3
@@ -1119,7 +1066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.21.5, @babel/helpers@npm:^7.22.0, @babel/helpers@npm:^7.22.5":
+"@babel/helpers@npm:^7.21.5, @babel/helpers@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helpers@npm:7.22.5"
   dependencies:
@@ -1141,7 +1088,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.15, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.8, @babel/parser@npm:^7.21.9, @babel/parser@npm:^7.22.0, @babel/parser@npm:^7.22.5":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.15, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.8, @babel/parser@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/parser@npm:7.22.5"
   bin:
@@ -1150,7 +1097,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:^7.18.6":
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:7.22.5"
   dependencies:
@@ -1161,7 +1108,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.22.3":
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.22.5"
   dependencies:
@@ -1188,17 +1135,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-private-property-in-object@npm:^7.21.0":
-  version: 7.21.11
-  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.11"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.18.6
-    "@babel/helper-create-class-features-plugin": ^7.21.0
-    "@babel/helper-plugin-utils": ^7.20.2
-    "@babel/plugin-syntax-private-property-in-object": ^7.14.5
+"@babel/plugin-proposal-private-property-in-object@npm:7.21.0-placeholder-for-preset-env.2":
+  version: 7.21.0-placeholder-for-preset-env.2
+  resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.0-placeholder-for-preset-env.2"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 1b880543bc5f525b360b53d97dd30807302bb82615cd42bf931968f59003cac75629563d6b104868db50abd22235b3271fdf679fea5db59a267181a99cc0c265
+  checksum: d97745d098b835d55033ff3a7fb2b895b9c5295b08a5759e4f20df325aa385a3e0bc9bd5ad8f2ec554a44d4e6525acfc257b8c5848a1345cb40f26a30e277e91
   languageName: node
   linkType: hard
 
@@ -1269,7 +1211,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-import-assertions@npm:^7.20.0":
+"@babel/plugin-syntax-import-assertions@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-syntax-import-assertions@npm:7.22.5"
   dependencies:
@@ -1280,7 +1222,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-import-attributes@npm:^7.22.3":
+"@babel/plugin-syntax-import-attributes@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-syntax-import-attributes@npm:7.22.5"
   dependencies:
@@ -1413,7 +1355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-arrow-functions@npm:^7.21.5":
+"@babel/plugin-transform-arrow-functions@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-arrow-functions@npm:7.22.5"
   dependencies:
@@ -1424,7 +1366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-generator-functions@npm:^7.22.3":
+"@babel/plugin-transform-async-generator-functions@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-async-generator-functions@npm:7.22.5"
   dependencies:
@@ -1438,20 +1380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-async-to-generator@npm:7.20.7":
-  version: 7.20.7
-  resolution: "@babel/plugin-transform-async-to-generator@npm:7.20.7"
-  dependencies:
-    "@babel/helper-module-imports": ^7.18.6
-    "@babel/helper-plugin-utils": ^7.20.2
-    "@babel/helper-remap-async-to-generator": ^7.18.9
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: fe9ee8a5471b4317c1b9ea92410ace8126b52a600d7cfbfe1920dcac6fb0fad647d2e08beb4fd03c630eb54430e6c72db11e283e3eddc49615c68abd39430904
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-async-to-generator@npm:^7.20.7":
+"@babel/plugin-transform-async-to-generator@npm:7.22.5, @babel/plugin-transform-async-to-generator@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-async-to-generator@npm:7.22.5"
   dependencies:
@@ -1464,7 +1393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-block-scoped-functions@npm:^7.18.6":
+"@babel/plugin-transform-block-scoped-functions@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.22.5"
   dependencies:
@@ -1475,7 +1404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-block-scoping@npm:^7.21.0":
+"@babel/plugin-transform-block-scoping@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-block-scoping@npm:7.22.5"
   dependencies:
@@ -1486,7 +1415,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-properties@npm:^7.22.3":
+"@babel/plugin-transform-class-properties@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-class-properties@npm:7.22.5"
   dependencies:
@@ -1498,7 +1427,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-class-static-block@npm:^7.22.3":
+"@babel/plugin-transform-class-static-block@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-class-static-block@npm:7.22.5"
   dependencies:
@@ -1511,7 +1440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-classes@npm:^7.21.0":
+"@babel/plugin-transform-classes@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-classes@npm:7.22.5"
   dependencies:
@@ -1530,7 +1459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-computed-properties@npm:^7.21.5":
+"@babel/plugin-transform-computed-properties@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-computed-properties@npm:7.22.5"
   dependencies:
@@ -1542,7 +1471,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-destructuring@npm:^7.21.3":
+"@babel/plugin-transform-destructuring@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-destructuring@npm:7.22.5"
   dependencies:
@@ -1553,7 +1482,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-dotall-regex@npm:^7.18.6, @babel/plugin-transform-dotall-regex@npm:^7.4.4":
+"@babel/plugin-transform-dotall-regex@npm:^7.22.5, @babel/plugin-transform-dotall-regex@npm:^7.4.4":
   version: 7.22.5
   resolution: "@babel/plugin-transform-dotall-regex@npm:7.22.5"
   dependencies:
@@ -1565,7 +1494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-duplicate-keys@npm:^7.18.9":
+"@babel/plugin-transform-duplicate-keys@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-duplicate-keys@npm:7.22.5"
   dependencies:
@@ -1576,7 +1505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-dynamic-import@npm:^7.22.1":
+"@babel/plugin-transform-dynamic-import@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-dynamic-import@npm:7.22.5"
   dependencies:
@@ -1588,7 +1517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-exponentiation-operator@npm:^7.18.6":
+"@babel/plugin-transform-exponentiation-operator@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.22.5"
   dependencies:
@@ -1600,7 +1529,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-export-namespace-from@npm:^7.22.3":
+"@babel/plugin-transform-export-namespace-from@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-export-namespace-from@npm:7.22.5"
   dependencies:
@@ -1612,7 +1541,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-for-of@npm:^7.21.5":
+"@babel/plugin-transform-for-of@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-for-of@npm:7.22.5"
   dependencies:
@@ -1623,7 +1552,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-function-name@npm:^7.18.9":
+"@babel/plugin-transform-function-name@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-function-name@npm:7.22.5"
   dependencies:
@@ -1636,7 +1565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-json-strings@npm:^7.22.3":
+"@babel/plugin-transform-json-strings@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-json-strings@npm:7.22.5"
   dependencies:
@@ -1648,7 +1577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-literals@npm:^7.18.9":
+"@babel/plugin-transform-literals@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-literals@npm:7.22.5"
   dependencies:
@@ -1659,7 +1588,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-logical-assignment-operators@npm:^7.22.3":
+"@babel/plugin-transform-logical-assignment-operators@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.22.5"
   dependencies:
@@ -1671,7 +1600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-member-expression-literals@npm:^7.18.6":
+"@babel/plugin-transform-member-expression-literals@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-member-expression-literals@npm:7.22.5"
   dependencies:
@@ -1682,7 +1611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-amd@npm:^7.20.11":
+"@babel/plugin-transform-modules-amd@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-modules-amd@npm:7.22.5"
   dependencies:
@@ -1694,7 +1623,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-commonjs@npm:^7.21.5":
+"@babel/plugin-transform-modules-commonjs@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.22.5"
   dependencies:
@@ -1707,7 +1636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-systemjs@npm:^7.22.3":
+"@babel/plugin-transform-modules-systemjs@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-modules-systemjs@npm:7.22.5"
   dependencies:
@@ -1721,7 +1650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-umd@npm:^7.18.6":
+"@babel/plugin-transform-modules-umd@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-modules-umd@npm:7.22.5"
   dependencies:
@@ -1733,7 +1662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.22.3":
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.22.5"
   dependencies:
@@ -1745,7 +1674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-new-target@npm:^7.22.3":
+"@babel/plugin-transform-new-target@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-new-target@npm:7.22.5"
   dependencies:
@@ -1756,7 +1685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.3":
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.22.5"
   dependencies:
@@ -1768,7 +1697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-numeric-separator@npm:^7.22.3":
+"@babel/plugin-transform-numeric-separator@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-numeric-separator@npm:7.22.5"
   dependencies:
@@ -1780,7 +1709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-object-rest-spread@npm:^7.22.3":
+"@babel/plugin-transform-object-rest-spread@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-object-rest-spread@npm:7.22.5"
   dependencies:
@@ -1795,7 +1724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-object-super@npm:^7.18.6":
+"@babel/plugin-transform-object-super@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-object-super@npm:7.22.5"
   dependencies:
@@ -1807,7 +1736,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-catch-binding@npm:^7.22.3":
+"@babel/plugin-transform-optional-catch-binding@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.22.5"
   dependencies:
@@ -1819,7 +1748,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-optional-chaining@npm:^7.22.3, @babel/plugin-transform-optional-chaining@npm:^7.22.5":
+"@babel/plugin-transform-optional-chaining@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-optional-chaining@npm:7.22.5"
   dependencies:
@@ -1832,7 +1761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-parameters@npm:^7.22.3, @babel/plugin-transform-parameters@npm:^7.22.5":
+"@babel/plugin-transform-parameters@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-parameters@npm:7.22.5"
   dependencies:
@@ -1843,7 +1772,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-methods@npm:^7.22.3":
+"@babel/plugin-transform-private-methods@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-private-methods@npm:7.22.5"
   dependencies:
@@ -1855,7 +1784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-private-property-in-object@npm:^7.22.3":
+"@babel/plugin-transform-private-property-in-object@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-private-property-in-object@npm:7.22.5"
   dependencies:
@@ -1869,7 +1798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-property-literals@npm:^7.18.6":
+"@babel/plugin-transform-property-literals@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-property-literals@npm:7.22.5"
   dependencies:
@@ -1880,7 +1809,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-regenerator@npm:^7.21.5":
+"@babel/plugin-transform-regenerator@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-regenerator@npm:7.22.5"
   dependencies:
@@ -1892,7 +1821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-reserved-words@npm:^7.18.6":
+"@babel/plugin-transform-reserved-words@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-reserved-words@npm:7.22.5"
   dependencies:
@@ -1903,23 +1832,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:7.22.4":
-  version: 7.22.4
-  resolution: "@babel/plugin-transform-runtime@npm:7.22.4"
+"@babel/plugin-transform-runtime@npm:7.22.5":
+  version: 7.22.5
+  resolution: "@babel/plugin-transform-runtime@npm:7.22.5"
   dependencies:
-    "@babel/helper-module-imports": ^7.21.4
-    "@babel/helper-plugin-utils": ^7.21.5
+    "@babel/helper-module-imports": ^7.22.5
+    "@babel/helper-plugin-utils": ^7.22.5
     babel-plugin-polyfill-corejs2: ^0.4.3
     babel-plugin-polyfill-corejs3: ^0.8.1
     babel-plugin-polyfill-regenerator: ^0.5.0
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: e51400ffeccfc8875c6d136510aa6145e44d825ee7fb52da462401388b4303a6a274ca94fad4aa46b06870c6fdc6141dafa51f681423160d924a21212daa8792
+  checksum: 52cf177045b5f61a6cfc36b45aa7629586dc00a28371a09ef03e877a627f520efd51817ad8cceabaaa25f266e069859b36a5ac5018afeaa7f37aafa9325df4d8
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-shorthand-properties@npm:^7.18.6":
+"@babel/plugin-transform-shorthand-properties@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-shorthand-properties@npm:7.22.5"
   dependencies:
@@ -1930,7 +1859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-spread@npm:^7.20.7":
+"@babel/plugin-transform-spread@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-spread@npm:7.22.5"
   dependencies:
@@ -1942,7 +1871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-sticky-regex@npm:^7.18.6":
+"@babel/plugin-transform-sticky-regex@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-sticky-regex@npm:7.22.5"
   dependencies:
@@ -1953,7 +1882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-template-literals@npm:^7.18.9":
+"@babel/plugin-transform-template-literals@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-template-literals@npm:7.22.5"
   dependencies:
@@ -1964,7 +1893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-typeof-symbol@npm:^7.18.9":
+"@babel/plugin-transform-typeof-symbol@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-typeof-symbol@npm:7.22.5"
   dependencies:
@@ -1975,7 +1904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-escapes@npm:^7.21.5":
+"@babel/plugin-transform-unicode-escapes@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-unicode-escapes@npm:7.22.5"
   dependencies:
@@ -1986,7 +1915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-property-regex@npm:^7.22.3":
+"@babel/plugin-transform-unicode-property-regex@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-unicode-property-regex@npm:7.22.5"
   dependencies:
@@ -1998,7 +1927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-regex@npm:^7.18.6":
+"@babel/plugin-transform-unicode-regex@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-unicode-regex@npm:7.22.5"
   dependencies:
@@ -2010,7 +1939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-unicode-sets-regex@npm:^7.22.3":
+"@babel/plugin-transform-unicode-sets-regex@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-unicode-sets-regex@npm:7.22.5"
   dependencies:
@@ -2022,24 +1951,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:7.22.4":
-  version: 7.22.4
-  resolution: "@babel/preset-env@npm:7.22.4"
+"@babel/preset-env@npm:7.22.5":
+  version: 7.22.5
+  resolution: "@babel/preset-env@npm:7.22.5"
   dependencies:
-    "@babel/compat-data": ^7.22.3
-    "@babel/helper-compilation-targets": ^7.22.1
-    "@babel/helper-plugin-utils": ^7.21.5
-    "@babel/helper-validator-option": ^7.21.0
-    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": ^7.18.6
-    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.22.3
-    "@babel/plugin-proposal-private-property-in-object": ^7.21.0
+    "@babel/compat-data": ^7.22.5
+    "@babel/helper-compilation-targets": ^7.22.5
+    "@babel/helper-plugin-utils": ^7.22.5
+    "@babel/helper-validator-option": ^7.22.5
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": ^7.22.5
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": ^7.22.5
+    "@babel/plugin-proposal-private-property-in-object": 7.21.0-placeholder-for-preset-env.2
     "@babel/plugin-syntax-async-generators": ^7.8.4
     "@babel/plugin-syntax-class-properties": ^7.12.13
     "@babel/plugin-syntax-class-static-block": ^7.14.5
     "@babel/plugin-syntax-dynamic-import": ^7.8.3
     "@babel/plugin-syntax-export-namespace-from": ^7.8.3
-    "@babel/plugin-syntax-import-assertions": ^7.20.0
-    "@babel/plugin-syntax-import-attributes": ^7.22.3
+    "@babel/plugin-syntax-import-assertions": ^7.22.5
+    "@babel/plugin-syntax-import-attributes": ^7.22.5
     "@babel/plugin-syntax-import-meta": ^7.10.4
     "@babel/plugin-syntax-json-strings": ^7.8.3
     "@babel/plugin-syntax-logical-assignment-operators": ^7.10.4
@@ -2051,56 +1980,56 @@ __metadata:
     "@babel/plugin-syntax-private-property-in-object": ^7.14.5
     "@babel/plugin-syntax-top-level-await": ^7.14.5
     "@babel/plugin-syntax-unicode-sets-regex": ^7.18.6
-    "@babel/plugin-transform-arrow-functions": ^7.21.5
-    "@babel/plugin-transform-async-generator-functions": ^7.22.3
-    "@babel/plugin-transform-async-to-generator": ^7.20.7
-    "@babel/plugin-transform-block-scoped-functions": ^7.18.6
-    "@babel/plugin-transform-block-scoping": ^7.21.0
-    "@babel/plugin-transform-class-properties": ^7.22.3
-    "@babel/plugin-transform-class-static-block": ^7.22.3
-    "@babel/plugin-transform-classes": ^7.21.0
-    "@babel/plugin-transform-computed-properties": ^7.21.5
-    "@babel/plugin-transform-destructuring": ^7.21.3
-    "@babel/plugin-transform-dotall-regex": ^7.18.6
-    "@babel/plugin-transform-duplicate-keys": ^7.18.9
-    "@babel/plugin-transform-dynamic-import": ^7.22.1
-    "@babel/plugin-transform-exponentiation-operator": ^7.18.6
-    "@babel/plugin-transform-export-namespace-from": ^7.22.3
-    "@babel/plugin-transform-for-of": ^7.21.5
-    "@babel/plugin-transform-function-name": ^7.18.9
-    "@babel/plugin-transform-json-strings": ^7.22.3
-    "@babel/plugin-transform-literals": ^7.18.9
-    "@babel/plugin-transform-logical-assignment-operators": ^7.22.3
-    "@babel/plugin-transform-member-expression-literals": ^7.18.6
-    "@babel/plugin-transform-modules-amd": ^7.20.11
-    "@babel/plugin-transform-modules-commonjs": ^7.21.5
-    "@babel/plugin-transform-modules-systemjs": ^7.22.3
-    "@babel/plugin-transform-modules-umd": ^7.18.6
-    "@babel/plugin-transform-named-capturing-groups-regex": ^7.22.3
-    "@babel/plugin-transform-new-target": ^7.22.3
-    "@babel/plugin-transform-nullish-coalescing-operator": ^7.22.3
-    "@babel/plugin-transform-numeric-separator": ^7.22.3
-    "@babel/plugin-transform-object-rest-spread": ^7.22.3
-    "@babel/plugin-transform-object-super": ^7.18.6
-    "@babel/plugin-transform-optional-catch-binding": ^7.22.3
-    "@babel/plugin-transform-optional-chaining": ^7.22.3
-    "@babel/plugin-transform-parameters": ^7.22.3
-    "@babel/plugin-transform-private-methods": ^7.22.3
-    "@babel/plugin-transform-private-property-in-object": ^7.22.3
-    "@babel/plugin-transform-property-literals": ^7.18.6
-    "@babel/plugin-transform-regenerator": ^7.21.5
-    "@babel/plugin-transform-reserved-words": ^7.18.6
-    "@babel/plugin-transform-shorthand-properties": ^7.18.6
-    "@babel/plugin-transform-spread": ^7.20.7
-    "@babel/plugin-transform-sticky-regex": ^7.18.6
-    "@babel/plugin-transform-template-literals": ^7.18.9
-    "@babel/plugin-transform-typeof-symbol": ^7.18.9
-    "@babel/plugin-transform-unicode-escapes": ^7.21.5
-    "@babel/plugin-transform-unicode-property-regex": ^7.22.3
-    "@babel/plugin-transform-unicode-regex": ^7.18.6
-    "@babel/plugin-transform-unicode-sets-regex": ^7.22.3
+    "@babel/plugin-transform-arrow-functions": ^7.22.5
+    "@babel/plugin-transform-async-generator-functions": ^7.22.5
+    "@babel/plugin-transform-async-to-generator": ^7.22.5
+    "@babel/plugin-transform-block-scoped-functions": ^7.22.5
+    "@babel/plugin-transform-block-scoping": ^7.22.5
+    "@babel/plugin-transform-class-properties": ^7.22.5
+    "@babel/plugin-transform-class-static-block": ^7.22.5
+    "@babel/plugin-transform-classes": ^7.22.5
+    "@babel/plugin-transform-computed-properties": ^7.22.5
+    "@babel/plugin-transform-destructuring": ^7.22.5
+    "@babel/plugin-transform-dotall-regex": ^7.22.5
+    "@babel/plugin-transform-duplicate-keys": ^7.22.5
+    "@babel/plugin-transform-dynamic-import": ^7.22.5
+    "@babel/plugin-transform-exponentiation-operator": ^7.22.5
+    "@babel/plugin-transform-export-namespace-from": ^7.22.5
+    "@babel/plugin-transform-for-of": ^7.22.5
+    "@babel/plugin-transform-function-name": ^7.22.5
+    "@babel/plugin-transform-json-strings": ^7.22.5
+    "@babel/plugin-transform-literals": ^7.22.5
+    "@babel/plugin-transform-logical-assignment-operators": ^7.22.5
+    "@babel/plugin-transform-member-expression-literals": ^7.22.5
+    "@babel/plugin-transform-modules-amd": ^7.22.5
+    "@babel/plugin-transform-modules-commonjs": ^7.22.5
+    "@babel/plugin-transform-modules-systemjs": ^7.22.5
+    "@babel/plugin-transform-modules-umd": ^7.22.5
+    "@babel/plugin-transform-named-capturing-groups-regex": ^7.22.5
+    "@babel/plugin-transform-new-target": ^7.22.5
+    "@babel/plugin-transform-nullish-coalescing-operator": ^7.22.5
+    "@babel/plugin-transform-numeric-separator": ^7.22.5
+    "@babel/plugin-transform-object-rest-spread": ^7.22.5
+    "@babel/plugin-transform-object-super": ^7.22.5
+    "@babel/plugin-transform-optional-catch-binding": ^7.22.5
+    "@babel/plugin-transform-optional-chaining": ^7.22.5
+    "@babel/plugin-transform-parameters": ^7.22.5
+    "@babel/plugin-transform-private-methods": ^7.22.5
+    "@babel/plugin-transform-private-property-in-object": ^7.22.5
+    "@babel/plugin-transform-property-literals": ^7.22.5
+    "@babel/plugin-transform-regenerator": ^7.22.5
+    "@babel/plugin-transform-reserved-words": ^7.22.5
+    "@babel/plugin-transform-shorthand-properties": ^7.22.5
+    "@babel/plugin-transform-spread": ^7.22.5
+    "@babel/plugin-transform-sticky-regex": ^7.22.5
+    "@babel/plugin-transform-template-literals": ^7.22.5
+    "@babel/plugin-transform-typeof-symbol": ^7.22.5
+    "@babel/plugin-transform-unicode-escapes": ^7.22.5
+    "@babel/plugin-transform-unicode-property-regex": ^7.22.5
+    "@babel/plugin-transform-unicode-regex": ^7.22.5
+    "@babel/plugin-transform-unicode-sets-regex": ^7.22.5
     "@babel/preset-modules": ^0.1.5
-    "@babel/types": ^7.22.4
+    "@babel/types": ^7.22.5
     babel-plugin-polyfill-corejs2: ^0.4.3
     babel-plugin-polyfill-corejs3: ^0.8.1
     babel-plugin-polyfill-regenerator: ^0.5.0
@@ -2108,7 +2037,7 @@ __metadata:
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 68ae8b712e7548cb0aa593019bf22ed473bd83887c621c1f820ef0af99958d48b687c01b8aee16035cbc70edae1edc703b892e6efed14b95c8435343a2cb2bda
+  checksum: 6d9d09010ababef2ab48c8830770b2a8f45d6cce51db0924a98b0d95a5b1248a99ee07ee61cb5446d8b05b562db99a8af30b3ed194546419fb9b2889b8fd1ed3
   languageName: node
   linkType: hard
 
@@ -2134,16 +2063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.22.3":
-  version: 7.22.3
-  resolution: "@babel/runtime@npm:7.22.3"
-  dependencies:
-    regenerator-runtime: ^0.13.11
-  checksum: 8fc50785ca4cba749fed90bffca7e6fd52d4709755654e95b8d2a945fc034b56fb8c2e8a0183fea7c4abb86bf5fa77678c0ea35163b6920649833d180c34c234
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:7.22.5, @babel/runtime@npm:^7.8.4":
   version: 7.22.5
   resolution: "@babel/runtime@npm:7.22.5"
   dependencies:
@@ -2152,18 +2072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:7.21.9":
-  version: 7.21.9
-  resolution: "@babel/template@npm:7.21.9"
-  dependencies:
-    "@babel/code-frame": ^7.21.4
-    "@babel/parser": ^7.21.9
-    "@babel/types": ^7.21.5
-  checksum: 6ec2c60d4d53b2a9230ab82c399ba6525df87e9a4e01e4b111e071cbad283b1362e7c99a1bc50027073f44f2de36a495a89c27112c4e7efe7ef9c8d9c84de2ec
-  languageName: node
-  linkType: hard
-
-"@babel/template@npm:^7.20.7, @babel/template@npm:^7.21.9, @babel/template@npm:^7.22.5":
+"@babel/template@npm:7.22.5, @babel/template@npm:^7.20.7, @babel/template@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/template@npm:7.22.5"
   dependencies:
@@ -2174,7 +2083,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.21.5, @babel/traverse@npm:^7.22.1, @babel/traverse@npm:^7.22.5":
+"@babel/traverse@npm:^7.21.5, @babel/traverse@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/traverse@npm:7.22.5"
   dependencies:
@@ -2192,7 +2101,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.0, @babel/types@npm:^7.22.3, @babel/types@npm:^7.22.4, @babel/types@npm:^7.22.5, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.5, @babel/types@npm:^7.22.5, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.22.5
   resolution: "@babel/types@npm:7.22.5"
   dependencies:
@@ -4326,14 +4235,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ngtools/webpack@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@ngtools/webpack@npm:16.1.0-rc.0"
+"@ngtools/webpack@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@ngtools/webpack@npm:16.1.0"
   peerDependencies:
-    "@angular/compiler-cli": ^16.0.0 || ^16.1.0-next.0
+    "@angular/compiler-cli": ^16.1.0
     typescript: ">=4.9.3 <5.2"
     webpack: ^5.54.0
-  checksum: 770fd35c1d7d7c9917c667ee7451993c1118f969e4f3bd4683994f28f1c734cccc3cdc66c47941e473c6c7b54a4df533746552330a31cdbebf86316ddef17247
+  checksum: 4ec6f2d6fde7191f263a93831d43a3e9f329dff8535e41592439a057a97bbb33544cd11cafc01767e54af40658cf4544452773b9810de6cb398831a76d55c65a
   languageName: node
   linkType: hard
 
@@ -5046,14 +4955,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@schematics/angular@npm:16.1.0-rc.0":
-  version: 16.1.0-rc.0
-  resolution: "@schematics/angular@npm:16.1.0-rc.0"
+"@schematics/angular@npm:16.1.0":
+  version: 16.1.0
+  resolution: "@schematics/angular@npm:16.1.0"
   dependencies:
-    "@angular-devkit/core": 16.1.0-rc.0
-    "@angular-devkit/schematics": 16.1.0-rc.0
+    "@angular-devkit/core": 16.1.0
+    "@angular-devkit/schematics": 16.1.0
     jsonc-parser: 3.2.0
-  checksum: 529839ecec74a08479488afe45e79674208212812971f4ce50a45cedf7ddde39e61ffbe63d920815858431c98de29d8824b961e8494acb758609f32ceb645d53
+  checksum: 0532123211857b20f4dbb171bc12e2fe0ff00c270a2d2845e2aa17ad17cf5530644307f97666f9107511e346b210a505acf0307dad41dc6f848117875b8ae9c2
   languageName: node
   linkType: hard
 
@@ -15097,16 +15006,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:1.62.1":
-  version: 1.62.1
-  resolution: "sass@npm:1.62.1"
+"sass@npm:1.63.2":
+  version: 1.63.2
+  resolution: "sass@npm:1.63.2"
   dependencies:
     chokidar: ">=3.0.0 <4.0.0"
     immutable: ^4.0.0
     source-map-js: ">=0.6.2 <2.0.0"
   bin:
     sass: sass.js
-  checksum: 1b1b3584b38a63dd94156b65f13b90e3f84b170a38c3d5e3fa578b7a32a37aeb349b4926b0eaf9448d48e955e86b1ee01b13993f19611dad8068af07a607c13b
+  checksum: 7ffc2b789aeae4637f09195f7d24e149fc590e2c69cb209c64fdf0ed0d7f09da28097c48fda7f36d257aeb7dd8e16a9ff77b50cf78830afe6f996e6dcd957280
   languageName: node
   linkType: hard
 
@@ -17411,9 +17320,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:5.85.1":
-  version: 5.85.1
-  resolution: "webpack@npm:5.85.1"
+"webpack@npm:5.86.0":
+  version: 5.86.0
+  resolution: "webpack@npm:5.86.0"
   dependencies:
     "@types/eslint-scope": ^3.7.3
     "@types/estree": ^1.0.0
@@ -17444,7 +17353,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 6fa659ef5e53211e6eeaed1987ac415ddd219584414b2d5ca0d528f0c7dd49be5363a9840e1def33efe1b3305ef3ad3c91f803bd87e41d2771b125340caa4df7
+  checksum: 682b1aa8328bb9d52ae66a1d0a1078af88f9e3b3b3a9c9e1ce203e669581a8e61d522420ef253130eacd510d24d7275b840c1311d50bd048d6fd7c1af186ce55
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The Babel plugins were recently moved to a different place in the CLI which causes breakages in the snapshot builds. These changes update to the correct paths.