### PR TITLE
ci: set timeouts for jobs to prevent overusage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ defaults:
 
 jobs:
   lint:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       # Because the checkout and setup node action is contained in the dev-infra repo, we must
@@ -41,6 +42,7 @@ jobs:
         run: yarn tsc -p tsconfig.json
 
   test:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       # Because the checkout and setup node action is contained in the dev-infra repo, we must
@@ -54,6 +56,7 @@ jobs:
       - run: yarn bazel test -- //...
 
   test-win:
+    timeout-minutes: 30
     runs-on: windows-latest
     steps:
       # Because the checkout and setup node action is contained in the dev-infra repo, we must
@@ -67,6 +70,7 @@ jobs:
       - run: yarn bazel test --test_tag_filters=windows --build_tests_only -- ... -bazel/remote-execution/...
 
   test-macos:
+    timeout-minutes: 30
     runs-on: macos-latest
     steps:
       # Because the checkout and setup node action is contained in the dev-infra repo, we must

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,32 +4244,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google-cloud/storage@npm:^7.0.0":
-  version: 7.7.0
-  resolution: "@google-cloud/storage@npm:7.7.0"
-  dependencies:
-    "@google-cloud/paginator": "npm:^5.0.0"
-    "@google-cloud/projectify": "npm:^4.0.0"
-    "@google-cloud/promisify": "npm:^4.0.0"
-    abort-controller: "npm:^3.0.0"
-    async-retry: "npm:^1.3.3"
-    compressible: "npm:^2.0.12"
-    duplexify: "npm:^4.0.0"
-    ent: "npm:^2.2.0"
-    fast-xml-parser: "npm:^4.3.0"
-    gaxios: "npm:^6.0.2"
-    google-auth-library: "npm:^9.0.0"
-    mime: "npm:^3.0.0"
-    mime-types: "npm:^2.0.8"
-    p-limit: "npm:^3.0.1"
-    retry-request: "npm:^7.0.0"
-    teeny-request: "npm:^9.0.0"
-    uuid: "npm:^8.0.0"
-  checksum: 8fffef374b061e567e146f81b2cdb5125cc3dd9ede06fb4879b6e45a892fb2b298778a3e94d7b59a7671fde6697b3e23f1593c069cf97522c50746cd599bf7f0
-  languageName: node
-  linkType: hard
-
-"@google-cloud/storage@npm:^7.7.0":
+"@google-cloud/storage@npm:^7.0.0, @google-cloud/storage@npm:^7.7.0":
   version: 7.7.0
   resolution: "@google-cloud/storage@npm:7.7.0"
   dependencies:


### PR DESCRIPTION
Set timeout for ci jobs


Also, update the failing yarn.lock