### PR TITLE
refactor(api-gen): adjust visibility and tsconfig for outside consump…

### DIFF
--- a/bazel/api-gen/extraction/BUILD.bazel
+++ b/bazel/api-gen/extraction/BUILD.bazel
@@ -24,6 +24,7 @@ ts_library(
     name = "extract_api_to_json_lib",
     srcs = glob(["**/*.ts"]),
     devmode_module = "commonjs",
+    tsconfig = "//:tsconfig.json",
     deps = [
         "@npm//@angular/compiler",
         "@npm//@angular/compiler-cli",
@@ -46,6 +47,7 @@ nodejs_binary(
     # actions using the linker. An alternative would be to:
     #   - bundle the Angular compiler into a CommonJS bundle
     #   - use the patched resolution- but also patch the ESM imports (similar to how FW does it).
+    visibility = ["//visibility:public"],
 )
 
 # Expose the sources in the dev-infra NPM package.

--- a/bazel/api-gen/generate_api_docs.bzl
+++ b/bazel/api-gen/generate_api_docs.bzl
@@ -10,7 +10,6 @@ def generate_api_docs(name, module_name, srcs):
         module_name = module_name,
         srcs = srcs,
         output_name = json_outfile,
-        visibility = ["//visibility:private"],
     )
 
     render_api_to_html(

--- a/bazel/api-gen/rendering/BUILD.bazel
+++ b/bazel/api-gen/rendering/BUILD.bazel
@@ -10,7 +10,7 @@ ts_library(
         "**/*.tsx",
     ]),
     devmode_module = "commonjs",
-    tsconfig = "//:tsconfig",
+    tsconfig = "//:tsconfig.json",
     deps = [
         "@npm//@bazel/runfiles",
         "@npm//@types/marked",
@@ -35,6 +35,7 @@ nodejs_binary(
         "--bazel_patch_module_resolver",
         "--node_options=--preserve-symlinks-main",
     ],
+    visibility = ["//visibility:public"],
 )
 
 # Expose the sources in the dev-infra NPM package.


### PR DESCRIPTION
…tion

In working on getting these rules working in the framework repo, I found that the rules need:
* To specify `:tsconfig.json` instead of just `:tsconfig` for the packaging substitution to apply
* To make the nodejs_binary targets public.

Changing the `_extraction` target of the macro from private just makes debugging easier.