### PR TITLE
build: speed up remote execution builds on Github actions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -63,6 +63,10 @@ build:remote --define=EXECUTOR=remote
 build:remote --cpu=k8
 build:remote --host_cpu=k8
 
+# Bazel detects maximum number of jobs based on host resources.
+# Since we run remotely, we can increase this number significantly.
+common:remote --jobs=100
+
 # Setup the remote build execution servers.
 build:remote --remote_cache=remotebuildexecution.googleapis.com
 build:remote --remote_executor=remotebuildexecution.googleapis.com


### PR DESCRIPTION
Currently we seem to be running with extremely limited concurrency, making Bazel builds take up to 10min.