### PR TITLE
fix(github-actions): use the workflow-artifact-name to disambiguate multiple previews across channels

### DIFF
--- a/github-actions/previews/upload-artifacts-to-firebase/action.yml
+++ b/github-actions/previews/upload-artifacts-to-firebase/action.yml
@@ -89,7 +89,7 @@ runs:
         expires: 10d
         projectId: '${{inputs.firebase-project-id}}'
         entryPoint: '${{inputs.firebase-config-dir}}'
-        channelId: pr-${{github.repository}}-${{steps.artifact-info.outputs.unsafe-pull-number}}
+        channelId: pr-${{github.repository}}-${{steps.artifact-info.outputs.unsafe-pull-number}}-${{inputs.workflow-artifact-name}}
 
     - uses: marocchino/sticky-pull-request-comment@efaaab3fd41a9c3de579aba759d2552635e590fd # v2
       with:


### PR DESCRIPTION
Allow the workflow artifact name to be used to prevent multiple previews from using the same channel.