### PR TITLE
fix(shared-docs): use .md.html as the extension for generated guides

### DIFF
--- a/docs/markdown/_guides.bzl
+++ b/docs/markdown/_guides.bzl
@@ -25,7 +25,7 @@ def _generate_guides(ctx):
         # because we want to preserve directories for the input files and `declare_file` expects a
         # path that is relative to the current package. We don't use `.replace`
         # here because the extension can be also in upper case.
-        relative_basepath = path_relative_to_label(ctx.label, input_file.short_path)[:-len(".md")]
+        relative_basepath = path_relative_to_label(ctx.label, input_file.short_path)
 
         # For each input file "xxx.md", we want to write an output file "xxx.html"
         html_outputs += [ctx.actions.declare_file("%s.html" % relative_basepath)]

--- a/docs/markdown/guides/index.ts
+++ b/docs/markdown/guides/index.ts
@@ -24,8 +24,7 @@ async function main() {
     const markdownContent = readFileSync(filePath, {encoding: 'utf8'});
     const htmlOutputContent = await parseMarkdown(markdownContent);
 
-    // The expected file name structure is the [name of the file].md.html.
-    const htmlFileName = filePath + '.html';
+    const htmlFileName = filePath.substring(0, filePath.length - '.md'.length) + '.html';
     const htmlOutputPath = path.join(outputFilenameExecRootRelativePath, htmlFileName);
 
     writeFileSync(htmlOutputPath, htmlOutputContent, {encoding: 'utf8'});

--- a/docs/markdown/guides/index.ts
+++ b/docs/markdown/guides/index.ts
@@ -24,7 +24,8 @@ async function main() {
     const markdownContent = readFileSync(filePath, {encoding: 'utf8'});
     const htmlOutputContent = await parseMarkdown(markdownContent);
 
-    const htmlFileName = filePath.substring(0, filePath.length - '.md'.length) + '.html';
+    // The expected file name structure is the [name of the file].md.html.
+    const htmlFileName = filePath + '.html';
     const htmlOutputPath = path.join(outputFilenameExecRootRelativePath, htmlFileName);
 
     writeFileSync(htmlOutputPath, htmlOutputContent, {encoding: 'utf8'});


### PR DESCRIPTION
Generated guides are expected to be the full file name with .html at the end.