### PR TITLE
fix(api-gen): decorators aren't classes

### DIFF
--- a/bazel/api-gen/rendering/entities/categorization.ts
+++ b/bazel/api-gen/rendering/entities/categorization.ts
@@ -23,7 +23,6 @@ export function isClassEntry(entry: DocEntry): entry is ClassEntry {
   return (
     entry.entryType === EntryType.UndecoratedClass ||
     entry.entryType === EntryType.Component ||
-    entry.entryType === EntryType.Decorator ||
     entry.entryType === EntryType.Pipe ||
     entry.entryType === EntryType.NgModule
   );


### PR DESCRIPTION
Removes decorator doc entries from being classified as classes since they don't have members.