### PR TITLE
fix(ng-dev): don't require a branch confirmation if no targets are used

### DIFF
--- a/ng-dev/pr/merge/merge-tool.ts
+++ b/ng-dev/pr/merge/merge-tool.ts
@@ -157,6 +157,9 @@ export class MergeTool {
       }
 
       if (
+        // If there is no target labeling then the pull request is always just directly merged, so
+        // the confirmation can be skipped.
+        !this.config.pullRequest.__noTargetLabeling &&
         // In cases where manual branch targeting is used, the user already confirmed.
         !this.flags.forceManualBranches &&
         this.flags.branchPrompt &&


### PR DESCRIPTION
If there is no target labelling then no branch prompt is necessary