### PR TITLE
feat(ng-dev): support enforcing certain checks to be running

### DIFF
--- a/.ng-dev/pull-request.mts
+++ b/.ng-dev/pull-request.mts
@@ -3,9 +3,7 @@ import {PullRequestConfig} from '../ng-dev/pr/config/index.js';
 /** Configuration for interacting with pull requests in the repo. */
 export const pullRequest: PullRequestConfig = {
   githubApiMerge: false,
-  mergeReadyLabel: 'action: merge',
-  caretakerNoteLabel: 'merge note',
-  commitMessageFixupLabel: 'needs commit fixup',
+  requiredStatuses: [{name: 'test', type: 'check'}],
 
   // Disable target labeling in the dev-infra repo as we don't have
   // any release trains and version branches.

--- a/ng-dev/pr/common/validation/assert-enforced-statuses.ts
+++ b/ng-dev/pr/common/validation/assert-enforced-statuses.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {PullRequestConfig} from '../../config/index.js';
+import {getStatusesForPullRequest, PullRequestFromGithub} from '../fetch-pull-request.js';
+import {createPullRequestValidation, PullRequestValidation} from './validation-config.js';
+
+/** Assert the pull request has passing enforced statuses. */
+// TODO: update typings to make sure portability is properly handled for windows build.
+export const enforcedStatusesValidation = createPullRequestValidation(
+  {name: 'assertEnforcedStatuses', canBeForceIgnored: true},
+  () => Validation,
+);
+
+class Validation extends PullRequestValidation {
+  assert(pullRequest: PullRequestFromGithub, config: PullRequestConfig) {
+    if (config.requiredStatuses === undefined) {
+      return;
+    }
+
+    const {statuses} = getStatusesForPullRequest(pullRequest);
+    const missing: string[] = [];
+
+    for (const enforced of config.requiredStatuses) {
+      if (!statuses.some((s) => s.name === enforced.name && s.type === enforced.name)) {
+        missing.push(enforced.name);
+      }
+    }
+
+    if (missing.length > 0) {
+      throw this._createError(
+        `Required statuses are missing on the pull request (${missing.join(', ')}).`,
+      );
+    }
+  }
+}

--- a/ng-dev/pr/common/validation/validate-pull-request.ts
+++ b/ng-dev/pr/common/validation/validate-pull-request.ts
@@ -15,6 +15,7 @@ import {PullRequestTarget} from '../targeting/target-label.js';
 import {changesAllowForTargetLabelValidation} from './assert-allowed-target-label.js';
 import {breakingChangeInfoValidation} from './assert-breaking-change-info.js';
 import {completedReviewsValidation} from './assert-completed-reviews.js';
+import {enforcedStatusesValidation} from './assert-enforced-statuses.js';
 import {mergeReadyValidation} from './assert-merge-ready.js';
 import {passingCiValidation} from './assert-passing-ci.js';
 import {pendingStateValidation} from './assert-pending.js';
@@ -47,6 +48,7 @@ export async function assertValidPullRequest(
     pendingStateValidation.run(validationConfig, pullRequest),
     breakingChangeInfoValidation.run(validationConfig, commitsInPr, labels),
     passingCiValidation.run(validationConfig, pullRequest),
+    enforcedStatusesValidation.run(validationConfig, pullRequest, ngDevConfig.pullRequest),
   ];
 
   if (activeReleaseTrains !== null) {

--- a/ng-dev/pr/common/validation/validation-config.ts
+++ b/ng-dev/pr/common/validation/validation-config.ts
@@ -19,6 +19,7 @@ export class PullRequestValidationConfig {
   assertChangesAllowForTargetLabel = true;
   assertPassingCi = true;
   assertCompletedReviews = true;
+  assertEnforcedStatuses = true;
 
   static create(config: Partial<PullRequestValidationConfig>) {
     return Object.assign(new PullRequestValidationConfig(), config);

--- a/ng-dev/pr/config/index.ts
+++ b/ng-dev/pr/config/index.ts
@@ -30,8 +30,13 @@ export interface PullRequestConfig {
    * defaults are provided by the common dev-infra github configuration.
    */
   remote?: GithubConfig;
+
   /** Required base commits for given branches. */
   requiredBaseCommits?: {[branchName: string]: string};
+
+  /** List of statuses that are required before a pull request can be merged. */
+  requiredStatuses?: {type: 'check' | 'status'; name: string}[];
+
   /**
    * Whether pull requests should be merged using the Github API. This can be enabled
    * if projects want to have their pull requests show up as `Merged` in the Github UI.
@@ -39,6 +44,7 @@ export interface PullRequestConfig {
    * not support this.
    */
   githubApiMerge: false | GithubApiMergeStrategyConfig;
+
   /**
    * List of commit scopes which are exempted from target label content requirements. i.e. no `feat`
    * scopes in patch branches, no breaking changes in minor or patch changes.


### PR DESCRIPTION
This can be used in the future to enforce the unified status check, or to enforce additional thing. Right now it can be used to enforce some checks that aren't guaranteed to run otherwise.

In the future we may remove the configuration option and always default to the unified status check. This is the goundwork for future changes.