### PR TITLE
feat(api-gen): add deprecated flag to manifest, filter duplicates

### DIFF
--- a/bazel/api-gen/manifest/BUILD.bazel
+++ b/bazel/api-gen/manifest/BUILD.bazel
@@ -7,12 +7,16 @@ package(default_visibility = ["//bazel/api-gen:__subpackages__"])
 esbuild(
     name = "bin",
     entry_point = ":index.ts",
+    external = [
+        "@angular/compiler-cli",
+    ],
     format = "esm",
     output = "bin.mjs",
     platform = "node",
     target = "es2022",
     deps = [
         ":generate_api_manifest_lib",
+        "@npm//@angular/compiler-cli",
     ],
 )
 
@@ -22,6 +26,7 @@ ts_library(
     devmode_module = "commonjs",
     tsconfig = "//:tsconfig.json",
     deps = [
+        "@npm//@angular/compiler-cli",
         "@npm//@bazel/runfiles",
         "@npm//@types/node",
     ],

--- a/bazel/api-gen/manifest/generate_manifest.ts
+++ b/bazel/api-gen/manifest/generate_manifest.ts
@@ -1,0 +1,75 @@
+// @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
+import type {DocEntry, JsDocTagEntry} from '@angular/compiler-cli';
+
+/** The JSON data file format for extracted API reference info. */
+export interface EntryCollection {
+  moduleName: string;
+  entries: DocEntry[];
+}
+
+export interface ManifestEntry {
+  name: string;
+  type: string;
+  isDeprecated: boolean;
+}
+
+/** Manifest that maps each module name to a list of API symbols. */
+export type Manifest = Record<string, ManifestEntry[]>;
+
+/** Gets a unique lookup key for an API, e.g. "@angular/core/ElementRef". */
+function getApiLookupKey(moduleName: string, name: string) {
+  return `${moduleName}/${name}`;
+}
+
+/** Gets whether the given entry has the "@deprecated" JsDoc tag. */
+function hasDeprecatedTag(entry: DocEntry) {
+  return entry.jsdocTags.some((t: JsDocTagEntry) => t.name === 'deprecated');
+}
+
+/** Gets whether the given entry is deprecated in the manifest. */
+function isDeprecated(
+  lookup: Map<string, DocEntry[]>,
+  moduleName: string,
+  entry: DocEntry,
+): boolean {
+  const entriesWithSameName = lookup.get(getApiLookupKey(moduleName, entry.name));
+
+  // If there are multiple entries with the same name in the same module, only mark them as
+  // deprecated if *all* of the entries with the same name are deprecated (e.g. function overloads).
+  if (entriesWithSameName && entriesWithSameName.length > 1) {
+    return entriesWithSameName.every((entry) => hasDeprecatedTag(entry));
+  }
+
+  return hasDeprecatedTag(entry);
+}
+
+/** Generates an API manifest for a set of API collections extracted by extract_api_to_json.  */
+export function generateManifest(apiCollections: EntryCollection[]): Manifest {
+  // Filter out repeated entries for function overloads, but also keep track of
+  // all symbols keyed to their lookup key. We need this lookup later for determining whether
+  // to mark an entry as deprecated.
+  const entryLookup = new Map<string, DocEntry[]>();
+  for (const collection of apiCollections) {
+    collection.entries = collection.entries.filter((entry) => {
+      const lookupKey = getApiLookupKey(collection.moduleName, entry.name);
+      if (entryLookup.has(lookupKey)) {
+        entryLookup.get(lookupKey)!.push(entry);
+        return false;
+      }
+
+      entryLookup.set(lookupKey, [entry]);
+      return true;
+    });
+  }
+
+  return apiCollections.reduce((result, collection) => {
+    return {
+      ...result,
+      [collection.moduleName]: collection.entries.map((entry) => ({
+        name: entry.name,
+        type: entry.entryType,
+        isDeprecated: isDeprecated(entryLookup, collection.moduleName, entry),
+      })),
+    };
+  }, {});
+}

--- a/bazel/api-gen/manifest/index.ts
+++ b/bazel/api-gen/manifest/index.ts
@@ -1,18 +1,5 @@
 import {readFileSync, writeFileSync} from 'fs';
-
-/** The JSON data file format for extracted API reference info. */
-interface EntryCollection {
-  moduleName: string;
-  entries: {name: string; entryType: string}[];
-}
-
-export interface ManifestEntry {
-  name: string;
-  type: string;
-}
-
-/** Manifest that maps each module name to a list of API symbols. */
-type Manifest = Record<string, ManifestEntry[]>;
+import {EntryCollection, generateManifest} from './generate_manifest';
 
 function main() {
   const [srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
@@ -22,13 +9,7 @@ function main() {
     .map((srcPath) => readFileSync(srcPath, {encoding: 'utf8'}));
   const apiCollections = sourceContents.map((s) => JSON.parse(s) as EntryCollection);
 
-  const manifest: Manifest = apiCollections.reduce((result, collection) => {
-    return {
-      ...result,
-      [collection.moduleName]: collection.entries.map((e) => ({name: e.name, type: e.entryType})),
-    };
-  }, {});
-
+  const manifest = generateManifest(apiCollections);
   writeFileSync(outputFilenameExecRootRelativePath, JSON.stringify(manifest), {encoding: 'utf8'});
 }
 

--- a/bazel/api-gen/manifest/test/BUILD.bazel
+++ b/bazel/api-gen/manifest/test/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//bazel/api-gen/manifest:generate_api_manifest.bzl", "generate_api_manifest")
 load("//bazel/api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
 
 generate_api_manifest(
     name = "test",
@@ -15,4 +16,24 @@ extract_api_to_json(
     entry_point = "another-fake-source.ts",
     module_name = "@angular/router",
     output_name = "api.json",
+)
+
+ts_library(
+    name = "unit_test_lib",
+    testonly = True,
+    srcs = [
+        "manifest.spec.ts",
+    ],
+    deps = [
+        "//bazel/api-gen/manifest:generate_api_manifest_lib",
+        "@npm//@angular/compiler-cli",
+        "@npm//@types/jasmine",
+    ],
+)
+
+jasmine_node_test(
+    name = "unit_tests",
+    data = ["@npm//@angular/compiler-cli"],
+    external = ["@angular/compiler-cli"],
+    specs = [":unit_test_lib"],
 )

--- a/bazel/api-gen/manifest/test/manifest.spec.ts
+++ b/bazel/api-gen/manifest/test/manifest.spec.ts
@@ -1,0 +1,145 @@
+// @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
+import {DocEntry, EntryType, JsDocTagEntry} from '@angular/compiler-cli';
+import {generateManifest} from '../generate_manifest';
+
+describe('api manifest generation', () => {
+  it('should generate a manifest from multiple collections', () => {
+    const manifest = generateManifest([
+      {
+        moduleName: '@angular/core',
+        entries: [entry({name: 'PI', entryType: EntryType.Constant})],
+      },
+      {
+        moduleName: '@angular/router',
+        entries: [entry({name: 'Router', entryType: EntryType.UndecoratedClass})],
+      },
+    ]);
+
+    expect(manifest).toEqual({
+      '@angular/core': [{name: 'PI', type: EntryType.Constant, isDeprecated: false}],
+      '@angular/router': [{name: 'Router', type: EntryType.UndecoratedClass, isDeprecated: false}],
+    });
+  });
+
+  it('should generate a manifest when collections share a symbol with the same name', () => {
+    const manifest = generateManifest([
+      {
+        moduleName: '@angular/core',
+        entries: [entry({name: 'PI', entryType: EntryType.Constant})],
+      },
+      {
+        moduleName: '@angular/router',
+        entries: [entry({name: 'PI', entryType: EntryType.Constant})],
+      },
+    ]);
+
+    expect(manifest).toEqual({
+      '@angular/core': [{name: 'PI', type: EntryType.Constant, isDeprecated: false}],
+      '@angular/router': [{name: 'PI', type: EntryType.Constant, isDeprecated: false}],
+    });
+  });
+
+  it('should mark a manifest entry as deprecated', () => {
+    const manifest = generateManifest([
+      {
+        moduleName: '@angular/core',
+        entries: [
+          entry({name: 'PI', entryType: EntryType.Constant, jsdocTags: jsdocTags('deprecated')}),
+          entry({name: 'XI', entryType: EntryType.Constant, jsdocTags: jsdocTags('experimental')}),
+        ],
+      },
+    ]);
+
+    expect(manifest).toEqual({
+      '@angular/core': [
+        {name: 'PI', type: EntryType.Constant, isDeprecated: true},
+        {name: 'XI', type: EntryType.Constant, isDeprecated: false},
+      ],
+    });
+  });
+
+  it('should deduplicate function overloads', () => {
+    const manifest = generateManifest([
+      {
+        moduleName: '@angular/core',
+        entries: [
+          entry({name: 'save', entryType: EntryType.Function}),
+          entry({name: 'save', entryType: EntryType.Function}),
+        ],
+      },
+    ]);
+
+    expect(manifest).toEqual({
+      '@angular/core': [{name: 'save', type: EntryType.Function, isDeprecated: false}],
+    });
+  });
+
+  it('should not mark a function as deprecated if only one overload is deprecated', () => {
+    const manifest = generateManifest([
+      {
+        moduleName: '@angular/core',
+        entries: [
+          entry({name: 'save', entryType: EntryType.Function}),
+          entry({name: 'save', entryType: EntryType.Function, jsdocTags: jsdocTags('deprecated')}),
+        ],
+      },
+    ]);
+
+    expect(manifest).toEqual({
+      '@angular/core': [{name: 'save', type: EntryType.Function, isDeprecated: false}],
+    });
+  });
+
+  it('should mark a function as deprecated if all overloads are deprecated', () => {
+    const manifest = generateManifest([
+      {
+        moduleName: '@angular/core',
+        entries: [
+          entry({name: 'save', entryType: EntryType.Function, jsdocTags: jsdocTags('deprecated')}),
+          entry({name: 'save', entryType: EntryType.Function, jsdocTags: jsdocTags('deprecated')}),
+        ],
+      },
+    ]);
+
+    expect(manifest).toEqual({
+      '@angular/core': [{name: 'save', type: EntryType.Function, isDeprecated: true}],
+    });
+  });
+
+  it("should mark a fn as deprecated if there's one w/ the same name in another collection", () => {
+    const manifest = generateManifest([
+      {
+        moduleName: '@angular/core',
+        entries: [
+          entry({name: 'save', entryType: EntryType.Function, jsdocTags: jsdocTags('deprecated')}),
+        ],
+      },
+      {
+        moduleName: '@angular/more',
+        entries: [entry({name: 'save', entryType: EntryType.Function})],
+      },
+    ]);
+
+    expect(manifest).toEqual({
+      '@angular/core': [{name: 'save', type: EntryType.Function, isDeprecated: true}],
+      '@angular/more': [{name: 'save', type: EntryType.Function, isDeprecated: false}],
+    });
+  });
+});
+
+/** Creates a fake DocsEntry with the given object's fields patches onto the result. */
+function entry(patch: Partial<DocEntry>): DocEntry {
+  return {
+    name: '',
+    description: '',
+    entryType: EntryType.Constant,
+    jsdocTags: [],
+    rawComment: '',
+    ...patch,
+  };
+}
+
+/** Creates a fake jsdoc tag entry list that contains a tag with the given name */
+function jsdocTags(name: string): JsDocTagEntry[] {
+  return [{name, comment: ''}];
+}


### PR DESCRIPTION
Some symbol names appear more than once in the case of function overloads; this commit filters these duplicate entries and additionally adds a deprecated flag to the results.