### PR TITLE
fix(ng-dev): fix useless regex escape

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -66907,7 +66907,7 @@ var parseOptions = {
   headerPattern,
   headerCorrespondence,
   noteKeywords: [NoteSections.BREAKING_CHANGE, NoteSections.DEPRECATED],
-  notesPattern: (keywords) => new RegExp(`^s*(${keywords}): ?(.*)`)
+  notesPattern: (keywords) => new RegExp(`^\\s*(${keywords}): ?(.*)`)
 };
 var parseCommitMessage = parseInternal;
 function parseInternal(fullText) {

--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -69328,7 +69328,7 @@ var parseOptions = {
   headerPattern,
   headerCorrespondence,
   noteKeywords: [NoteSections.BREAKING_CHANGE, NoteSections.DEPRECATED],
-  notesPattern: (keywords) => new RegExp(`^s*(${keywords}): ?(.*)`)
+  notesPattern: (keywords) => new RegExp(`^\\s*(${keywords}): ?(.*)`)
 };
 var parseCommitFromGitLog = parseInternal;
 function parseInternal(fullText) {

--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -31480,7 +31480,7 @@ var parseOptions = {
   headerPattern,
   headerCorrespondence,
   noteKeywords: [NoteSections.BREAKING_CHANGE, NoteSections.DEPRECATED],
-  notesPattern: (keywords) => new RegExp(`^s*(${keywords}): ?(.*)`)
+  notesPattern: (keywords) => new RegExp(`^\\s*(${keywords}): ?(.*)`)
 };
 var parseCommitMessage = parseInternal;
 function parseInternal(fullText) {

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -63869,7 +63869,7 @@ var parseOptions = {
   headerPattern,
   headerCorrespondence,
   noteKeywords: [NoteSections.BREAKING_CHANGE, NoteSections.DEPRECATED],
-  notesPattern: (keywords) => new RegExp(`^s*(${keywords}): ?(.*)`)
+  notesPattern: (keywords) => new RegExp(`^\\s*(${keywords}): ?(.*)`)
 };
 var parseCommitFromGitLog = parseInternal;
 function parseInternal(fullText) {

--- a/ng-dev/commit-message/parse.ts
+++ b/ng-dev/commit-message/parse.ts
@@ -110,7 +110,7 @@ const parseOptions: Options & {notesPattern: (keywords: string) => RegExp} = {
   headerPattern,
   headerCorrespondence,
   noteKeywords: [NoteSections.BREAKING_CHANGE, NoteSections.DEPRECATED],
-  notesPattern: (keywords: string) => new RegExp(`^\s*(${keywords}): ?(.*)`),
+  notesPattern: (keywords: string) => new RegExp(`^\\s*(${keywords}): ?(.*)`),
 };
 
 /** Parse a commit message into its composite parts. */


### PR DESCRIPTION
Fixes [security notice 42](https://github.com/angular/dev-infra/security/code-scanning/42).

Fixes #1324