### PR TITLE
fix(github-actions): use GITHUB_ACTION_PATH environment variable for path

### DIFF
--- a/github-actions/bazel/setup-bazel-remote-exec/action.yml
+++ b/github-actions/bazel/setup-bazel-remote-exec/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: ${{github.action_path}}/setup_remote_exec.sh
+    - run: $GITHUB_ACTION_PATH/setup_remote_exec.sh
       env:
         BAZELRC_PATH: ${{ inputs.bazelrc }}
         NGAT: 'qoDjQodnm6t97MfFcj7x+g=='


### PR DESCRIPTION
The GITHUB_ACTION_PATH environment variable works cross operating system better than the value being stamped from within the yaml