### PR TITLE
feat(api-gen): add `import_map` attr

### DIFF
--- a/bazel/api-gen/extraction/index.ts
+++ b/bazel/api-gen/extraction/index.ts
@@ -1,12 +1,30 @@
 import {writeFileSync} from 'fs';
+import path from 'path';
 // @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
 import {NgtscProgram, CompilerOptions, createCompilerHost} from '@angular/compiler-cli';
 
 function main() {
-  const [moduleName, entryPointExecRootRelativePath, srcs, outputFilenameExecRootRelativePath] =
-    process.argv.slice(2);
+  const [
+    moduleName,
+    entryPointExecRootRelativePath,
+    srcs,
+    outputFilenameExecRootRelativePath,
+    serializedPathMapWithExecRootRelativePaths,
+  ] = process.argv.slice(2);
 
-  const compilerOptions: CompilerOptions = {};
+  // The path map is a serialized JSON map of import path to index.ts file.
+  // For example, {'@angular/core': 'path/to/some/index.ts'}
+  const pathMap = JSON.parse(serializedPathMapWithExecRootRelativePaths) as Record<string, string>;
+
+  // The tsconfig expects the path map in the form of path -> array of actual locations.
+  // We also resolve the exec root relative paths to absolute paths to disambiguate.
+  const resolvedPathMap: {[key: string]: string[]} = {};
+  for (const [importPath, filePath] of Object.entries(pathMap)) {
+    const importPathWithWildcard = path.join(importPath, '*');
+    resolvedPathMap[importPathWithWildcard] = [path.resolve(path.dirname(filePath))];
+  }
+
+  const compilerOptions: CompilerOptions = {paths: resolvedPathMap};
   const compilerHost = createCompilerHost({options: compilerOptions});
   const program: NgtscProgram = new NgtscProgram(srcs.split(','), compilerOptions, compilerHost);
 

--- a/bazel/api-gen/extraction/test/BUILD.bazel
+++ b/bazel/api-gen/extraction/test/BUILD.bazel
@@ -4,8 +4,14 @@ package(default_visibility = ["//bazel/api-gen:__subpackages__"])
 
 extract_api_to_json(
     name = "test",
-    srcs = ["fake-source.ts"],
+    srcs = [
+        "fake-source.ts",
+        "//bazel/api-gen/extraction/test/dummy-entry-point:dummy_package",
+    ],
     entry_point = "fake-source.ts",
+    import_map = {
+        "//bazel/api-gen/extraction/test/dummy-entry-point:index.ts": "@angular/dummy-package",
+    },
     module_name = "@angular/core",
     output_name = "api.json",
 )

--- a/bazel/api-gen/extraction/test/dummy-entry-point/BUILD.bazel
+++ b/bazel/api-gen/extraction/test/dummy-entry-point/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//bazel/api-gen:__subpackages__"])
+
+filegroup(
+    name = "dummy_package",
+    srcs = ["index.ts"],
+)

--- a/bazel/api-gen/extraction/test/dummy-entry-point/index.ts
+++ b/bazel/api-gen/extraction/test/dummy-entry-point/index.ts
@@ -1,0 +1,5 @@
+export class Version {
+  constructor(public sha: string = '') {}
+}
+
+export const VERSION = new Version('123abc');

--- a/bazel/api-gen/extraction/test/fake-source.ts
+++ b/bazel/api-gen/extraction/test/fake-source.ts
@@ -1,4 +1,12 @@
+// @ts-ignore Intentionally nonexistent path for testing purposes.
+import {Version} from '@angular/dummy-package';
+
 export class UserProfile {
   /** The user's name */
   name: string = 'Morgan';
 }
+
+// By using an implicit type coming from a path-mapped import,
+// we test that the extractor can correctly resolve type information
+// from other packages.
+export const VERSION = new Version('789def');

--- a/bazel/api-gen/generate_api_docs.bzl
+++ b/bazel/api-gen/generate_api_docs.bzl
@@ -1,7 +1,7 @@
 load("//bazel/api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
 load("//bazel/api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
 
-def generate_api_docs(name, module_name, entry_point, srcs):
+def generate_api_docs(name, module_name, entry_point, srcs, import_map = {}):
     """Generates API documentation reference pages for the given sources."""
     json_outfile = name + "_api.json"
 
@@ -11,6 +11,7 @@ def generate_api_docs(name, module_name, entry_point, srcs):
         entry_point = entry_point,
         srcs = srcs,
         output_name = json_outfile,
+        import_map = import_map,
     )
 
     render_api_to_html(

--- a/bazel/api-gen/test/BUILD.bazel
+++ b/bazel/api-gen/test/BUILD.bazel
@@ -4,5 +4,8 @@ generate_api_docs(
     name = "test",
     srcs = ["//bazel/api-gen/extraction/test:source_files"],
     entry_point = "//bazel/api-gen/extraction/test:fake-source.ts",
+    import_map = {
+        "//bazel/api-gen/extraction/test/dummy-entry-point:index.ts": "@angular/dummy-package",
+    },
     module_name = "@angular/core",
 )


### PR DESCRIPTION
Adds an `import_map` attribute to extract_api_to_json in order to enable resolving Angular packages, e.g. `@angular/core`. This is necessary for api extraction in order to fully resolve types when they're based on types in other packages.