### PR TITLE
fix(ng-dev): recognize empty cherry-picks that should result in an error

### DIFF
--- a/ng-dev/pr/merge/failures.ts
+++ b/ng-dev/pr/merge/failures.ts
@@ -40,7 +40,7 @@ export class UnsatisfiedBaseShaFatalError extends FatalMergeToolError {
 export class MergeConflictsFatalError extends FatalMergeToolError {
   constructor(public failedBranches: string[]) {
     super(
-      `Could not merge pull request into the following branches due to merge ` +
+      `Cannot not merge pull request into the following branches due to merge ` +
         `conflicts: ${failedBranches.join(', ')}. Please rebase the PR or update the target label.`,
     );
   }


### PR DESCRIPTION
Recognize empty cherry-picks that should result in an error, when
merging. This indicates that such PRs are obsolete.

To fix this, there are two things going on:

- The `cherry-pick` `--no-commit` flag when checking for mergability
  ended up hiding the error that changes are already applied.
- The failure branches in the autosquash branch, in the second iteration
  of cherry-picking (the non-dry run execution), we did not catch
  potential errors that weren't surfacing in dry-run execution- causing
  us to post a comment like `This PR was merged into bla`.