### PR TITLE
refactor: fix config discovery to work with latest prettier

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -81021,7 +81021,10 @@ var Prettier = class extends Formatter {
       "**/*.json",
       "**/*.{yml,yaml}"
     ];
-    this.configPath = this.config["prettier"] ? ChildProcess.spawnSync(this.binaryFilePath, ["--find-config-path", "."]).stdout.trim() : "";
+    this.configPath = this.config["prettier"] ? ChildProcess.spawnSync(this.binaryFilePath, [
+      "--find-config-path",
+      join4(process.cwd(), "dummy.js")
+    ]).stdout.trim() : "";
     this.actions = {
       check: {
         commandFlags: `--config ${this.configPath} --check`,

--- a/ng-dev/format/formatters/prettier.ts
+++ b/ng-dev/format/formatters/prettier.ts
@@ -33,7 +33,10 @@ export class Prettier extends Formatter {
    * to discover it repeatedly for each execution.
    */
   private configPath = this.config['prettier']
-    ? ChildProcess.spawnSync(this.binaryFilePath, ['--find-config-path', '.']).stdout.trim()
+    ? ChildProcess.spawnSync(this.binaryFilePath, [
+        '--find-config-path',
+        join(process.cwd(), 'dummy.js'),
+      ]).stdout.trim()
     : '';
 
   override actions = {


### PR DESCRIPTION
Fix config discovery to work with latest prettier. See: https://github.com/prettier/prettier/pull/15363/files

Fix for https://github.com/angular/angular-cli/pull/26571