### PR TITLE
fix(dev-infra): update `zone.js` import to use modern

### DIFF
--- a/bazel/benchmark/component_benchmark/defaults/index.ts
+++ b/bazel/benchmark/component_benchmark/defaults/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import 'zone.js/dist/zone';
+import 'zone.js';
 
 import {enableProdMode} from '@angular/core';
 import {platformBrowser} from '@angular/platform-browser';


### PR DESCRIPTION
`/dist/` is legacy and it will be removed in the next version