### PR TITLE
ci: setup codeql github action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: 'CodeQL'
+
+on:
+  push:
+  pull_request_target:
+  schedule:
+    # Run every Sunday at 12:00
+    - cron: '0 12 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8ab72a0f4710f64c7212160969f7ea05f111a31d # tag=v2.21.4
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
Sets up a Github Action for CodeQL manually to allow it to run on pull requests in addition to branches