### PR TITLE
ci: set default permissions and specific commit for codeql-action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,8 @@ on:
     # Run every Sunday at 12:00
     - cron: '0 12 * * 0'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze
@@ -25,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@a9fb7d923c0e2516dbb608ac87d9c3cdd12e236d # tag=v2.21.5
         with:
           languages: ${{ matrix.language }}
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
Fixes https://github.com/angular/dev-infra/security/code-scanning/46
Fixes https://github.com/angular/dev-infra/security/code-scanning/45