### PR TITLE
fix(bazel/markdown-to-html): properly expand range strings

### DIFF
--- a/bazel/markdown_to_html/src/extensions/docs-code/format/highlight.ts
+++ b/bazel/markdown_to_html/src/extensions/docs-code/format/highlight.ts
@@ -1,7 +1,7 @@
 import {decode} from 'html-entities';
 import highlightJs from 'highlight.js';
 import {CodeToken} from '.';
-import {parseRangeString} from './range';
+import {expandRangeStringValues} from './range';
 import {JSDOM} from 'jsdom';
 
 const lineNumberClassName: string = 'hljs-ln-number';
@@ -33,7 +33,7 @@ export function highlightCode(token: CodeToken) {
   let lineIndex = 0;
   let resultFileLineIndex = 1;
 
-  const highlightedLineRanges = token.highlight ? parseRangeString(token.highlight) : [];
+  const highlightedLineRanges = token.highlight ? expandRangeStringValues(token.highlight) : [];
 
   const containerEl = new JSDOM().window.document.body;
 

--- a/bazel/markdown_to_html/src/extensions/docs-code/format/index.ts
+++ b/bazel/markdown_to_html/src/extensions/docs-code/format/index.ts
@@ -3,6 +3,7 @@ import {DiffMetadata, calculateDiff} from './diff';
 import {highlightCode} from './highlight';
 import {extractRegions} from './region';
 import {JSDOM} from 'jsdom';
+import {expandRangeStringValues} from './range';
 
 /** Marked token for a custom docs element. */
 export interface CodeToken extends Tokens.Generic {
@@ -70,7 +71,7 @@ function applyContainerAttributesAndClasses(el: Element, token: CodeToken) {
     el.setAttribute('path', token.path);
   }
   if (token.visibleLines) {
-    el.setAttribute('visibleLines', token.visibleLines);
+    el.setAttribute('visibleLines', expandRangeStringValues(token.visibleLines).toString());
   }
   if (token.header) {
     el.setAttribute('header', token.header);

--- a/bazel/markdown_to_html/src/extensions/docs-code/format/range.ts
+++ b/bazel/markdown_to_html/src/extensions/docs-code/format/range.ts
@@ -1,5 +1,7 @@
 /**
- * The function used to generate ranges of highlighted or visible lines in code blocks
+ * Expand a provided set of range values into a singel array of all values in the range.
+ *
+ * For example,  [[1,3], [12-13]] is expanded to [1,2,3,12,13].
  */
 export function expandRangeStringValues(rangeString: string | undefined): number[] {
   if (rangeString === undefined) {

--- a/bazel/markdown_to_html/src/extensions/docs-code/format/range.ts
+++ b/bazel/markdown_to_html/src/extensions/docs-code/format/range.ts
@@ -1,7 +1,7 @@
 /**
  * The function used to generate ranges of highlighted or visible lines in code blocks
  */
-export function parseRangeString(rangeString: string | undefined): number[] {
+export function expandRangeStringValues(rangeString: string | undefined): number[] {
   if (rangeString === undefined) {
     return [];
   }


### PR DESCRIPTION
Expand range strings into full is of numbers in the range(s)