### PR TITLE
feat(api-gen): add more structure to the transform pipeline

### DIFF
--- a/api-gen/rendering/entities.ts
+++ b/api-gen/rendering/entities.ts
@@ -21,6 +21,7 @@ export enum EntryType {
   Enum = 'enum',
   Function = 'function',
   Interface = 'interface',
+  NgModule = 'ng_module',
   Pipe = 'pipe',
   TypeAlias = 'type_alias',
   UndecoratedClass = 'undecorated_class',
@@ -68,6 +69,11 @@ export interface ClassEntry extends DocEntry {
   members: MemberEntry[];
 }
 
+/** Documentation entity for a TypeScript enum. */
+export interface EnumEntry extends DocEntry {
+  members: EnumMemberEntry[];
+}
+
 /** Documentation entity for an Angular directives and components. */
 export interface DirectiveEntry extends ClassEntry {
   selector: string;
@@ -75,18 +81,30 @@ export interface DirectiveEntry extends ClassEntry {
   isStandalone: boolean;
 }
 
+export interface PipeEntry extends ClassEntry {
+  pipeName: string;
+  isStandalone: boolean;
+  // TODO: add `isPure`.
+}
+
 export interface FunctionEntry extends DocEntry {
   params: ParameterEntry[];
   returnType: string;
 }
 
-/** Sub-entry for a single class member. */
+/** Sub-entry for a single class or enum member. */
 export interface MemberEntry {
   name: string;
   memberType: MemberType;
   memberTags: MemberTags[];
   description: string;
   jsdocTags: JsDocTagEntry[];
+}
+
+/** Sub-entry for an enum member. */
+export interface EnumMemberEntry extends MemberEntry {
+  type: string;
+  value: string;
 }
 
 /** Sub-entry for a class property. */

--- a/api-gen/rendering/entities/categorization.ts
+++ b/api-gen/rendering/entities/categorization.ts
@@ -1,0 +1,19 @@
+import {ClassEntry, DocEntry, EntryType, FunctionEntry} from '../entities';
+
+/** Gets whether the given entry represents a class */
+export function isClassEntry(entry: DocEntry): entry is ClassEntry {
+  // TODO: add something like `statementType` to extraction so we don't have to check so many
+  //     entry types here.
+  return (
+    entry.entryType === EntryType.UndecoratedClass ||
+    entry.entryType === EntryType.Component ||
+    entry.entryType === EntryType.Decorator ||
+    entry.entryType === EntryType.Pipe ||
+    entry.entryType === EntryType.NgModule
+  );
+}
+
+/** Gets whether the given entry represents a function */
+export function isFunctionEntry(entry: DocEntry): entry is FunctionEntry {
+  return entry.entryType === EntryType.Function;
+}

--- a/api-gen/rendering/entities/entry_template_map.ts
+++ b/api-gen/rendering/entities/entry_template_map.ts
@@ -1,0 +1,10 @@
+import {EntryType} from '../entities';
+
+/** A map of EntityType to nunjucks template. */
+export const DOC_ENTRY_TEMPLATES = new Map([
+  [EntryType.UndecoratedClass, 'class.njk'],
+  [EntryType.Directive, 'class.njk'],
+  [EntryType.Component, 'class.njk'],
+  [EntryType.Pipe, 'class.njk'],
+  [EntryType.NgModule, 'class.njk'],
+]);

--- a/api-gen/rendering/entities/renderables.ts
+++ b/api-gen/rendering/entities/renderables.ts
@@ -1,0 +1,76 @@
+import {
+  ClassEntry,
+  ConstantEntry,
+  DirectiveEntry,
+  DocEntry,
+  EnumEntry,
+  EnumMemberEntry,
+  FunctionEntry,
+  JsDocTagEntry,
+  MemberEntry,
+  ParameterEntry,
+  PipeEntry,
+} from '../entities';
+
+/** JsDoc tag info augmented with transformed content for rendering. */
+export interface JsDocTagRenderable extends JsDocTagEntry {
+  htmlComment: string;
+}
+
+/** A documentation entry augmented with transformed content for rendering. */
+export interface DocEntryRenderable extends DocEntry {
+  htmlDescription: string;
+  jsdocTags: JsDocTagRenderable[];
+}
+
+/** Documentation entity for a constant augmented transformed content for rendering. */
+export type ConstantEntryRenderable = ConstantEntry & DocEntryRenderable;
+
+/** Documentation entity for a TypeScript class augmented transformed content for rendering. */
+export type ClassEntryRenderable = ClassEntry &
+  DocEntryRenderable & {
+    members: MemberEntryRenderable[];
+  };
+
+/** Documentation entity for a TypeScript enum augmented transformed content for rendering. */
+export type EnumEntryRenderable = EnumEntry &
+  DocEntryRenderable & {
+    members: EnumMemberEntryRenderable[];
+  };
+
+/**
+ * Documentation entity for an Angular directives and components augmented transformed
+ * content for rendering.
+ */
+export type DirectiveEntryRenderable = DirectiveEntry & DocEntryRenderable;
+
+/** Documentation entity for a pipe augmented transformed content for rendering. */
+export type PipeEntryRenderable = PipeEntry & DocEntryRenderable;
+
+export type FunctionEntryRenderable = FunctionEntry &
+  DocEntryRenderable & {
+    params: ParameterEntryRenderable[];
+  };
+
+/** Sub-entry for a single class or enum member augmented with transformed content for rendering. */
+export interface MemberEntryRenderable extends MemberEntry {
+  htmlDescription: string;
+  jsdocTags: JsDocTagRenderable[];
+}
+
+/** Sub-entry for an enum member augmented transformed content for rendering. */
+export type EnumMemberEntryRenderable = EnumMemberEntry & MemberEntryRenderable;
+
+/** Sub-entry for a class property augmented transformed content for rendering. */
+export type PropertyEntryRenderable = MemberEntryRenderable;
+
+/** Sub-entry for a class method augmented transformed content for rendering. */
+export type MethodEntryRenderable = MemberEntryRenderable &
+  FunctionEntryRenderable & {
+    params: ParameterEntryRenderable[];
+  };
+
+/** Sub-entry for a single function parameter augmented transformed content for rendering. */
+export interface ParameterEntryRenderable extends ParameterEntry {
+  htmlDescription: string;
+}

--- a/api-gen/rendering/entities/traits.ts
+++ b/api-gen/rendering/entities/traits.ts
@@ -1,0 +1,32 @@
+import {JsDocTagEntry, MemberEntry} from '../entities';
+import {JsDocTagRenderable, MemberEntryRenderable} from './renderables';
+
+/** A doc entry that has jsdoc tags. */
+export interface HasJsDocTags {
+  jsdocTags: JsDocTagEntry[];
+}
+
+/** A doc entry that has jsdoc tags transformed for rendering. */
+export interface HasRenderableJsDocTags {
+  jsdocTags: JsDocTagRenderable[];
+}
+
+/** A doc entry that has a description. */
+export interface HasDescription {
+  description: string;
+}
+
+/** A doc entry that has a transformed html description. */
+export interface HasHtmlDescription {
+  htmlDescription: string;
+}
+
+/** A doc entry that has members transformed for rendering. */
+export interface HasMembers {
+  members: MemberEntry[];
+}
+
+/** A doc entry that has members transformed for rendering. */
+export interface HasRenderableMembers {
+  members: MemberEntryRenderable[];
+}

--- a/api-gen/rendering/index.ts
+++ b/api-gen/rendering/index.ts
@@ -9,25 +9,37 @@ interface EntryList {
   entries: DocEntry[];
 }
 
-function main() {
-  const [srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
-
-  // Each data file contains an array of entries, so we aggregate the entries of all
-  // input data files.
-  const entries = srcs.split(',').reduce((entries: DocEntry[], jsonDataFilePath: string) => {
+/** Aggregate all JSON data source files into an array of docs entries. */
+function aggregateEntries(srcs: string[]): DocEntry[] {
+  return srcs.reduce((entries: DocEntry[], jsonDataFilePath: string) => {
     const fileContent = readFileSync(jsonDataFilePath, {encoding: 'utf8'});
     return entries.concat((JSON.parse(fileContent) as EntryList).entries) as DocEntry[];
   }, []);
+}
+
+function main() {
+  const [srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
+
+  // Docs rendering happens in three phases that occur here:
+  // 1) Aggregate all the raw extracted doc info.
+  // 2) Transform the raw data to a renderable state.
+  // 3) Render to HTML.
+
+  // Each data file contains an array of entries,
+  // so we aggregate the entries of all input data files.
+  const entries = aggregateEntries(srcs.split(','));
 
   // Transform the data from its raw extracted form to its renderable form.
-  // This includes any processors, such as markdown→html.
+  // This includes any content processors such as markdown → html.
   const renderEntries = entries.map(processEntryForRender);
 
   // Render the processed data into the final HTML documents.
   const htmlOutputs = renderEntries.map(renderEntry);
+
   for (let i = 0; i < htmlOutputs.length; i++) {
-    // TODO: make real file names
-    writeFileSync(path.join(outputFilenameExecRootRelativePath, `${i}.html`), htmlOutputs[i], {
+    // TODO: de-duplicate identifiers by incorporating package entry point.
+    const filename = `${renderEntries[i].name}.html`;
+    writeFileSync(path.join(outputFilenameExecRootRelativePath, filename), htmlOutputs[i], {
       encoding: 'utf8',
     });
   }

--- a/api-gen/rendering/nunjucks_loader.ts
+++ b/api-gen/rendering/nunjucks_loader.ts
@@ -1,0 +1,19 @@
+import {runfiles} from '@bazel/runfiles';
+import {readFileSync} from 'fs';
+import nunjucks from 'nunjucks';
+import {join} from 'path';
+
+/**
+ * Custom nunjucks loader that resolves against bazel runfiles.
+ * This is necessary for references to files inside nunjucks templates.
+ */
+export class NunjucksRunfilesLoader extends nunjucks.FileSystemLoader {
+  override getSource(name: string) {
+    const runfilesPath = runfiles.resolvePackageRelative(join('templates', name));
+    return {
+      src: readFileSync(runfilesPath, {encoding: 'utf8'}),
+      path: runfilesPath,
+      noCache: false,
+    };
+  }
+}

--- a/api-gen/rendering/processing.ts
+++ b/api-gen/rendering/processing.ts
@@ -1,10 +1,15 @@
+import {isClassEntry} from './entities/categorization';
 import {DocEntry} from './entities';
-import {DocRenderEntry} from './render-entities';
-import {marked} from 'marked';
+import {DocEntryRenderable} from './entities/renderables';
+import {getClassRenderable} from './transforms/class-transforms';
+import {addHtmlDescription, addHtmlJsDocTagComments} from './transforms/jsdoc-transforms';
 
-export function processEntryForRender(entry: DocEntry): DocRenderEntry {
-  return {
-    ...entry,
-    htmlDescription: marked.parse(entry.description),
-  };
+/** Given a doc entry, get the transformed version of the entry for rendering. */
+export function processEntryForRender(entry: DocEntry): DocEntryRenderable {
+  if (isClassEntry(entry)) {
+    return getClassRenderable(entry);
+  }
+
+  // Fall back to adding an `htmlDescription` and transformed JsDoc tags.
+  return addHtmlJsDocTagComments(addHtmlDescription(entry));
 }

--- a/api-gen/rendering/render-entities.ts
+++ b/api-gen/rendering/render-entities.ts
@@ -1,5 +1,0 @@
-import {DocEntry} from './entities';
-
-export interface DocRenderEntry extends DocEntry {
-  htmlDescription: string;
-}

--- a/api-gen/rendering/rendering.ts
+++ b/api-gen/rendering/rendering.ts
@@ -1,12 +1,19 @@
-import {runfiles} from '@bazel/runfiles';
-import {readFileSync} from 'fs';
 import nunjucks from 'nunjucks';
-import {DocRenderEntry} from './render-entities';
+import {DOC_ENTRY_TEMPLATES} from './entities/entry_template_map';
+import {NunjucksRunfilesLoader} from './nunjucks_loader';
+import {DocEntryRenderable} from './entities/renderables';
 
-export function renderEntry(entry: DocRenderEntry): string {
-  // TODO: get template based on type of entity
-  // TODO: only read each template once per program invocation.
-  const templatePath = runfiles.resolvePackageRelative('./templates/component-reference.njk');
-  const template = readFileSync(templatePath, {encoding: 'utf8'});
-  return nunjucks.renderString(template, entry);
+/** Configure a nunjucks environment with our custom loader. */
+const nunjucksEnvironment = new nunjucks.Environment(new NunjucksRunfilesLoader());
+
+/** Renders a processed entry to an HTML string. */
+export function renderEntry(entry: DocEntryRenderable): string {
+  const template = DOC_ENTRY_TEMPLATES.get(entry.entryType);
+
+  if (!template) {
+    throw new Error(`No template for entry type "${entry.entryType}"`);
+  }
+
+  // Unfortunately at this point we lose all of our beautiful type safety.
+  return nunjucksEnvironment.render(template, entry);
 }

--- a/api-gen/rendering/templates/class-member-list.njk
+++ b/api-gen/rendering/templates/class-member-list.njk
@@ -1,0 +1,12 @@
+{% from "class-member.njk" import classMember %}
+
+{% macro classMemberList(members) %}
+
+  <div class="adev-reference-members">
+    {{class.members.length}}
+    {% for member in members %}
+      {% call classMember(member) -%}{%- endcall %}
+    {% endfor %}
+  </div>
+
+{% endmacro %}

--- a/api-gen/rendering/templates/class-member.njk
+++ b/api-gen/rendering/templates/class-member.njk
@@ -1,0 +1,39 @@
+{% macro classMember(member) %}
+
+  <div id="{{member.name}}" class="adev-reference-member-card">
+    <header>
+      <h3>{{member.name}}</h3>
+    </header>
+    <div class="adev-reference-card-body">
+      {{member.htmlDescription | safe}}
+
+      {# TODO: modifiers (static, protected, readonly) #}
+      {# TODO: asyncmetric getter/setter #}
+
+      {% if member.isDeprecated %}
+        <div>
+          <span class="adev-param-keyword adev-deprecated">@deprecated</span>
+          {{member.htmlDeprecatedComment | safe}}
+        </div>
+      {% endif %}
+
+      {% if member.params.length %}
+        {% for param in member.params %}
+          <div>
+            {# TODO: isOptional, isRestParam #}
+            <span class="adev-param-keyword">@param</span>
+            <span class="adev-param-name">{{param.name}}</span>
+            <code>{{param.type}}</code>
+            {{param.htmlDescription | safe}}
+          </div>
+        {% endfor %}
+        <div>
+          <span class="adev-param-keyword">@returns</span>
+          <code>{{member.returnType}}</code>
+          {{member.htmlReturnDescription | safe}}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+
+{% endmacro %}

--- a/api-gen/rendering/templates/class.njk
+++ b/api-gen/rendering/templates/class.njk
@@ -1,0 +1,6 @@
+{% from "class-member-list.njk" import classMemberList %}
+
+<h1>{{name}}</h1>
+<p>{{htmlDescription | safe}}</p>
+
+{% call classMemberList(members) -%}{%- endcall %}

--- a/api-gen/rendering/templates/component-reference.njk
+++ b/api-gen/rendering/templates/component-reference.njk
@@ -1,2 +1,0 @@
-<h1>{{name}}</h1>
-<p>{{htmlDescription | safe}}</p>

--- a/api-gen/rendering/test/fake-entries.json
+++ b/api-gen/rendering/test/fake-entries.json
@@ -2,11 +2,72 @@
   "entries": [
     {
       "name": "NgTemplateOutlet",
-      "description": "*one* directive"
+      "description": "*one* directive",
+      "entryType": "directive",
+      "members": [],
+      "jsdocTags": [],
+      "rawComment": ""
     },
     {
-      "name": "NgComponentOutlet",
-      "description": "two _directive_"
+      "name": "UserProfile",
+      "entryType": "undecorated_class",
+      "members": [
+        {
+          "name": "userId",
+          "type": "number",
+          "memberType": "property",
+          "memberTags": [],
+          "description": "A user identifier.",
+          "jsdocTags": []
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "memberType": "getter",
+          "memberTags": [],
+          "description": "Name of the user",
+          "jsdocTags": []
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "memberType": "setter",
+          "memberTags": [],
+          "description": "Name of the user",
+          "jsdocTags": []
+        },
+        {
+          "params": [
+            {
+              "name": "config",
+              "description": "Setting for saving.",
+              "type": "object",
+              "isOptional": false,
+              "isRestParam": false
+            }
+          ],
+          "name": "save",
+          "returnType": "boolean",
+          "entryType": "function",
+          "description": "Save the user.",
+          "jsdocTags": [
+            {
+              "name": "param",
+              "comment": "Setting for saving."
+            },
+            {
+              "name": "returns",
+              "comment": "Whether it succeeded"
+            }
+          ],
+          "rawComment": "/**\n           * Save the user.\n           * @param config Setting for saving.\n           * @returns Whether it succeeded\n           */",
+          "memberType": "method",
+          "memberTags": []
+        }
+      ],
+      "description": "",
+      "jsdocTags": [],
+      "rawComment": ""
     }
   ]
 }

--- a/api-gen/rendering/transforms/class-transforms.ts
+++ b/api-gen/rendering/transforms/class-transforms.ts
@@ -1,0 +1,9 @@
+import {ClassEntry} from '../entities';
+import {ClassEntryRenderable} from '../entities/renderables';
+import {addHtmlDescription, addHtmlJsDocTagComments} from './jsdoc-transforms';
+import {addRenderableMembers} from './member-transforms';
+
+/** Given an unprocessed class entry, get the fully renderable class entry. */
+export function getClassRenderable(classEntry: ClassEntry): ClassEntryRenderable {
+  return addRenderableMembers(addHtmlJsDocTagComments(addHtmlDescription(classEntry)));
+}

--- a/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -1,0 +1,37 @@
+import {marked} from 'marked';
+import {
+  HasDescription,
+  HasHtmlDescription,
+  HasJsDocTags,
+  HasRenderableJsDocTags,
+} from '../entities/traits';
+
+/** Given an entity with a description, gets the entity augmented with an `htmlDescription`. */
+export function addHtmlDescription<T extends HasDescription>(entry: T): T & HasHtmlDescription {
+  return {
+    ...entry,
+    htmlDescription: getHtmlForJsDocText(entry.description),
+  };
+}
+
+/**
+ * Given an entity with JsDoc tags, gets the entity with JsDocTagRenderable entries that
+ * have been augmented with an `htmlComment`.
+ */
+export function addHtmlJsDocTagComments<T extends HasJsDocTags>(
+  entry: T,
+): T & HasRenderableJsDocTags {
+  return {
+    ...entry,
+    jsdocTags: entry.jsdocTags.map((tag) => ({
+      ...tag,
+      htmlComment: getHtmlForJsDocText(tag.comment),
+    })),
+  };
+}
+
+/** Given a markdown JsDoc text, gets the rendered HTML. */
+export function getHtmlForJsDocText(text: string): string {
+  // TODO: use the fully configured `marked` processors
+  return marked.parse(text);
+}

--- a/api-gen/rendering/transforms/member-transforms.ts
+++ b/api-gen/rendering/transforms/member-transforms.ts
@@ -1,0 +1,12 @@
+import {HasMembers, HasRenderableMembers} from '../entities/traits';
+import {addHtmlDescription, addHtmlJsDocTagComments} from './jsdoc-transforms';
+
+/** Given an entity with members, gets the entity augmented with renderable members. */
+export function addRenderableMembers<T extends HasMembers>(entry: T): T & HasRenderableMembers {
+  // TODO: combine any getters and setters with the same name into one entry
+  // TODO: method parameters
+  return {
+    ...entry,
+    members: entry.members.map((member) => addHtmlDescription(addHtmlJsDocTagComments(member))),
+  };
+}


### PR DESCRIPTION
Based on top of #1381.

This commit:
* Expands the processing of raw docs entries to "renderable" entries.
* Adds a nunjucks file loader that lets templates use macros
* Adds some actual templating for classes