### PR TITLE
fix(bazel): spec bundling and app bundling breaking rxjs v6 testing code

### DIFF
--- a/bazel/app-bundling/esbuild.config-tmpl.mjs
+++ b/bazel/app-bundling/esbuild.config-tmpl.mjs
@@ -36,7 +36,8 @@ export default {
   // Based on the CLI configuration:
   // https://github.com/angular/angular-cli/blame/8089c9388056b3caaf56f981848aca94f022da73/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts#L51.
   conditions: ['es2022', 'es2020', 'es2015', 'module'],
-  mainFields: ['fesm2022', 'es2022', 'es2020', 'module', 'main'],
+  // Note: ES2015 main condition is needed for `rxjs@v6`.
+  mainFields: ['fesm2022', 'es2022', 'es2020', 'es2015', 'module', 'main'],
   // The majority of these options match with the ones the CLI sets:
   // https://github.com/angular/angular-cli/blob/0d76bf04bca6e083865972b5398a32bbe9396e14/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts#L133.
   treeShaking: true,

--- a/bazel/spec-bundling/esbuild.config-tmpl.mjs
+++ b/bazel/spec-bundling/esbuild.config-tmpl.mjs
@@ -24,7 +24,8 @@ export default {
   // Based on the CLI configuration:
   // https://github.com/angular/angular-cli/blame/8089c9388056b3caaf56f981848aca94f022da73/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts#L51.
   conditions: ['es2022', 'es2020', 'es2015', 'module'],
-  mainFields: ['fesm2022', 'es2022', 'es2020', 'module', 'main'],
+  // Note: ES2015 main condition is needed for `rxjs@v6`.
+  mainFields: ['fesm2022', 'es2022', 'es2020', 'es2015', 'module', 'main'],
   // Addition of `.mjs` to the non-jsx defaults.
   // https://esbuild.github.io/api/#resolve-extensions
   resolveExtensions: ['.mjs', '.js', '.json'],


### PR DESCRIPTION
RxJS v6 does not match any conditions so we end up bundling the ES5 distribution which breaks surprisingly due to certain methods being missed on e.g. `Observable`.

We fix this by just preferring the more up-to-date distribution.

```
     error: TypeError: observable2.logSubscribedFrame is not a function
          at ColdObservable2._subscribe (file:///usr/local/google/home/pgschwendtner/.cache/bazel/_bazel_pgschwendtner/84e2b91096f108a3ead3e72250add8ed/sandbox/linux-sandbox/285/execroot/angular/bazel-out/k8-fastbuild/bin/packages/router/node_modules/rxjs/src/internal/testing/ColdObservable.ts:26:32)
          at ColdObservable2.Observable2._trySubscribe (file:///usr/local/google/home/pgschwendtner/.cache/bazel/_bazel_pgschwendtner/84e2b91096f108a3ead3e72250add8ed/sandbox/linux-sandbox/285/execroot/angular/bazel-out/k8-fastbuild/bin/packages/router/node_modules/rxjs/src/internal/Observable.ts:239:6)
```

https://screenshot.googleplex.com/3rzJQgp7bnXYRDW