### PR TITLE
fix(api-gen): support multiple collections for one module in manifest

### DIFF
--- a/bazel/api-gen/manifest/generate_manifest.ts
+++ b/bazel/api-gen/manifest/generate_manifest.ts
@@ -62,14 +62,20 @@ export function generateManifest(apiCollections: EntryCollection[]): Manifest {
     });
   }
 
-  return apiCollections.reduce((result, collection) => {
-    return {
-      ...result,
-      [collection.moduleName]: collection.entries.map((entry) => ({
+  const manifest: Manifest = {};
+  for (const collection of apiCollections) {
+    if (!manifest[collection.moduleName]) {
+      manifest[collection.moduleName] = [];
+    }
+
+    manifest[collection.moduleName].push(
+      ...collection.entries.map((entry) => ({
         name: entry.name,
         type: entry.entryType,
         isDeprecated: isDeprecated(entryLookup, collection.moduleName, entry),
       })),
-    };
-  }, {});
+    );
+  }
+
+  return manifest;
 }

--- a/bazel/api-gen/manifest/test/manifest.spec.ts
+++ b/bazel/api-gen/manifest/test/manifest.spec.ts
@@ -39,6 +39,26 @@ describe('api manifest generation', () => {
     });
   });
 
+  it('should union collections for the same module into one manifest', () => {
+    const manifest = generateManifest([
+      {
+        moduleName: '@angular/core',
+        entries: [entry({name: 'PI', entryType: EntryType.Constant})],
+      },
+      {
+        moduleName: '@angular/core',
+        entries: [entry({name: 'TAO', entryType: EntryType.Constant})],
+      },
+    ]);
+
+    expect(manifest).toEqual({
+      '@angular/core': [
+        {name: 'PI', type: EntryType.Constant, isDeprecated: false},
+        {name: 'TAO', type: EntryType.Constant, isDeprecated: false},
+      ],
+    });
+  });
+
   it('should mark a manifest entry as deprecated', () => {
     const manifest = generateManifest([
       {


### PR DESCRIPTION
Currently the manifest generation assumes each module has exactly one API collection. This change makes it so that a module may be split up into multiple collections, all of which will be unioned together into the manifest. The impetus for this change is adding hand-written collections for Angular element and block APIs.