### PR TITLE
feat(docs-shared): include edit button in documentation headers

### DIFF
--- a/docs/markdown/guides/index.ts
+++ b/docs/markdown/guides/index.ts
@@ -22,7 +22,7 @@ async function main() {
     }
 
     const markdownContent = readFileSync(filePath, {encoding: 'utf8'});
-    const htmlOutputContent = await parseMarkdown(markdownContent);
+    const htmlOutputContent = await parseMarkdown(markdownContent, {markdownFilePath: filePath});
 
     // The expected file name structure is the [name of the file].md.html.
     const htmlFileName = filePath + '.html';

--- a/docs/markdown/guides/parse.ts
+++ b/docs/markdown/guides/parse.ts
@@ -22,8 +22,14 @@ import {docsDecorativeHeaderExtension} from './extensions/docs-decorative-header
 import {docsCodeBlockExtension} from './extensions/docs-code/docs-code-block';
 import {docsCodeExtension} from './extensions/docs-code/docs-code';
 import {docsCodeMultifileExtension} from './extensions/docs-code/docs-code-multifile';
+import {ParserContext, setContext} from './utils';
 
-export async function parseMarkdown(markdownContent: string): Promise<string> {
+export async function parseMarkdown(
+  markdownContent: string,
+  context: ParserContext,
+): Promise<string> {
+  setContext(context);
+
   marked.use({
     hooks,
     renderer,

--- a/docs/markdown/guides/testing/docs-alert/docs-alert.spec.ts
+++ b/docs/markdown/guides/testing/docs-alert/docs-alert.spec.ts
@@ -12,7 +12,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-alert/docs-alert.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   for (let level in AlertSeverityLevel) {

--- a/docs/markdown/guides/testing/docs-callout/docs-callout.spec.ts
+++ b/docs/markdown/guides/testing/docs-callout/docs-callout.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-callout/docs-callout.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it(`defaults to a helpful callout`, () => {

--- a/docs/markdown/guides/testing/docs-card-container/docs-card-container.spec.ts
+++ b/docs/markdown/guides/testing/docs-card-container/docs-card-container.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-card-container/docs-card-container.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('creates card containers containing multiple cards', () => {

--- a/docs/markdown/guides/testing/docs-card/docs-card.spec.ts
+++ b/docs/markdown/guides/testing/docs-card/docs-card.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-card/docs-card.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('creates cards with no links', () => {

--- a/docs/markdown/guides/testing/docs-code-block/docs-code-block.spec.ts
+++ b/docs/markdown/guides/testing/docs-code-block/docs-code-block.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-code-block/docs-code-block.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('converts triple ticks into a code block', () => {

--- a/docs/markdown/guides/testing/docs-code-multifile/docs-code-multifile.spec.ts
+++ b/docs/markdown/guides/testing/docs-code-multifile/docs-code-multifile.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-code-multifile/docs-code-multifile.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('converts triple ticks into a code block', () => {

--- a/docs/markdown/guides/testing/docs-code/docs-code.spec.ts
+++ b/docs/markdown/guides/testing/docs-code/docs-code.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-code/docs-code.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('converts docs-code elements into a code block', () => {

--- a/docs/markdown/guides/testing/docs-decorative-header/docs-decorative-header.spec.ts
+++ b/docs/markdown/guides/testing/docs-decorative-header/docs-decorative-header.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-decorative-header/docs-decorative-header.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('sets the custom title in the header', () => {

--- a/docs/markdown/guides/testing/docs-pill-row/docs-pill-row.spec.ts
+++ b/docs/markdown/guides/testing/docs-pill-row/docs-pill-row.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-pill-row/docs-pill-row.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('should create a nav container with all of the docs pills inside', () => {

--- a/docs/markdown/guides/testing/docs-pill/docs-pill.spec.ts
+++ b/docs/markdown/guides/testing/docs-pill/docs-pill.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-pill/docs-pill.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('should render links to anchors on the same page', () => {

--- a/docs/markdown/guides/testing/docs-step/docs-step.spec.ts
+++ b/docs/markdown/guides/testing/docs-step/docs-step.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-step/docs-step.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('should create a list item for each step', () => {

--- a/docs/markdown/guides/testing/docs-video/docs-video.spec.ts
+++ b/docs/markdown/guides/testing/docs-video/docs-video.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-video/docs-video.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('should create an iframe in a container', () => {

--- a/docs/markdown/guides/testing/docs-workflow/docs-workflow.spec.ts
+++ b/docs/markdown/guides/testing/docs-workflow/docs-workflow.spec.ts
@@ -11,7 +11,7 @@ describe('markdown to html', () => {
       runfiles.resolvePackageRelative('docs-workflow/docs-workflow.md'),
       {encoding: 'utf-8'},
     );
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('create an ordered list container around the docs-steps', () => {

--- a/docs/markdown/guides/testing/heading/heading.spec.ts
+++ b/docs/markdown/guides/testing/heading/heading.spec.ts
@@ -10,7 +10,7 @@ describe('markdown to html', () => {
     const markdownContent = await readFile(runfiles.resolvePackageRelative('heading/heading.md'), {
       encoding: 'utf-8',
     });
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('should treat # as document headers', () => {

--- a/docs/markdown/guides/testing/image/image.spec.ts
+++ b/docs/markdown/guides/testing/image/image.spec.ts
@@ -10,7 +10,7 @@ describe('markdown to html', () => {
     const markdownContent = await readFile(runfiles.resolvePackageRelative('image/image.md'), {
       encoding: 'utf-8',
     });
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('should wrap images in custom classes', () => {

--- a/docs/markdown/guides/testing/link/link.spec.ts
+++ b/docs/markdown/guides/testing/link/link.spec.ts
@@ -8,7 +8,7 @@ describe('markdown to html', () => {
     const markdownContent = await readFile(runfiles.resolvePackageRelative('link/link.md'), {
       encoding: 'utf-8',
     });
-    parsedMarkdown = await parseMarkdown(markdownContent);
+    parsedMarkdown = await parseMarkdown(markdownContent, {});
   });
 
   it('should render external links with _blank target', () => {

--- a/docs/markdown/guides/testing/list/list.spec.ts
+++ b/docs/markdown/guides/testing/list/list.spec.ts
@@ -10,7 +10,7 @@ describe('markdown to html', () => {
     const markdownContent = await readFile(runfiles.resolvePackageRelative('list/list.md'), {
       encoding: 'utf-8',
     });
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('should wrap lists in custom classes', () => {

--- a/docs/markdown/guides/testing/table/table.spec.ts
+++ b/docs/markdown/guides/testing/table/table.spec.ts
@@ -8,7 +8,7 @@ describe('markdown to html', () => {
     const markdownContent = await readFile(runfiles.resolvePackageRelative('table/table.md'), {
       encoding: 'utf-8',
     });
-    parsedMarkdown = await parseMarkdown(markdownContent);
+    parsedMarkdown = await parseMarkdown(markdownContent, {});
   });
 
   it('should wrap the table in custom div', () => {

--- a/docs/markdown/guides/testing/text/text.spec.ts
+++ b/docs/markdown/guides/testing/text/text.spec.ts
@@ -10,7 +10,7 @@ describe('markdown to html', () => {
     const markdownContent = await readFile(runfiles.resolvePackageRelative('text/text.md'), {
       encoding: 'utf-8',
     });
-    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent));
+    markdownDocument = JSDOM.fragment(await parseMarkdown(markdownContent, {}));
   });
 
   it('should wrap emoji in custom classes', () => {

--- a/docs/markdown/guides/utils.ts
+++ b/docs/markdown/guides/utils.ts
@@ -10,10 +10,10 @@ import {existsSync, readFileSync} from 'fs';
 import {join} from 'path';
 import {cwd} from 'process';
 
+// TODO(josephperrott): Set edit content url based on the owner, repo and branch.
+
 /** The base url for edting the a file in the repository. */
-const GITHUB_EDIT_CONTENT_URL = '//';
-/** The path within the repository to the file being displayed. */
-const CURRENT_PAGE_PATH = '//';
+const GITHUB_EDIT_CONTENT_URL = 'https://github.com/angular/angular/edit/main';
 
 /** Get the page title with edit button to modify the page source. */
 export function getPageTitle(text: string): string {
@@ -21,11 +21,21 @@ export function getPageTitle(text: string): string {
   <!-- Page title -->
   <div class="docs-page-title">
     <h1 tabindex="-1">${text}</h1>
-    <a class="docs-github-links" target="_blank" href="${GITHUB_EDIT_CONTENT_URL}/${CURRENT_PAGE_PATH}" title="Edit this page" aria-label="Edit this page">
+    <a class="docs-github-links" target="_blank" href="${GITHUB_EDIT_CONTENT_URL}/${context?.markdownFilePath}" title="Edit this page" aria-label="Edit this page">
       <!-- Pencil -->
       <docs-icon role="presentation">edit</docs-icon>
     </a>
   </div>`;
+}
+
+/** Configuration using environment for parser, providing context. */
+export interface ParserContext {
+  markdownFilePath?: string;
+}
+
+let context: ParserContext = {};
+export function setContext(envContext: Partial<ParserContext>) {
+  context = envContext;
 }
 
 /** The base directory of the workspace the script is running in. */


### PR DESCRIPTION
Include edit button properly opening the edit page of the markdown file being shown.