### PR TITLE
build: update dependency build_bazel_rules_nodejs to v5.8.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,8 +28,8 @@ http_archive(
 # Fetch rules_nodejs and install its dependencies so we can install our npm dependencies.
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "5dd1e5dea1322174c57d3ca7b899da381d516220793d0adef3ba03b9d23baa8e",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/v6.0.2/rules_nodejs-5.8.3.tar.gz"],
+    sha256 = "709cc0dcb51cf9028dd57c268066e5bc8f03a119ded410a13b5c3925d6e43c48",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.4/rules_nodejs-5.8.4.tar.gz"],
 )
 
 load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_dependencies")


### PR DESCRIPTION
Update dependency for build_bazel_rules_nodejs