### PR TITLE
feat(ng-dev): provide override flag for ignoring pending reviews

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -67151,7 +67151,6 @@ var Validation2 = class extends PullRequestValidation {
 var completedReviewsValidation = createPullRequestValidation({ name: "assertCompletedReviews", canBeForceIgnored: false }, () => Validation3);
 var Validation3 = class extends PullRequestValidation {
   assert(pullRequest) {
-    console.log(pullRequest.title);
     const totalCount = pullRequest.reviewRequests.totalCount;
     if (totalCount !== 0) {
       throw this._createError(`Pull request cannot be merged with pending reviews, it current has ${totalCount} pending review(s)`);

--- a/ng-dev/pr/common/validation/assert-completed-reviews.ts
+++ b/ng-dev/pr/common/validation/assert-completed-reviews.ts
@@ -17,7 +17,6 @@ export const completedReviewsValidation = createPullRequestValidation(
 
 class Validation extends PullRequestValidation {
   assert(pullRequest: PullRequestFromGithub) {
-    console.log(pullRequest.title);
     const totalCount = pullRequest.reviewRequests.totalCount;
     if (totalCount !== 0) {
       throw this._createError(

--- a/ng-dev/pr/merge/cli.ts
+++ b/ng-dev/pr/merge/cli.ts
@@ -18,6 +18,7 @@ export interface MergeCommandOptions {
   branchPrompt: boolean;
   forceManualBranches: boolean;
   dryRun: boolean;
+  ignorePendingReviews: boolean;
 }
 
 /** Builds the command. */
@@ -39,6 +40,11 @@ async function builder(argv: Argv) {
       type: 'boolean',
       default: false,
       description: 'Whether to manually select the branches you wish to merge the PR into.',
+    })
+    .option('ignore-pending-reviews' as 'ignorePendingReviews', {
+      type: 'boolean',
+      default: false,
+      description: 'Bypass the check for pending reviews on the pull request',
     });
 }
 
@@ -48,8 +54,9 @@ async function handler({
   branchPrompt,
   forceManualBranches,
   dryRun,
+  ignorePendingReviews,
 }: Arguments<MergeCommandOptions>) {
-  await mergePullRequest(pr, {branchPrompt, forceManualBranches, dryRun});
+  await mergePullRequest(pr, {branchPrompt, forceManualBranches, dryRun, ignorePendingReviews});
 }
 
 /** yargs command module describing the command. */

--- a/ng-dev/pr/merge/merge-pull-request.ts
+++ b/ng-dev/pr/merge/merge-pull-request.ts
@@ -51,7 +51,9 @@ export async function mergePullRequest(prNumber: number, flags: PullRequestMerge
 
   /** Performs the merge and returns whether it was successful or not. */
   async function performMerge(
-    validationConfig: PullRequestValidationConfig = new PullRequestValidationConfig(),
+    validationConfig: PullRequestValidationConfig = PullRequestValidationConfig.create({
+      assertCompletedReviews: !flags.ignorePendingReviews,
+    }),
   ): Promise<boolean> {
     try {
       await tool.merge(prNumber, validationConfig);

--- a/ng-dev/pr/merge/merge-tool.ts
+++ b/ng-dev/pr/merge/merge-tool.ts
@@ -40,12 +40,14 @@ export interface PullRequestMergeFlags {
   branchPrompt: boolean;
   forceManualBranches: boolean;
   dryRun: boolean;
+  ignorePendingReviews: boolean;
 }
 
 const defaultPullRequestMergeFlags: PullRequestMergeFlags = {
   branchPrompt: true,
   forceManualBranches: false,
   dryRun: false,
+  ignorePendingReviews: false,
 };
 
 /**


### PR DESCRIPTION
Allow for a caretaker to explicitly override pending reviews with a command line flag.