### PR TITLE
fix: branch manager breaking due to no git identity

### DIFF
--- a/.github/local-actions/branch-manager/lib/main.ts
+++ b/.github/local-actions/branch-manager/lib/main.ts
@@ -68,6 +68,10 @@ async function main(repo: {owner: string; repo: string}, token: string, pr: numb
   /** The git client used to perform actions. */
   const git = await AuthenticatedGitClient.get();
 
+  // Needed for testing the merge-ability via `git cherry-pick` in the merge strategy.
+  git.run(['config', 'user.email', 'angular-robot@google.com']);
+  git.run(['config', 'user.name', 'Angular Robot']);
+
   /** The pull request after being retrieved and validated. */
   const pullRequest = await loadAndValidatePullRequest(
     {git, config},

--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -78343,6 +78343,8 @@ async function main(repo2, token2, pr2) {
   const config = await getConfig([assertValidGithubConfig, assertValidPullRequestConfig]);
   AuthenticatedGitClient.configure(token2);
   const git = await AuthenticatedGitClient.get();
+  git.run(["config", "user.email", "angular-robot@google.com"]);
+  git.run(["config", "user.name", "Angular Robot"]);
   const pullRequest = await loadAndValidatePullRequest({ git, config }, pr2, PullRequestValidationConfig.create({
     assertPending: false,
     assertCompletedReviews: false


### PR DESCRIPTION
The merge strategy now performs a real cherry pick but Git fails because there is no identity configured in Git.