### PR TITLE
feat(shared-docs): create stackblitz post API pages generator

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -2,7 +2,7 @@ load("//tools:defaults.bzl", "ng_module", "pkg_npm")
 load("//:package.bzl", "NPM_PACKAGE_SUBSTITUTIONS")
 
 ng_module(
-    name = "docs-shared",
+    name = "docs",
     srcs = [
         "public-api.ts",
     ],
@@ -27,11 +27,14 @@ pkg_npm(
         "//docs/icons",
         "//docs/markdown:BUILD.bazel",
         "//docs/markdown:_guides.bzl",
+        "//docs/markdown:_stackblitz.bzl",
+        "//docs/markdown/examples/template:files",
         "//docs/styles",
     ],
     substitutions = NPM_PACKAGE_SUBSTITUTIONS,
     deps = [
-        ":docs-shared",
+        ":docs",
         "//docs/markdown:guides.mjs",
+        "//docs/markdown:stackblitz.mjs",
     ],
 )

--- a/docs/index.bzl
+++ b/docs/index.bzl
@@ -1,3 +1,5 @@
 load("//docs/markdown:_guides.bzl", _generate_guides = "generate_guides")
+load("//docs/markdown:_stackblitz.bzl", _generate_stackblitz = "generate_stackblitz")
 
 generate_guides = _generate_guides
+generate_stackblitz = _generate_stackblitz

--- a/docs/markdown/BUILD.bazel
+++ b/docs/markdown/BUILD.bazel
@@ -7,20 +7,6 @@ load("//tools:defaults.bzl", "esbuild_esm_bundle")
 
 package(default_visibility = ["//docs/markdown:__subpackages__"])
 
-nodejs_binary(
-    name = "markdown",
-    data = [
-        "@npm//jsdom",
-    ],
-    entry_point = "//docs/markdown:guides.mjs",
-    visibility = ["//visibility:public"],
-)
-
-exports_files([
-    "_guides.bzl",
-    "BUILD.bazel",
-])
-
 esbuild_esm_bundle(
     name = "guides",
     entry_point = "//docs/markdown/guides:index.ts",
@@ -34,4 +20,43 @@ esbuild_esm_bundle(
         "//docs/markdown/guides:index",
     ],
 )
+
+esbuild_esm_bundle(
+    name = "stackblitz-bundle",
+    entry_point = "//docs/markdown/examples/stackblitz:index.ts",
+    # JSDOM should not be bundled because it has workers and dynamic imports.
+    external = ["jsdom"],
+    output = "stackblitz.mjs",
+    platform = "node",
+    target = "es2022",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//docs/markdown/examples/stackblitz:index",
+    ],
+)
+
+exports_files([
+    "_guides.bzl",
+    "_stackblitz.bzl",
+    "BUILD.bazel",
+])
+
 # END-DEV-ONLY
+
+nodejs_binary(
+    name = "stackblitz",
+    data = [
+        "@npm//jsdom",
+    ],
+    entry_point = "//docs/markdown:stackblitz.mjs",
+    visibility = ["//visibility:public"],
+)
+
+nodejs_binary(
+    name = "markdown",
+    data = [
+        "@npm//jsdom",
+    ],
+    entry_point = "//docs/markdown:guides.mjs",
+    visibility = ["//visibility:public"],
+)

