### PR TITLE
fix(shared-docs): use .md.html as the extension for generated guides

### DIFF
--- a/docs/markdown/guides/index.ts
+++ b/docs/markdown/guides/index.ts
@@ -24,7 +24,8 @@ async function main() {
     const markdownContent = readFileSync(filePath, {encoding: 'utf8'});
     const htmlOutputContent = await parseMarkdown(markdownContent);
 
-    const htmlFileName = filePath.substring(0, filePath.length - '.md'.length) + '.html';
+    // The expected file name structure is the [name of the file].md.html.
+    const htmlFileName = filePath + '.html';
     const htmlOutputPath = path.join(outputFilenameExecRootRelativePath, htmlFileName);
 
     writeFileSync(htmlOutputPath, htmlOutputContent, {encoding: 'utf8'});


### PR DESCRIPTION
Generated guides are expected to be the full file name with .html at the end.