### PR TITLE
feat(api-gen): set up Ngtsc program for raw api extraction

### DIFF
--- a/api-gen/extraction/BUILD.bazel
+++ b/api-gen/extraction/BUILD.bazel
@@ -44,5 +44,8 @@ nodejs_binary(
     # Do not use the NodeJS linker because:
     #  - it's brittle and causes race conditions on Windows.
     #  - it requires additional work to setup the runtime linker.
-    templated_args = ["--bazel_patch_module_resolver"],
+    templated_args = [
+        "--bazel_patch_module_resolver",
+        "--node_options=--preserve-symlinks-main",
+    ],
 )

--- a/api-gen/extraction/BUILD.bazel
+++ b/api-gen/extraction/BUILD.bazel
@@ -41,11 +41,9 @@ nodejs_binary(
         "@npm//@angular/compiler-cli",
     ],
     entry_point = "bin.mjs",
-    # Do not use the NodeJS linker because:
-    #  - it's brittle and causes race conditions on Windows.
-    #  - it requires additional work to setup the runtime linker.
-    templated_args = [
-        "--bazel_patch_module_resolver",
-        "--node_options=--preserve-symlinks-main",
-    ],
+    # Note: Using the linker here as we need it for ESM. The linker is not
+    # super reliably when running concurrently on Windows- but we have existing
+    # actions using the linker. An alternative would be to:
+    #   - bundle the Angular compiler into a CommonJS bundle
+    #   - use the patched resolution- but also patch the ESM imports (similar to how FW does it).
 )

--- a/api-gen/extraction/BUILD.bazel
+++ b/api-gen/extraction/BUILD.bazel
@@ -1,7 +1,24 @@
 load("@npm//@bazel/concatjs:index.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+load("//bazel/esbuild:index.bzl", "esbuild")
 
 package(default_visibility = ["//api-gen:__subpackages__"])
+
+esbuild(
+    name = "bin",
+    entry_point = ":index.ts",
+    external = [
+        "@angular/compiler-cli",
+    ],
+    format = "esm",
+    output = "bin.mjs",
+    platform = "node",
+    target = "es2022",
+    deps = [
+        ":extract_api_to_json_lib",
+        "@npm//@angular/compiler-cli",
+    ],
+)
 
 ts_library(
     name = "extract_api_to_json_lib",
@@ -19,9 +36,11 @@ ts_library(
 nodejs_binary(
     name = "extract_api_to_json",
     data = [
-        ":extract_api_to_json_lib",
+        ":bin",
+        "@npm//@angular/compiler",
+        "@npm//@angular/compiler-cli",
     ],
-    entry_point = "//api-gen/extraction:index.ts",
+    entry_point = "bin.mjs",
     # Do not use the NodeJS linker because:
     #  - it's brittle and causes race conditions on Windows.
     #  - it requires additional work to setup the runtime linker.

--- a/api-gen/extraction/extract_api_to_json.bzl
+++ b/api-gen/extraction/extract_api_to_json.bzl
@@ -1,3 +1,5 @@
+load("@build_bazel_rules_nodejs//:providers.bzl", "run_node")
+
 def _extract_api_to_json(ctx):
     """Implementation of the extract_api_to_json rule"""
 
@@ -13,9 +15,10 @@ def _extract_api_to_json(ctx):
 
     # Define an action that runs the nodejs_binary executable. This is
     # the main thing that this rule does.
-    ctx.actions.run(
+    run_node(
+        ctx = ctx,
         inputs = depset(ctx.files.srcs),
-        executable = ctx.executable._extract_api_to_json,
+        executable = "_extract_api_to_json",
         outputs = [json_output],
         arguments = [args],
     )

--- a/api-gen/extraction/index.ts
+++ b/api-gen/extraction/index.ts
@@ -1,11 +1,21 @@
 import {writeFileSync} from 'fs';
+// @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
+import {NgtscProgram, CompilerOptions, createCompilerHost} from '@angular/compiler-cli';
 
 function main() {
-  const [srcs, outputFileName] = process.argv.slice(2);
+  const [srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
 
-  // TODO: read data with APIs from @angular/compiler-cli
+  const compilerOptions: CompilerOptions = {};
+  const compilerHost = createCompilerHost({options: compilerOptions});
+  const program: NgtscProgram = new NgtscProgram(srcs.split(','), compilerOptions, compilerHost);
+  console.log(`NgtscProgram successfully created: ${!!program}`);
 
-  writeFileSync(outputFileName, JSON.stringify({entries: []}), {encoding: 'utf8'});
+  // TODO: call the real API when it is published to npm.
+  //     When tested with a locally built @angular/compiler-cli, it works!
+  // const output = JSON.stringify(program.getApiDocumentation());
+  const output = JSON.stringify({entries: []});
+
+  writeFileSync(outputFilenameExecRootRelativePath, output, {encoding: 'utf8'});
 }
 
 main();

--- a/api-gen/extraction/test/BUILD.bazel
+++ b/api-gen/extraction/test/BUILD.bazel
@@ -5,3 +5,8 @@ extract_api_to_json(
     srcs = ["fake-source.ts"],
     output_name = "api.json",
 )
+
+filegroup(
+    name = "source_files",
+    srcs = ["fake-source.ts"],
+)

--- a/api-gen/rendering/BUILD.bazel
+++ b/api-gen/rendering/BUILD.bazel
@@ -31,5 +31,8 @@ nodejs_binary(
     # Do not use the NodeJS linker because:
     #  - it's brittle and causes race conditions on Windows.
     #  - it requires additional work to setup the runtime linker.
-    templated_args = ["--bazel_patch_module_resolver"],
+    templated_args = [
+        "--bazel_patch_module_resolver",
+        "--node_options=--preserve-symlinks-main",
+    ],
 )


### PR DESCRIPTION
Based on top of #1392

This adds the setup for creating an Ngtsc program to pull API data from files.

Immense thanks to @devversion for helping me with the ESM compatibility workaround 🥇 