### PR TITLE
feat(github-actions): improve CI bazel options when setting up bazel

### DIFF
--- a/github-actions/bazel/setup/action.yml
+++ b/github-actions/bazel/setup/action.yml
@@ -29,8 +29,9 @@ runs:
     - name: Configure action caching for bazel repository cache
       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # tag=v3.3.1
       with:
-        enableCrossOsArchive: true
+        # Note: Bazel repository cache is located in system locations and cannot use
+        # a shared cache between different runner operating systems.
         path: '~/.cache/bazel_repo_cache'
-        key: bazel-cache-${{ hashFiles('**/WORKSPACE') }}
+        key: bazel-cache-${{ runner.os }}-${{ hashFiles('**/WORKSPACE') }}
         restore-keys: |
-          bazel-cache-
+          bazel-cache-${{ runner.os }}-

--- a/github-actions/bazel/setup/action.yml
+++ b/github-actions/bazel/setup/action.yml
@@ -20,8 +20,8 @@ runs:
           \%LocalAppData\%/bazelisk
         key: bazel-version-${{ hashFiles('**/.bazelversion') }}
 
-    - name: Add repository cache directory to bazelrc config
-      run: $GITHUB_ACTION_PATH/add-repository-cache.sh
+    - name: Setup CI bazelrc config
+      run: node $GITHUB_ACTION_PATH/setup-ci-bazelrc.mjs
       env:
         BAZELRC_PATH: ${{ inputs.bazelrc }}
       shell: bash

--- a/github-actions/bazel/setup/add-repository-cache.sh
+++ b/github-actions/bazel/setup/add-repository-cache.sh
@@ -1,6 +1,0 @@
-echo """
-build --repository_cache=~/.cache/bazel_repo_cache
-""" >> $BAZELRC_PATH
-
-
-cat $BAZELRC_PATH

--- a/github-actions/bazel/setup/setup-ci-bazelrc.mjs
+++ b/github-actions/bazel/setup/setup-ci-bazelrc.mjs
@@ -1,0 +1,32 @@
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+// Resolves the cache path to a system absolute path. This is necessary
+// for Bazel to properly pick up the path. Note also that backslashes
+// in the bazelrc file need to be escaled as otherwise those would escape
+// followed characters that weren't supposed to be escaped.
+const cachePath = path.join(os.homedir(), '.cache/bazel_repo_cache');
+const escapedCachePath = cachePath.replace(/\\/g, '\\\\');
+
+const bazelRcContent = `
+# Print all the options that apply to the build.
+# This helps us diagnose which options override others
+# (e.g. /etc/bazel.bazelrc vs. tools/bazel.rc)
+build --announce_rc
+
+# Avoids re-downloading NodeJS/browsers all the time.
+build --repository_cache=${escapedCachePath}
+
+# More details on failures
+build --verbose_failures=true
+
+# CI supports colors but Bazel does not detect it.
+common --color=yes
+`;
+
+await fs.promises.mkdir(cachePath, {recursive: true});
+await fs.promises.appendFile(process.env.BAZELRC_PATH, bazelRcContent);
+
+console.info('Appended to the Bazel RC file:\n\n');
+console.info(bazelRcContent);


### PR DESCRIPTION
* Re-enables some options that were lost from the CircleCI -> GHA migration, like color, verbose failures, and RC announcing

* Attempts to fix Bazel caching by not using tilde, but actually expanding the path into an absolute path. Similar to how it's done in CircleCI.