### PR TITLE
build: update yarn install command to work with yarn 4.

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -27,7 +27,7 @@ jobs:
             .github/ng-renovate/.yarn/cache
             /tmp/renovate
           key: v2-renovate-${{hashFiles('.github/ng-renovate/yarn.lock')}}-${{ steps.date.outputs.date }}
-      - run: yarn install --immutable --cwd .github/ng-renovate
+      - run: yarn --cwd .github/ng-renovate install --immutable
         shell: bash
 
       # Note: Run Renovate outside of Yarn as otherwise we would end up breaking Yarn path


### PR DESCRIPTION
The `ng-renovate` workflow is currently broken because one of the breaking changes in version 4 is that `--cwd` need to be supplied as the very first option.

See:  https://github.com/yarnpkg/berry/commit/981d5bbbff6ae228825480f699071a10f3522964