### PR TITLE
feat(api-gen): call getApiDocumentation to produce real output

### DIFF
--- a/api-gen/extraction/extract_api_to_json.bzl
+++ b/api-gen/extraction/extract_api_to_json.bzl
@@ -9,6 +9,9 @@ def _extract_api_to_json(ctx):
     # Pass the module_name for the extracted APIs. This will be something like "@angular/core".
     args.add(ctx.attr.module_name)
 
+    # Pass the entry_point for from which to extract public symbols.
+    args.add(ctx.file.entry_point)
+
     # Pass the set of source files from which API reference data will be extracted.
     args.add_joined(ctx.files.srcs, join_with = ",")
 
@@ -46,6 +49,11 @@ extract_api_to_json = rule(
         ),
         "output_name": attr.output(
             doc = """Name of the JSON output file.""",
+        ),
+        "entry_point": attr.label(
+            doc = """Source file entry-point from which to extract public symbols""",
+            mandatory = True,
+            allow_single_file = True,
         ),
         "module_name": attr.string(
             doc = """JS Module name to be used for the extracted symbols""",

--- a/api-gen/extraction/index.ts
+++ b/api-gen/extraction/index.ts
@@ -3,17 +3,16 @@ import {writeFileSync} from 'fs';
 import {NgtscProgram, CompilerOptions, createCompilerHost} from '@angular/compiler-cli';
 
 function main() {
-  const [moduleName, srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
+  const [moduleName, entryPoint, srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
 
   const compilerOptions: CompilerOptions = {};
   const compilerHost = createCompilerHost({options: compilerOptions});
   const program: NgtscProgram = new NgtscProgram(srcs.split(','), compilerOptions, compilerHost);
-  console.log(`NgtscProgram successfully created: ${!!program}`);
 
-  // TODO: call the real API when it is published to npm.
-  //     When tested with a locally built @angular/compiler-cli, it works!
-  // const output = JSON.stringify(program.getApiDocumentation());
-  const output = JSON.stringify({moduleName: moduleName, entries: []});
+  const output = JSON.stringify({
+    moduleName: moduleName,
+    entries: program.getApiDocumentation(entryPoint),
+  });
 
   writeFileSync(outputFilenameExecRootRelativePath, output, {encoding: 'utf8'});
 }

--- a/api-gen/extraction/test/BUILD.bazel
+++ b/api-gen/extraction/test/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//api-gen:__subpackages__"])
 extract_api_to_json(
     name = "test",
     srcs = ["fake-source.ts"],
+    entry_point = "fake-source.ts",
     module_name = "@angular/core",
     output_name = "api.json",
 )

--- a/api-gen/extraction/test/fake-source.ts
+++ b/api-gen/extraction/test/fake-source.ts
@@ -1,1 +1,4 @@
-export class UserProfile {}
+export class UserProfile {
+  /** The user's name */
+  name: string = 'Morgan';
+}

--- a/api-gen/generate_api_docs.bzl
+++ b/api-gen/generate_api_docs.bzl
@@ -1,13 +1,14 @@
 load("//api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
 load("//api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
 
-def generate_api_docs(name, module_name, srcs):
+def generate_api_docs(name, module_name, entry_point, srcs):
     """Generates API documentation reference pages for the given sources."""
     json_outfile = name + "_api.json"
 
     extract_api_to_json(
         name = name + "_extraction",
         module_name = module_name,
+        entry_point = entry_point,
         srcs = srcs,
         output_name = json_outfile,
         visibility = ["//visibility:private"],

--- a/api-gen/test/BUILD.bazel
+++ b/api-gen/test/BUILD.bazel
@@ -3,5 +3,6 @@ load("//api-gen:generate_api_docs.bzl", "generate_api_docs")
 generate_api_docs(
     name = "test",
     srcs = ["//api-gen/extraction/test:source_files"],
+    entry_point = "//api-gen/extraction/test:fake-source.ts",
     module_name = "@angular/core",
 )


### PR DESCRIPTION
The latest `next` version of `@angular/compiler-cli` includes the new API, so we can now run it for real. This also adds an `entry_point` to the extraction rule, which is expected by the compiler-cli API.