### PR TITLE
Update index.bzl: fix bug with checking for "browsers" in kwargs

### DIFF
--- a/bazel/karma/index.bzl
+++ b/bazel/karma/index.bzl
@@ -33,7 +33,7 @@ def karma_web_test_suite(name, **kwargs):
       and a local target to ease debugging."""
 
     # Set up default browsers if no explicit `browsers` have been specified.
-    if not hasattr(kwargs, "browsers"):
+    if "browsers" not in kwargs:
         kwargs["tags"] = ["native"] + kwargs.get("tags", [])
         kwargs["browsers"] = [
             "//bazel/browsers/chromium:chromium",


### PR DESCRIPTION
Because kwargs is a dictionary, use `not in` to check for presence. `hasattr` is for objects.