### PR TITLE
refactor(bazel): remove ESM bundling for markdown to HTML

### DIFF
--- a/.ng-dev/commit-message.mts
+++ b/.ng-dev/commit-message.mts
@@ -20,6 +20,7 @@ export const commitMessage: CommitMessageConfig = {
       'integration',
       'karma',
       'map-size-tracking',
+      'markdown-to-html',
       'protos',
       'remote-execution',
       'spec-bundling',
@@ -46,7 +47,6 @@ export const commitMessage: CommitMessageConfig = {
     ...buildScopesFor('apps', []),
     ...buildScopesFor('circleci-orb', []),
     ...buildScopesFor('lint-rules', ['tslint', 'stylelint']),
-    ...buildScopesFor('markdown-to-html', []),
     ...buildScopesFor('shared-scripts', []),
   ],
 };

--- a/bazel/markdown_to_html/BUILD.bazel
+++ b/bazel/markdown_to_html/BUILD.bazel
@@ -1,22 +1,7 @@
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-load("//bazel/esbuild:index.bzl", "esbuild_esm_bundle")
+load("@npm//@bazel/concatjs:index.bzl", "ts_library")
 
 package(default_visibility = ["//bazel/markdown_to_html:__subpackages__"])
-
-esbuild_esm_bundle(
-    name = "bin",
-    entry_point = ":index.ts",
-    external = [
-        "marked",
-    ],
-    output = "bin.mjs",
-    platform = "node",
-    target = "es2022",
-    deps = [
-        ":markdown_to_html_lib",
-    ],
-)
 
 ts_library(
     name = "markdown_to_html_lib",
@@ -33,16 +18,11 @@ ts_library(
 # Action binary for the api_gen bazel rule.
 nodejs_binary(
     name = "markdown_to_html",
-    data = [
-        ":bin",
-        "@npm//marked",
+    data = [":markdown_to_html_lib"],
+    entry_point = ":index.ts",
+    templated_args = [
+        "--bazel_patch_module_resolver",
     ],
-    entry_point = "bin.mjs",
-    # Note: Using the linker here as we need it for ESM. The linker is not
-    # super reliably when running concurrently on Windows- but we have existing
-    # actions using the linker. An alternative would be to:
-    #   - bundle the Angular compiler into a CommonJS bundle
-    #   - use the patched resolution- but also patch the ESM imports (similar to how FW does it).
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
follow up fixes to the markdown to html PR.