### PR TITLE
refactor(api-gen): use param files for all rules

### DIFF
--- a/bazel/api-gen/extraction/extract_api_to_json.bzl
+++ b/bazel/api-gen/extraction/extract_api_to_json.bzl
@@ -6,6 +6,10 @@ def _extract_api_to_json(ctx):
     # Define arguments that will be passed to the underlying nodejs program.
     args = ctx.actions.args()
 
+    # Use a param file because we may have a large number of inputs.
+    args.set_param_file_format("multiline")
+    args.use_param_file("%s", use_always = True)
+
     # Pass the module_name for the extracted APIs. This will be something like "@angular/core".
     args.add(ctx.attr.module_name)
 

--- a/bazel/api-gen/extraction/index.ts
+++ b/bazel/api-gen/extraction/index.ts
@@ -1,16 +1,19 @@
-import {writeFileSync} from 'fs';
+import {readFileSync, writeFileSync} from 'fs';
 import path from 'path';
 // @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
 import {NgtscProgram, CompilerOptions, createCompilerHost} from '@angular/compiler-cli';
 
 function main() {
+  const [paramFilePath] = process.argv.slice(2);
+  const rawParamLines = readFileSync(paramFilePath, {encoding: 'utf8'}).split('\n');
+
   const [
     moduleName,
     entryPointExecRootRelativePath,
     srcs,
     outputFilenameExecRootRelativePath,
     serializedPathMapWithExecRootRelativePaths,
-  ] = process.argv.slice(2);
+  ] = rawParamLines;
 
   // The path map is a serialized JSON map of import path to index.ts file.
   // For example, {'@angular/core': 'path/to/some/index.ts'}

--- a/bazel/api-gen/manifest/generate_api_manifest.bzl
+++ b/bazel/api-gen/manifest/generate_api_manifest.bzl
@@ -6,6 +6,10 @@ def _generate_api_manifest(ctx):
     # Define arguments that will be passed to the underlying nodejs program.
     args = ctx.actions.args()
 
+    # Use a param file because we may have a large number of json inputs.
+    args.set_param_file_format("multiline")
+    args.use_param_file("%s", use_always = True)
+
     # Pass the set of JSON data files from which the API manifest will be generated.
     args.add_joined(ctx.files.srcs, join_with = ",")
 

--- a/bazel/api-gen/manifest/index.ts
+++ b/bazel/api-gen/manifest/index.ts
@@ -2,7 +2,9 @@ import {readFileSync, writeFileSync} from 'fs';
 import {EntryCollection, generateManifest} from './generate_manifest';
 
 function main() {
-  const [srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
+  const [paramFilePath] = process.argv.slice(2);
+  const rawParamLines = readFileSync(paramFilePath, {encoding: 'utf8'}).split('\n');
+  const [srcs, outputFilenameExecRootRelativePath] = rawParamLines;
 
   const sourceContents = srcs
     .split(',')

--- a/bazel/api-gen/rendering/index.ts
+++ b/bazel/api-gen/rendering/index.ts
@@ -27,13 +27,15 @@ function getNormalizedFilename(moduleName: string, entryName: string): string {
 }
 
 function main() {
-  const [srcs, outputFilenameExecRootRelativePath] = process.argv.slice(2);
+  const [paramFilePath] = process.argv.slice(2);
+  const rawParamLines = readFileSync(paramFilePath, {encoding: 'utf8'}).split('\n');
+
+  const [srcs, outputFilenameExecRootRelativePath] = rawParamLines;
 
   // TODO: Remove when we are using Bazel v6+
   // On RBE, the output directory is not created properly due to a bug.
   // https://github.com/bazelbuild/bazel/commit/4310aeb36c134e5fc61ed5cdfdf683f3e95f19b7.
-  mkdirSync(outputFilenameExecRootRelativePath, {recursive: true})
-
+  mkdirSync(outputFilenameExecRootRelativePath, {recursive: true});
 
   // Docs rendering happens in three phases that occur here:
   // 1) Aggregate all the raw extracted doc info.

--- a/bazel/api-gen/rendering/render_api_to_html.bzl
+++ b/bazel/api-gen/rendering/render_api_to_html.bzl
@@ -4,6 +4,10 @@ def _render_api_to_html(ctx):
     # Define arguments that will be passed to the underlying nodejs program.
     args = ctx.actions.args()
 
+    # Use a param file because we may have a large number of json inputs
+    args.set_param_file_format("multiline")
+    args.use_param_file("%s", use_always = True)
+
     # Pass the list of json data files from which documents will be generated.
     args.add_joined(ctx.files.srcs, join_with = ",")
 


### PR DESCRIPTION
Some the the rules are bordering the limit of command line args, so this moves them all to params files.