### PR TITLE
fix(ng-dev/release): santize commit messages before generating change logs

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -81593,7 +81593,10 @@ function fetchCommitsForRevisionRange(client, revisionRange) {
     `--format=${gitLogFormatForParsing}${splitDelimiter}`,
     revisionRange
   ]);
-  return output.stdout.split(splitDelimiter).filter((entry) => !!entry.trim()).map((entry) => parseCommitFromGitLog(Buffer.from(entry, "utf-8")));
+  return output.stdout.split(splitDelimiter).filter((entry) => !!entry.trim()).map(santizeCommitMessage).map((entry) => parseCommitFromGitLog(Buffer.from(entry, "utf-8")));
+}
+function santizeCommitMessage(content) {
+  return content.replace(/ (@[A-z0-9]+) /g, " `$1` ");
 }
 
 // 

--- a/ng-dev/release/notes/commits/get-commits-in-range.ts
+++ b/ng-dev/release/notes/commits/get-commits-in-range.ts
@@ -71,7 +71,6 @@ export function getCommitsForRangeWithDeduping(
 
     commits.push(commit);
   }
-
   return commits;
 }
 
@@ -90,5 +89,16 @@ export function fetchCommitsForRevisionRange(
   return output.stdout
     .split(splitDelimiter)
     .filter((entry) => !!entry.trim())
+    .map(santizeCommitMessage)
     .map((entry) => parseCommitFromGitLog(Buffer.from(entry, 'utf-8')));
+}
+
+/**
+ * Santized a raw Github message to avoid unintended results in github rendered contexts.
+ *
+ * Currently sanitization does:
+ *  - Removes unexpected references to users
+ */
+function santizeCommitMessage(content: string): string {
+  return content.replace(/ (@[A-z0-9]+) /g, ' `$1` ');
 }


### PR DESCRIPTION
We are seeing instances of including `@for` in a commit message title and Github tries to link to an account.  This change wraps these types of occurrences in a codespan so that it does not occur.