### PR TITLE
ci: disable `angular/universal` from renovate updates

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -15,7 +15,6 @@ module.exports = {
     'angular/dev-infra',
     'angular/components',
     'angular/angular-cli',
-    'angular/universal',
     'angular/vscode-ng-language-service',
     'angular/.github',
   ],


### PR DESCRIPTION
This repo is in maintaince mode as it has it's content has been migrated into the CLI repo.