### PR TITLE
feat(bazel): tag benchmark tests for bazel query discoverability

### DIFF
--- a/bazel/benchmark/component_benchmark/benchmark_test.bzl
+++ b/bazel/benchmark/component_benchmark/benchmark_test.bzl
@@ -16,6 +16,7 @@ def benchmark_test(name, server, tags = [], **kwargs):
         server = server,
         # Benchmark targets should not run on CI by default.
         tags = tags + [
+            "benchmark-test",
             "manual",
             "no-remote-exec",
         ],


### PR DESCRIPTION
This allows us to query for benchmark test targets without having to look for them via rule kind name.