### PR TITLE
feat(markdown-to-html): add skeleton for marked rendering

### DIFF
--- a/.ng-dev/commit-message.mts
+++ b/.ng-dev/commit-message.mts
@@ -44,8 +44,9 @@ export const commitMessage: CommitMessageConfig = {
     ]),
     ...buildScopesFor('api-gen', []),
     ...buildScopesFor('apps', []),
-    ...buildScopesFor('lint-rules', ['tslint', 'stylelint']),
-    ...buildScopesFor('shared-scripts', []),
     ...buildScopesFor('circleci-orb', []),
+    ...buildScopesFor('lint-rules', ['tslint', 'stylelint']),
+    ...buildScopesFor('markdown-to-html', []),
+    ...buildScopesFor('shared-scripts', []),
   ],
 };

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -18,6 +18,7 @@ filegroup(
         "//bazel/integration:files",
         "//bazel/karma:files",
         "//bazel/map-size-tracking:files",
+        "//bazel/markdown_to_html:files",
         "//bazel/private:files",
         "//bazel/remote-execution:files",
         "//bazel/spec-bundling:files",

--- a/bazel/markdown_to_html/BUILD.bazel
+++ b/bazel/markdown_to_html/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+load("//bazel/esbuild:index.bzl", "esbuild_esm_bundle")
+
+package(default_visibility = ["//bazel/markdown_to_html:__subpackages__"])
+
+esbuild_esm_bundle(
+    name = "bin",
+    entry_point = ":index.ts",
+    external = [
+        "marked",
+    ],
+    output = "bin.mjs",
+    platform = "node",
+    target = "es2022",
+    deps = [
+        ":markdown_to_html_lib",
+    ],
+)
+
+ts_library(
+    name = "markdown_to_html_lib",
+    srcs = glob(["**/*.ts"]),
+    devmode_module = "commonjs",
+    tsconfig = "//:tsconfig.json",
+    deps = [
+        "@npm//@bazel/runfiles",
+        "@npm//@types/node",
+        "@npm//marked",
+    ],
+)
+
+# Action binary for the api_gen bazel rule.
+nodejs_binary(
+    name = "markdown_to_html",
+    data = [
+        ":bin",
+        "@npm//marked",
+    ],
+    entry_point = "bin.mjs",
+    # Note: Using the linker here as we need it for ESM. The linker is not
+    # super reliably when running concurrently on Windows- but we have existing
+    # actions using the linker. An alternative would be to:
+    #   - bundle the Angular compiler into a CommonJS bundle
+    #   - use the patched resolution- but also patch the ESM imports (similar to how FW does it).
+    visibility = ["//visibility:public"],
+)
+
+# Expose the sources in the dev-infra NPM package.
+filegroup(
+    name = "files",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)

--- a/bazel/markdown_to_html/index.ts
+++ b/bazel/markdown_to_html/index.ts
@@ -1,0 +1,21 @@
+import {readFileSync, writeFileSync} from 'fs';
+import {markdownFilenameToHtmlFilename, markdownToHtml} from './markdown_to_html';
+import path from 'path';
+
+function main() {
+  const [paramFilePath] = process.argv.slice(2);
+  const rawParamLines = readFileSync(paramFilePath, {encoding: 'utf8'}).split('\n');
+  const [srcs, outputFilenameExecRootRelativePath] = rawParamLines;
+
+  for (const markdownSourcePath of srcs.split(',')) {
+    const markdownContent = readFileSync(markdownSourcePath, {encoding: 'utf8'});
+    const htmlOutputContent = markdownToHtml(markdownContent);
+
+    const htmlFileName = markdownFilenameToHtmlFilename(markdownSourcePath);
+    const htmlOutputPath = path.join(outputFilenameExecRootRelativePath, htmlFileName);
+
+    writeFileSync(htmlOutputPath, htmlOutputContent, {encoding: 'utf8'});
+  }
+}
+
+main();

--- a/bazel/markdown_to_html/markdown_to_html.bzl
+++ b/bazel/markdown_to_html/markdown_to_html.bzl
@@ -1,0 +1,67 @@
+load("@build_bazel_rules_nodejs//:providers.bzl", "run_node")
+load("//bazel/private:path_relative_to_label.bzl", "path_relative_to_label")
+
+def _markdown_to_html(ctx):
+    """Implementation of the markdown_to_html rule"""
+
+    # Define arguments that will be passed to the underlying nodejs program.
+    args = ctx.actions.args()
+
+    # Use a param file because we may have a large number of inputs.
+    args.set_param_file_format("multiline")
+    args.use_param_file("%s", use_always = True)
+
+    # Pass the set of source files.
+    args.add_joined(ctx.files.srcs, join_with = ",")
+
+    # Pass the the output directory path (which is the bazel-bin directory).
+    args.add(ctx.bin_dir.path)
+
+    # Determine the set of html output files. For each input markdown file, produce an html
+    # file with the same name (replacing the markdown extension with `.html`).
+    html_outputs = []
+    for input_file in ctx.files.srcs:
+        # Determine the input file path relatively to the current package path. We do this
+        # because we want to preserve directories for the input files and `declare_file` expects a
+        # path that is relative to the current package. We don't use `.replace`
+        # here because the extension can be also in upper case.
+        relative_basepath = path_relative_to_label(ctx.label, input_file.short_path)[:-len(".md")]
+
+        # For each input file "xxx.md", we want to write an output file "xxx.html"
+        html_outputs += [ctx.actions.declare_file("%s.html" % relative_basepath)]
+
+    # Define an action that runs the nodejs_binary executable. This is
+    # the main thing that this rule does.
+    run_node(
+        ctx = ctx,
+        inputs = depset(ctx.files.srcs),
+        executable = "_markdown_to_html",
+        outputs = html_outputs,
+        arguments = [args],
+    )
+
+    # The return value describes what the rule is producing. In this case we need to specify
+    # the "DefaultInfo" with the output html files.
+    return [DefaultInfo(files = depset(html_outputs))]
+
+markdown_to_html = rule(
+    # Point to the starlark function that will execute for this rule.
+    implementation = _markdown_to_html,
+    doc = """Rule that renders markdown sources to html""",
+
+    # The attributes that can be set to this rule.
+    attrs = {
+        "srcs": attr.label_list(
+            doc = """Markdown sources to render to html.""",
+            allow_empty = False,
+            allow_files = True,
+        ),
+
+        # The executable for this rule (private).
+        "_markdown_to_html": attr.label(
+            default = Label("//bazel/markdown_to_html"),
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/bazel/markdown_to_html/markdown_to_html.ts
+++ b/bazel/markdown_to_html/markdown_to_html.ts
@@ -1,0 +1,15 @@
+import {marked} from 'marked';
+
+/** Given the file name of a markdown file, return the corresponding html file name.  */
+export function markdownFilenameToHtmlFilename(fileName: string): string {
+  if (!fileName.toLowerCase().endsWith('.md')) {
+    throw new Error(`Input file "${fileName}" does not end in a ".md" file extension.`);
+  }
+
+  return fileName.substring(0, fileName.length - '.md'.length) + '.html';
+}
+
+/** Renders markdown to html with additional Angular-specific extensions. */
+export function markdownToHtml(markdownSource: string): string {
+  return marked.parse(markdownSource);
+}

--- a/bazel/markdown_to_html/test/BUILD.bazel
+++ b/bazel/markdown_to_html/test/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
+load("//bazel/markdown_to_html:markdown_to_html.bzl", "markdown_to_html")
+
+markdown_to_html(
+    name = "test",
+    srcs = ["fake-markdown-source.md"],
+)
+
+ts_library(
+    name = "unit_test_lib",
+    testonly = True,
+    srcs = [
+        "markdown_to_html.spec.ts",
+    ],
+    deps = [
+        "//bazel/markdown_to_html:markdown_to_html_lib",
+        "@npm//@types/jasmine",
+        "@npm//marked",
+    ],
+)
+
+jasmine_node_test(
+    name = "unit_tests",
+    data = ["@npm//marked"],
+    external = ["marked"],
+    specs = [":unit_test_lib"],
+)

--- a/bazel/markdown_to_html/test/fake-markdown-source.md
+++ b/bazel/markdown_to_html/test/fake-markdown-source.md
@@ -1,0 +1,3 @@
+# Hello
+
+**I am a test source**

--- a/bazel/markdown_to_html/test/markdown_to_html.spec.ts
+++ b/bazel/markdown_to_html/test/markdown_to_html.spec.ts
@@ -1,0 +1,8 @@
+import {markdownToHtml} from '../markdown_to_html';
+
+describe('markdown to html', () => {
+  it('should transform standard markdown to html', () => {
+    const markdown = `**important**`;
+    expect(markdownToHtml(markdown)).toContain('<strong>important</strong>');
+  });
+});

--- a/bazel/private/path_relative_to_label.bzl
+++ b/bazel/private/path_relative_to_label.bzl
@@ -1,0 +1,7 @@
+def path_relative_to_label(label, short_path):
+    """
+      Gets a path relative to the specified label. This is achieved by just removing the label
+      package path from the specified path. e.g. the path is "guides/test/my-text.md" and the
+      label package is "guides/". The expected path would be "test/my-text.md".
+    """
+    return short_path[len(label.package) + 1:]


### PR DESCRIPTION
This commit adds a simple skeleton bazel rule and tests for rendering markdown to html with marked.