### PR TITLE
feat(api-gen): add macro that combines api doc extraction and rendering

### DIFF
--- a/api-gen/extraction/test/BUILD.bazel
+++ b/api-gen/extraction/test/BUILD.bazel
@@ -1,5 +1,7 @@
 load("//api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
 
+package(default_visibility = ["//api-gen:__subpackages__"])
+
 extract_api_to_json(
     name = "test",
     srcs = ["fake-source.ts"],

--- a/api-gen/generate_api_docs.bzl
+++ b/api-gen/generate_api_docs.bzl
@@ -1,0 +1,18 @@
+load("//api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
+
+def generate_api_docs(name, srcs):
+    """Generates API documentation reference pages for the given sources."""
+    json_outfile = name + "_api.json"
+
+    extract_api_to_json(
+        name = name + "_extraction",
+        srcs = srcs,
+        output_name = json_outfile,
+        visibility = ["//visibility:private"],
+    )
+
+    render_api_to_html(
+        name = name,
+        srcs = [json_outfile],
+    )

--- a/api-gen/test/BUILD.bazel
+++ b/api-gen/test/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//:api-gen/generate_api_docs.bzl", "generate_api_docs")
+
+generate_api_docs(
+    name = "test",
+    srcs = ["//api-gen/extraction/test:source_files"],
+)


### PR DESCRIPTION
This macro is a convenience for downstream repos to perform extraction and rendering with one API.