### PR TITLE
feat(api-gen): add module_name to the pipeline

### DIFF
--- a/api-gen/extraction/extract_api_to_json.bzl
+++ b/api-gen/extraction/extract_api_to_json.bzl
@@ -6,6 +6,9 @@ def _extract_api_to_json(ctx):
     # Define arguments that will be passed to the underlying nodejs program.
     args = ctx.actions.args()
 
+    # Pass the module_name for the extracted APIs. This will be something like "@angular/core".
+    args.add(ctx.attr.module_name)
+
     # Pass the set of source files from which API reference data will be extracted.
     args.add_joined(ctx.files.srcs, join_with = ",")
 
@@ -43,6 +46,10 @@ extract_api_to_json = rule(
         ),
         "output_name": attr.output(
             doc = """Name of the JSON output file.""",
+        ),
+        "module_name": attr.string(
+            doc = """JS Module name to be used for the extracted symbols""",
+            mandatory = True,
         ),
 
         # The executable for this rule (private).

--- a/api-gen/extraction/index.ts
+++ b/api-gen/extraction/index.ts
@@ -3,7 +3,7 @@ import {writeFileSync} from 'fs';
 import {NgtscProgram, CompilerOptions, createCompilerHost} from '@angular/compiler-cli';
 
 function main() {
-  const [srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
+  const [moduleName, srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
 
   const compilerOptions: CompilerOptions = {};
   const compilerHost = createCompilerHost({options: compilerOptions});
@@ -13,7 +13,7 @@ function main() {
   // TODO: call the real API when it is published to npm.
   //     When tested with a locally built @angular/compiler-cli, it works!
   // const output = JSON.stringify(program.getApiDocumentation());
-  const output = JSON.stringify({entries: []});
+  const output = JSON.stringify({moduleName: moduleName, entries: []});
 
   writeFileSync(outputFilenameExecRootRelativePath, output, {encoding: 'utf8'});
 }

--- a/api-gen/extraction/test/BUILD.bazel
+++ b/api-gen/extraction/test/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//api-gen:__subpackages__"])
 extract_api_to_json(
     name = "test",
     srcs = ["fake-source.ts"],
+    module_name = "@angular/core",
     output_name = "api.json",
 )
 

--- a/api-gen/generate_api_docs.bzl
+++ b/api-gen/generate_api_docs.bzl
@@ -1,12 +1,13 @@
 load("//api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
 load("//api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
 
-def generate_api_docs(name, srcs):
+def generate_api_docs(name, module_name, srcs):
     """Generates API documentation reference pages for the given sources."""
     json_outfile = name + "_api.json"
 
     extract_api_to_json(
         name = name + "_extraction",
+        module_name = module_name,
         srcs = srcs,
         output_name = json_outfile,
         visibility = ["//visibility:private"],

--- a/api-gen/rendering/entities/categorization.ts
+++ b/api-gen/rendering/entities/categorization.ts
@@ -7,9 +7,16 @@ import {
   MemberType,
   MethodEntry,
 } from '../entities';
-import {MemberEntryRenderable, MethodEntryRenderable} from './renderables';
+import {
+  ClassEntryRenderable,
+  DocEntryRenderable,
+  MemberEntryRenderable,
+  MethodEntryRenderable,
+} from './renderables';
 
 /** Gets whether the given entry represents a class */
+export function isClassEntry(entry: DocEntryRenderable): entry is ClassEntryRenderable;
+export function isClassEntry(entry: DocEntry): entry is ClassEntry;
 export function isClassEntry(entry: DocEntry): entry is ClassEntry {
   // TODO: add something like `statementType` to extraction so we don't have to check so many
   //     entry types here.
@@ -24,6 +31,7 @@ export function isClassEntry(entry: DocEntry): entry is ClassEntry {
 
 /** Gets whether the given member entry is a method entry. */
 export function isClassMethodEntry(entry: MemberEntryRenderable): entry is MethodEntryRenderable;
+export function isClassMethodEntry(entry: MemberEntry): entry is MethodEntry;
 export function isClassMethodEntry(entry: MemberEntry): entry is MethodEntry {
   return entry.memberType === MemberType.Method;
 }

--- a/api-gen/rendering/entities/renderables.ts
+++ b/api-gen/rendering/entities/renderables.ts
@@ -19,6 +19,7 @@ export interface JsDocTagRenderable extends JsDocTagEntry {
 
 /** A documentation entry augmented with transformed content for rendering. */
 export interface DocEntryRenderable extends DocEntry {
+  moduleName: string;
   htmlDescription: string;
   jsdocTags: JsDocTagRenderable[];
 }

--- a/api-gen/rendering/entities/traits.ts
+++ b/api-gen/rendering/entities/traits.ts
@@ -30,3 +30,8 @@ export interface HasMembers {
 export interface HasRenderableMembers {
   members: MemberEntryRenderable[];
 }
+
+/** A doc entry that has an associated JS module name. */
+export interface HasModuleName {
+  moduleName: string;
+}

--- a/api-gen/rendering/processing.ts
+++ b/api-gen/rendering/processing.ts
@@ -1,0 +1,15 @@
+import {DocEntry} from './entities';
+import {isClassEntry} from './entities/categorization';
+import {DocEntryRenderable} from './entities/renderables';
+import {getClassRenderable} from './transforms/class-transforms';
+import {addHtmlDescription, addHtmlJsDocTagComments} from './transforms/jsdoc-transforms';
+import {addModuleName} from './transforms/module-name';
+
+export function getRenderable(entry: DocEntry, moduleName: string): DocEntryRenderable {
+  if (isClassEntry(entry)) {
+    return getClassRenderable(entry, moduleName);
+  }
+
+  // Fallback to an uncategorized renderable.
+  return addHtmlDescription(addHtmlJsDocTagComments(addModuleName(entry, moduleName)));
+}

--- a/api-gen/rendering/rendering.ts
+++ b/api-gen/rendering/rendering.ts
@@ -1,13 +1,11 @@
 import {render} from 'preact-render-to-string';
-import {DocEntry} from './entities';
 import {isClassEntry} from './entities/categorization';
+import {DocEntryRenderable} from './entities/renderables';
 import {ClassReference} from './templates/class-reference';
-import {getClassRenderable} from './transforms/class-transforms';
 
 /** Given a doc entry, get the transformed version of the entry for rendering. */
-export function transformAndRenderEntry(entry: DocEntry): string {
-  if (isClassEntry(entry)) {
-    const renderable = getClassRenderable(entry);
+export function renderEntry(renderable: DocEntryRenderable): string {
+  if (isClassEntry(renderable)) {
     return render(ClassReference(renderable));
   }
 

--- a/api-gen/rendering/test/fake-entries.json
+++ b/api-gen/rendering/test/fake-entries.json
@@ -1,4 +1,5 @@
 {
+  "moduleName": "@angular/core",
   "entries": [
     {
       "name": "NgTemplateOutlet",

--- a/api-gen/rendering/transforms/class-transforms.ts
+++ b/api-gen/rendering/transforms/class-transforms.ts
@@ -2,8 +2,14 @@ import {ClassEntry} from '../entities';
 import {ClassEntryRenderable} from '../entities/renderables';
 import {addHtmlDescription, addHtmlJsDocTagComments} from './jsdoc-transforms';
 import {addRenderableMembers} from './member-transforms';
+import {addModuleName} from './module-name';
 
 /** Given an unprocessed class entry, get the fully renderable class entry. */
-export function getClassRenderable(classEntry: ClassEntry): ClassEntryRenderable {
-  return addRenderableMembers(addHtmlJsDocTagComments(addHtmlDescription(classEntry)));
+export function getClassRenderable(
+  classEntry: ClassEntry,
+  moduleName: string,
+): ClassEntryRenderable {
+  return addRenderableMembers(
+    addHtmlJsDocTagComments(addHtmlDescription(addModuleName(classEntry, moduleName))),
+  );
 }

--- a/api-gen/rendering/transforms/module-name.ts
+++ b/api-gen/rendering/transforms/module-name.ts
@@ -1,0 +1,9 @@
+import {DocEntry} from '../entities';
+import {HasModuleName} from '../entities/traits';
+
+export function addModuleName<T extends DocEntry>(entry: T, moduleName: string): T & HasModuleName {
+  return {
+    ...entry,
+    moduleName,
+  };
+}

--- a/api-gen/test/BUILD.bazel
+++ b/api-gen/test/BUILD.bazel
@@ -3,4 +3,5 @@ load("//api-gen:generate_api_docs.bzl", "generate_api_docs")
 generate_api_docs(
     name = "test",
     srcs = ["//api-gen/extraction/test:source_files"],
+    module_name = "@angular/core",
 )


### PR DESCRIPTION
Based on top of #1399

This commit adds `module_name` as an attribute to extraction, forwarding it along through the rest of the pipeline.

I'm not a huge fan of that way I've plumbed the moduleName through the pipeline here, but the only "clean" alternative I could come up with involved introducing a whole other set of `SomeDocEntry` that have the `moduleName` attached. 