### PR TITLE
fix(bazel): api-gen rendering not working in RBE

### DIFF
--- a/bazel/api-gen/rendering/index.ts
+++ b/bazel/api-gen/rendering/index.ts
@@ -1,4 +1,4 @@
-import {readFileSync, writeFileSync} from 'fs';
+import {mkdirSync, readFileSync, writeFileSync} from 'fs';
 import path from 'path';
 import {DocEntry} from './entities';
 import {getRenderable} from './processing';
@@ -28,6 +28,12 @@ function getNormalizedFilename(moduleName: string, entryName: string): string {
 
 function main() {
   const [srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
+
+  // TODO: Remove when we are using Bazel v6+
+  // On RBE, the output directory is not created properly due to a bug.
+  // https://github.com/bazelbuild/bazel/commit/4310aeb36c134e5fc61ed5cdfdf683f3e95f19b7.
+  mkdirSync(outputFilenameExecRootRelativePath, {recursive: true})
+
 
   // Docs rendering happens in three phases that occur here:
   // 1) Aggregate all the raw extracted doc info.


### PR DESCRIPTION
In Bazel v6 a bug in Bazel was fixed to address this. We cannot update though because of `rules_nodejs`. We work around the issue, where the output directory tree artifact not created:

https://github.com/bazelbuild/bazel/commit/4310aeb36c134e5fc61ed5cdfdf683f3e95f19b7