### PR TITLE
fix(bazel): do not error on `types` with wildcard

### DIFF
--- a/bazel/api-golden/find_entry_points.ts
+++ b/bazel/api-golden/find_entry_points.ts
@@ -22,19 +22,19 @@ export function findEntryPointsWithinNpmPackage(
   dirPath: string,
   packageJson: PackageJson,
 ): PackageEntryPoint[] {
-  const entryPoints: PackageEntryPoint[] = [];
-
   // Legacy behavior to support Angular packages without the `exports` field.
   // TODO: Remove when https://github.com/angular/angular-cli/issues/22889 is resolved.
   if (packageJson.exports === undefined) {
     return findEntryPointsThroughNestedPackageFiles(dirPath);
   }
 
-  for (const [subpath, conditions] of Object.entries(packageJson.exports)) {
-    if (conditions.types !== undefined) {
+  const entryPoints: PackageEntryPoint[] = [];
+  for (const [subpath, {types}] of Object.entries(packageJson.exports)) {
+    // Wildcard types mappings are supported.
+    if (types !== undefined && !types.includes('*')) {
       entryPoints.push({
         subpath,
-        typesEntryPointPath: join(dirPath, conditions.types),
+        typesEntryPointPath: join(dirPath, types),
       });
     }
   }

--- a/bazel/api-golden/test/fixtures/test_package/package.json
+++ b/bazel/api-golden/test/fixtures/test_package/package.json
@@ -10,6 +10,9 @@
     },
     "./testing/nested": {
       "types": "./testing/nested.d.ts"
+    },
+    "./testing/wildcard/*": {
+      "types": "./testing/wildcard/*.d.ts"
     }
   }
 }


### PR DESCRIPTION
Currently, when a package export types field contain a wildcard the the api-golden step fails due to unsupported package name. This commit fixes this issue by not considering this as entry-point.

This fix is needed for https://github.com/angular/angular/pull/52080