### PR TITLE
fix(bazel/markdown-to-html): set jsdom as external

### DIFF
--- a/bazel/markdown_to_html/BUILD.bazel
+++ b/bazel/markdown_to_html/BUILD.bazel
@@ -17,6 +17,8 @@ ts_library(
 esbuild_esm_bundle(
     name = "markdown_to_html_bundle",
     entry_point = ":index.ts",
+    # JSDOM should not be bundled because it has workers and dynamic imports.
+    external = ["jsdom"],
     output = "bin.mjs",
     platform = "node",
     target = "es2022",


### PR DESCRIPTION
Set jsdom as external since it uses workers and dynamic imports