--- a/docs/markdown/_stackblitz.bzl
+++ b/docs/markdown/_stackblitz.bzl
@@ -1,0 +1,68 @@
+load("@build_bazel_rules_nodejs//:providers.bzl", "run_node")
+
+def _generate_stackblitz(ctx):
+    """Implementation of the markdown rule"""
+
+    # Determine the stackblitz template base directory
+    stackblitz_template = " " * 1000
+    for file in ctx.files.stackblitz_template:
+        file_path = file.dirname
+        if (len(file_path) < len(stackblitz_template)):
+            stackblitz_template = file_path
+
+    # File declaration of the generated html file
+    html_output = ctx.actions.declare_file("%s.html" % ctx.attr.name)
+
+    # Temporary directory for the generation to utilize
+    tmp_directory = ctx.actions.declare_directory("TMP_" + ctx.label.name)
+
+    # Set the arguments for the actions inputs and output location.
+    args = ctx.actions.args()
+
+    # Path to the example being generated.
+    args.add(ctx.attr.example.label.package)
+
+    # Path to the actions temporary directory.
+    args.add(tmp_directory.short_path)
+
+    # Path to the stackblitz template
+    args.add(stackblitz_template)
+
+    # Path to the html output file to write to.
+    args.add(html_output.path)
+
+    ctx.runfiles(files = ctx.files.stackblitz_template)
+
+    run_node(
+        ctx = ctx,
+        inputs = depset(ctx.files.example + ctx.files.stackblitz_template),
+        executable = "_generate_stackblitz",
+        outputs = [html_output, tmp_directory],
+        arguments = [args],
+    )
+
+    # The return value describes what the rule is producing. In this case we need to specify
+    # the "DefaultInfo" with the output html files.
+    return [DefaultInfo(files = depset([html_output]))]
+
+generate_stackblitz = rule(
+    # Point to the starlark function that will execute for this rule.
+    implementation = _generate_stackblitz,
+    doc = """Rule that renders markdown sources to html""",
+
+    # The attributes that can be set to this rule.
+    attrs = {
+        "example": attr.label(
+            doc = """Files used for the stackblitz generation.""",
+        ),
+        "stackblitz_template": attr.label(
+            doc = """The stackblitz template directory to base generated stackblitz on.""",
+            default = Label("//docs/markdown/examples/template:files"),
+        ),
+        "_generate_stackblitz": attr.label(
+            default = Label("//docs/markdown:stackblitz"),
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/docs/markdown/examples/stackblitz/BUILD.bazel
+++ b/docs/markdown/examples/stackblitz/BUILD.bazel
@@ -1,0 +1,40 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "stackblitz",
+    srcs = glob(
+        [
+            "*.ts",
+        ],
+        exclude = [
+            "index.ts",
+        ],
+    ),
+    deps = [
+        "//docs/markdown/guides",
+        "@npm//@types/jsdom",
+        "@npm//@types/node",
+        "@npm//glob",
+        "@npm//jsdom",
+    ],
+)
+
+ts_library(
+    name = "index",
+    srcs = [
+        "index.ts",
+    ],
+    visibility = [
+        "//docs:__subpackages__",
+    ],
+    deps = [
+        ":stackblitz",
+        "@npm//@types/node",
+    ],
+)
+
+exports_files([
+    "index.ts",
+])

--- a/docs/markdown/examples/stackblitz/builder.ts
+++ b/docs/markdown/examples/stackblitz/builder.ts
@@ -1,0 +1,177 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {join} from 'path';
+import {readFile} from 'fs/promises';
+import {copyFolder, createFolder, removeFolder} from './file-system.js';
+import jsdom from 'jsdom';
+import {glob} from 'glob';
+import {regionParser} from '../../guides/extensions/docs-code/regions/region-parser.js';
+import {appendCopyrightToFile} from './copyright.js';
+import {FileType} from '../../guides/extensions/docs-code/sanitizers/eslint.js';
+import {EXCLUDE_FILES_FOR_STACKBLITZ, STACKBLITZ_CONFIG_FILENAME} from './defaults.js';
+
+interface StackblitzConfig {
+  title: string;
+  ignore: string[];
+  file: string;
+  tags: string[];
+  description: string;
+}
+
+export async function generateStackblitzExample(
+  exampleDir: string,
+  temporaryExampleDir: string,
+  stackblitzTemplateDir: string,
+) {
+  const config = await readFile(join(exampleDir, STACKBLITZ_CONFIG_FILENAME), 'utf-8');
+  const stackblitzConfig: StackblitzConfig = JSON.parse(config) as StackblitzConfig;
+
+  await createFolder(temporaryExampleDir);
+
+  // Copy template files to TEMP folder
+  await copyFolder(stackblitzTemplateDir, temporaryExampleDir);
+
+  // Copy example files to TEMP folder
+  await copyFolder(exampleDir, temporaryExampleDir);
+  const result = await generateStackblitzHtml(temporaryExampleDir, stackblitzConfig);
+  await removeFolder(temporaryExampleDir);
+  return result;
+}
+
+async function generateStackblitzHtml(
+  temporaryExampleDir: string,
+  stackBlitzConfig: StackblitzConfig,
+): Promise<string> {
+  const defaultIncludes = [
+    '**/*.ts',
+    '**/*.js',
+    '**/*.css',
+    '**/*.html',
+    '**/*.md',
+    '**/*.json',
+    '**/*.svg',
+  ];
+  const exampleFilePaths = await glob(defaultIncludes, {
+    cwd: temporaryExampleDir,
+    nodir: true,
+    dot: true,
+    ignore: stackBlitzConfig.ignore,
+  });
+
+  const postData = await createPostData(temporaryExampleDir, stackBlitzConfig, exampleFilePaths);
+  const primaryFile = getPrimaryFile(stackBlitzConfig.file, exampleFilePaths);
+  return createStackblitzHtml(postData, primaryFile);
+}
+
+function getPrimaryFile(primaryFilePath: string, exampleFilePaths: string[]): string {
+  if (primaryFilePath) {
+    if (!exampleFilePaths.some((filePath) => filePath === primaryFilePath)) {
+      throw new Error(`The specified primary file (${primaryFilePath}) does not exist!`);
+    }
+    return primaryFilePath;
+  } else {
+    const defaultPrimaryFilePaths = [
+      'src/app/app.component.html',
+      'src/app/app.component.ts',
+      'src/app/main.ts',
+    ];
+    const primaryFile = defaultPrimaryFilePaths.find((path) =>
+      exampleFilePaths.some((filePath) => filePath === path),
+    );
+
+    if (!primaryFile) {
+      throw new Error(
+        `None of the default primary files (${defaultPrimaryFilePaths.join(', ')}) exists.`,
+      );
+    }
+
+    return primaryFile;
+  }
+}
+
+async function createPostData(
+  exampleDir: string,
+  config: StackblitzConfig,
+  exampleFilePaths: string[],
+): Promise<Record<string, string>> {
+  const postData: Record<string, string> = {};
+
+  for (const filePath of exampleFilePaths) {
+    if (EXCLUDE_FILES_FOR_STACKBLITZ.some((excludedFile) => filePath.endsWith(excludedFile))) {
+      continue;
+    }
+
+    let content = await readFile(join(exampleDir, filePath), 'utf-8');
+    content = appendCopyrightToFile(filePath, content);
+    content = extractRegions(filePath, content);
+
+    postData[`project[files][${filePath}]`] = content;
+  }
+
+  const tags = ['angular', 'example', ...(config.tags || [])];
+  tags.forEach((tag, index) => (postData[`project[tags][${index}]`] = tag));
+
+  postData['project[description]'] = `Angular Example - ${config.description}`;
+  postData['project[template]'] = 'node';
+  postData['project[title]'] = config.title ?? 'Angular Example';
+
+  return postData;
+}
+
+function createStackblitzHtml(postData: Record<string, string>, primaryFile: string): string {
+  const baseHtml = createBaseStackblitzHtml(primaryFile);
+  const doc = new jsdom.JSDOM(baseHtml).window.document;
+  const form = doc.querySelector('form');
+
+  for (const [key, value] of Object.entries(postData)) {
+    const element = htmlToElement(doc, `<input type="hidden" name="${key}">`);
+    if (element && form) {
+      element.setAttribute('value', value as string);
+      form.appendChild(element);
+    }
+  }
+
+  return doc.documentElement.outerHTML;
+}
+
+function createBaseStackblitzHtml(primaryFile: string) {
+  const file = `?file=${primaryFile}`;
+  const action = `https://stackblitz.com/run${file}`;
+
+  return `
+    <!DOCTYPE html><html lang="en"><body>
+      <form id="mainForm" method="post" action="${action}" target="_self"></form>
+      <script>
+        var embedded = 'ctl=1';
+        var isEmbedded = window.location.search.indexOf(embedded) > -1;
+
+        if (isEmbedded) {
+          var form = document.getElementById('mainForm');
+          var action = form.action;
+          var actionHasParams = action.indexOf('?') > -1;
+          var symbol = actionHasParams ? '&' : '?'
+          form.action = form.action + symbol + embedded;
+        }
+        document.getElementById("mainForm").submit();
+      </script>
+    </body></html>
+  `.trim();
+}
+
+function htmlToElement(document: Document, html: string) {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.firstElementChild;
+}
+
+function extractRegions(path: string, contents: string): string {
+  const fileType: FileType | undefined = path?.split('.').pop() as FileType;
+  const regionParserResult = regionParser(contents, fileType);
+  return regionParserResult.contents;
+}

--- a/docs/markdown/examples/stackblitz/builder.ts
+++ b/docs/markdown/examples/stackblitz/builder.ts
@@ -141,8 +141,7 @@ function createStackblitzHtml(postData: Record<string, string>, primaryFile: str
 }
 
 function createBaseStackblitzHtml(primaryFile: string) {
-  const file = `?file=${primaryFile}`;
-  const action = `https://stackblitz.com/run${file}`;
+  const action = `https://stackblitz.com/run?file=${primaryFile}`;
 
   return `
     <!DOCTYPE html><html lang="en"><body>

--- a/docs/markdown/examples/stackblitz/copyright.ts
+++ b/docs/markdown/examples/stackblitz/copyright.ts
@@ -1,0 +1,43 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/** The pad used around the copyright blocks. */
+const PAD = '\n\n';
+/** The standard copyright block used throughout Angular. */
+const COPYRIGHT = `
+@license
+Copyright Google LLC All Rights Reserved.
+
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE file at https://angular.dev/license
+`;
+/** Copyright comment for CSS and Javascript/Typescript files. */
+const CSS_TS_COPYRIGHT = `/*${COPYRIGHT}*/${PAD}`;
+/** Copyright comment for HTML files. */
+const HTML_COPYRIGHT = `<!--${COPYRIGHT}-->${PAD}`;
+
+/**
+ * Append the copyright using the appropriate commenting structure based on the file extension.
+ *
+ * No copyright is appended if the type is unrecognized.
+ */
+export function appendCopyrightToFile(filename: string, content: string): string {
+  const extension = filename.split('.').pop();
+  switch (extension) {
+    case 'html':
+    case 'ng':
+      return `${HTML_COPYRIGHT}${content}`;
+    case 'js':
+    case 'ts':
+    case 'css':
+    case 'scss':
+      return `${CSS_TS_COPYRIGHT}${content}`;
+    default:
+      return content;
+  }
+}

--- a/docs/markdown/examples/stackblitz/defaults.ts
+++ b/docs/markdown/examples/stackblitz/defaults.ts
@@ -1,0 +1,22 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export const TEST_FILES_EXTENSION_SUFFIX = '.spec.ts';
+export const TEST_FILES_E2E_EXTENSION_SUFFIX = '.e2e-spec.ts';
+export const BUILD_BAZEL_FILENAME = 'BUILD.bazel';
+export const EXAMPLE_CONFIG_FILENAME = 'example-config.json';
+export const STACKBLITZ_CONFIG_FILENAME = 'stackblitz.json';
+
+/** Default file paths to be excluded from stackblitz examples. */
+export const EXCLUDE_FILES_FOR_STACKBLITZ = [
+  STACKBLITZ_CONFIG_FILENAME,
+  BUILD_BAZEL_FILENAME,
+  EXAMPLE_CONFIG_FILENAME,
+  TEST_FILES_EXTENSION_SUFFIX,
+  TEST_FILES_E2E_EXTENSION_SUFFIX,
+];

--- a/docs/markdown/examples/stackblitz/file-system.ts
+++ b/docs/markdown/examples/stackblitz/file-system.ts
@@ -10,8 +10,10 @@ import {existsSync} from 'fs';
 import {copyFile, mkdir, readdir, rm, stat} from 'fs/promises';
 import {join} from 'path';
 
+// TODO(josephperrott): Determine if we can use the fs default version of copying directories.
+
 /**
- * Recurusivelt copy folder and contents to the destigation, creating the destination folder
+ * Recursively copy folder and contents to the destigation, creating the destination folder
  * if necessary.
  **/
 export async function copyFolder(source: string, destination: string) {

--- a/docs/markdown/examples/stackblitz/file-system.ts
+++ b/docs/markdown/examples/stackblitz/file-system.ts
@@ -1,0 +1,57 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {existsSync} from 'fs';
+import {copyFile, mkdir, readdir, rm, stat} from 'fs/promises';
+import {join} from 'path';
+
+/**
+ * Recurusivelt copy folder and contents to the destigation, creating the destination folder
+ * if necessary.
+ **/
+export async function copyFolder(source: string, destination: string) {
+  if (!existsSync(destination)) {
+    await mkdir(destination, {recursive: true});
+  }
+
+  const files = await readdir(source);
+
+  for (const file of files) {
+    // If the file/dirname starts with `TMP_` we ignore it as we use `TMP_` to start the name of
+    // our temp directory. Since our temp directory is a subdirectory of the provided example,
+    // we would end up copying recursively forever.
+    if (file.startsWith('TMP_')) {
+      continue;
+    }
+    const sourcePath = join(source, file);
+    const destPath = join(destination, file);
+
+    const stats = await stat(sourcePath);
+    const isDirectory = await stats.isDirectory();
+
+    if (isDirectory) {
+      await copyFolder(sourcePath, destPath);
+    } else {
+      await copyFile(sourcePath, destPath);
+    }
+  }
+}
+
+/** Create folder at the provided path if it does not already exist. */
+export async function createFolder(path: string): Promise<void> {
+  if (!existsSync(path)) {
+    await mkdir(path, {recursive: true});
+  }
+}
+
+/** Remove folder at the provided path if it exists. */
+export async function removeFolder(path: string): Promise<void> {
+  if (existsSync(path)) {
+    await rm(path, {recursive: true});
+  }
+}

--- a/docs/markdown/examples/stackblitz/index.ts
+++ b/docs/markdown/examples/stackblitz/index.ts
@@ -1,0 +1,15 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {writeFileSync} from 'fs';
+import {generateStackblitzExample} from './builder.js';
+
+const [exampleDir, tmpDir, templateDir, outputFilePath] = process.argv.slice(2);
+const htmlOutputContent = await generateStackblitzExample(exampleDir, tmpDir, templateDir);
+
+writeFileSync(outputFilePath, htmlOutputContent, {encoding: 'utf8'});

--- a/docs/markdown/examples/template/.stackblitzrc
+++ b/docs/markdown/examples/template/.stackblitzrc
@@ -1,0 +1,4 @@
+{
+  "installDependencies": false,
+  "startCommand": "npm install --legacy-peer-deps && npm start"
+}

--- a/docs/markdown/examples/template/BUILD.bazel
+++ b/docs/markdown/examples/template/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "files",
+    srcs = glob(["**/*"]),
+    visibility = ["//visibility:public"],
+)

--- a/docs/markdown/examples/template/angular.json
+++ b/docs/markdown/examples/template/angular.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "cli": {
+    "analytics": false
+  },
+  "newProjectRoot": "projects",
+  "projects": {
+    "example-app": {
+      "projectType": "application",
+      "schematics": {
+        "@schematics/angular:component": {
+          "style": "css"
+        },
+        "@schematics/angular:application": {
+          "strict": true
+        }
+      },
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/example-app",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "css",
+            "assets": ["src/assets"],
+            "styles": ["src/styles.css"],
+            "stylePreprocessorOptions": {
+              "includePaths": ["node_modules/"]
+            },
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kb",
+                  "maximumError": "1mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "2kb",
+                  "maximumError": "4kb"
+                }
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "browserTarget": "example-app:build:production"
+            },
+            "development": {
+              "browserTarget": "example-app:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "example-app:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "inlineStyleLanguage": "css",
+            "assets": ["src/assets"],
+            "stylePreprocessorOptions": {
+              "includePaths": ["node_modules/"]
+            },
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/markdown/examples/template/karma.conf.js
+++ b/docs/markdown/examples/template/karma.conf.js
@@ -1,0 +1,41 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+        // for example, you can disable the random execution with `random: false`
+        // or set a specific seed with `seed: 4321`
+      },
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true, // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/example-app'),
+      subdir: '.',
+      reporters: [{type: 'html'}, {type: 'text-summary'}],
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true,
+  });
+};

--- a/docs/markdown/examples/template/package.json
+++ b/docs/markdown/examples/template/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "example-app",
+  "version": "0.0.0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^16.1.1",
+    "@angular/common": "^16.1.1",
+    "@angular/compiler": "^16.1.1",
+    "@angular/core": "^16.1.1",
+    "@angular/forms": "^16.1.1",
+    "@angular/platform-browser": "^16.1.1",
+    "@angular/platform-browser-dynamic": "^16.1.1",
+    "@angular/router": "^16.1.1",
+    "rxjs": "~7.4.0",
+    "tslib": "^2.3.0",
+    "zone.js": "~0.13.0"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^16.1.0",
+    "@angular/cli": "^16.1.0",
+    "@angular/compiler-cli": "^16.1.1",
+    "@types/jasmine": "~3.10.0",
+    "@types/node": "^12.11.1",
+    "jasmine-core": "~3.10.0",
+    "karma": "~6.3.0",
+    "karma-chrome-launcher": "~3.1.0",
+    "karma-coverage": "~2.0.3",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.0.3"
+  }
+}

--- a/docs/markdown/examples/template/src/app/app.component.ts
+++ b/docs/markdown/examples/template/src/app/app.component.ts
@@ -1,0 +1,23 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {Component} from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-root',
+  template: '<h2>Example template</h2>',
+  styles: [
+    `
+      h2 {
+        color: blue;
+      }
+    `,
+  ],
+})
+export class AppComponent {}

--- a/docs/markdown/examples/template/src/index.html
+++ b/docs/markdown/examples/template/src/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Example</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/docs/markdown/examples/template/src/main.ts
+++ b/docs/markdown/examples/template/src/main.ts
@@ -1,0 +1,15 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {bootstrapApplication, provideProtractorTestingSupport} from '@angular/platform-browser';
+
+import {AppComponent} from './app/app.component';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideProtractorTestingSupport()],
+}).catch((err) => console.error(err));

--- a/docs/markdown/examples/template/src/styles.css
+++ b/docs/markdown/examples/template/src/styles.css
@@ -1,0 +1,9 @@
+body {
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  margin: 0;
+  padding: 30px;
+}
+
+html, body {
+  height: 100%;
+}

--- a/docs/markdown/examples/template/tsconfig.app.json
+++ b/docs/markdown/examples/template/tsconfig.app.json
@@ -1,0 +1,10 @@
+/* To learn more about this file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"]
+}

--- a/docs/markdown/examples/template/tsconfig.json
+++ b/docs/markdown/examples/template/tsconfig.json
@@ -1,0 +1,37 @@
+/* To learn more about this file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2022",
+    "module": "es2020",
+    "lib": ["es2020", "dom"],
+    // Strictness flags. Matching the settings applied in the Angular Components source
+    // code, ensuring that examples do not break in StackBlitz with stricter settings.
+    "noUnusedParameters": false,
+    "noUnusedLocals": false,
+    "useDefineForClassFields": false,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "strictFunctionTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictBindCallApply": true,
+    "esModuleInterop": true
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/docs/markdown/examples/template/tsconfig.spec.json
+++ b/docs/markdown/examples/template/tsconfig.spec.json
@@ -1,0 +1,10 @@
+/* To learn more about this file see: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": ["jasmine"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,14 +16,15 @@
     "jsxFragmentFactory": "Fragment"
   },
   "exclude": [
-    "node_modules/**",
-    "bazel-out/**",
-    "dist/**",
+    ".yarn/**",
+    ".angular/**",
+    "apps/**",
     "bazel/benchmark/component_benchmark/**",
     "bazel/benchmark/driver-utilities/**",
     "bazel/integration/tests/**",
-    "apps/**",
-    ".yarn/**",
-    ".angular/**"
+    "bazel-out/**",
+    "dist/**",
+    "docs/markdown/examples/template/**",
+    "node_modules/**"
   ]
 }


### PR DESCRIPTION
A script and associated bazel rule for creating a stackblitz post API html page for examples.