### PR TITLE
feat(api-gen): accept extra entries for extraction

### DIFF
--- a/bazel/api-gen/extraction/extract_api_to_json.bzl
+++ b/bazel/api-gen/extraction/extract_api_to_json.bzl
@@ -35,11 +35,14 @@ def _extract_api_to_json(ctx):
         path_map[path] = files[0].path
     args.add(json.encode(path_map))
 
+    # Pass the set of (optional) extra entries
+    args.add_joined(ctx.files.extra_entries, join_with = ",")
+
     # Define an action that runs the nodejs_binary executable. This is
     # the main thing that this rule does.
     run_node(
         ctx = ctx,
-        inputs = depset(ctx.files.srcs),
+        inputs = depset(ctx.files.srcs + ctx.files.extra_entries),
         executable = "_extract_api_to_json",
         outputs = [json_output],
         arguments = [args],
@@ -78,6 +81,10 @@ extract_api_to_json = rule(
         "module_name": attr.string(
             doc = """JS Module name to be used for the extracted symbols""",
             mandatory = True,
+        ),
+        "extra_entries": attr.label_list(
+            doc = """JSON files that contain extra entries to append to the final collection.""",
+            allow_files = True,
         ),
 
         # The executable for this rule (private).

--- a/bazel/api-gen/extraction/test/BUILD.bazel
+++ b/bazel/api-gen/extraction/test/BUILD.bazel
@@ -16,6 +16,23 @@ extract_api_to_json(
     output_name = "api.json",
 )
 
+extract_api_to_json(
+    name = "test_with_extra_entries",
+    srcs = [
+        "fake-source.ts",
+        "//bazel/api-gen/extraction/test/dummy-entry-point:dummy_package",
+    ],
+    entry_point = "fake-source.ts",
+    extra_entries = [
+        "extra.json",
+    ],
+    import_map = {
+        "//bazel/api-gen/extraction/test/dummy-entry-point:index.ts": "@angular/dummy-package",
+    },
+    module_name = "@angular/core",
+    output_name = "extra_api.json",
+)
+
 filegroup(
     name = "source_files",
     srcs = ["fake-source.ts"],

--- a/bazel/api-gen/extraction/test/extra.json
+++ b/bazel/api-gen/extraction/test/extra.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "@extra",
+    "entryType": "block",
+    "description": "## This is the content of the file\n",
+    "rawComment": "## This is the content of the file\n",
+    "jsdocTags": []
+  }
+]

--- a/bazel/api-gen/generate_api_docs.bzl
+++ b/bazel/api-gen/generate_api_docs.bzl
@@ -1,7 +1,7 @@
 load("//bazel/api-gen/extraction:extract_api_to_json.bzl", "extract_api_to_json")
 load("//bazel/api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
 
-def generate_api_docs(name, module_name, entry_point, srcs, import_map = {}):
+def generate_api_docs(name, module_name, entry_point, srcs, import_map = {}, extra_entries = []):
     """Generates API documentation reference pages for the given sources."""
     json_outfile = name + "_api.json"
 
@@ -12,6 +12,7 @@ def generate_api_docs(name, module_name, entry_point, srcs, import_map = {}):
         srcs = srcs,
         output_name = json_outfile,
         import_map = import_map,
+        extra_entries = extra_entries,
     )
 
     render_api_to_html(

--- a/bazel/api-gen/test/BUILD.bazel
+++ b/bazel/api-gen/test/BUILD.bazel
@@ -9,3 +9,14 @@ generate_api_docs(
     },
     module_name = "@angular/core",
 )
+
+generate_api_docs(
+    name = "test_with_extra_entries",
+    srcs = ["//bazel/api-gen/extraction/test:source_files"],
+    entry_point = "//bazel/api-gen/extraction/test:fake-source.ts",
+    extra_entries = ["//bazel/api-gen/extraction/test:extra.json"],
+    import_map = {
+        "//bazel/api-gen/extraction/test/dummy-entry-point:index.ts": "@angular/dummy-package",
+    },
+    module_name = "@angular/core",
+)


### PR DESCRIPTION
This will be used by the framework to specify elements and blocks, which are not extracted directly from source.