### PR TITLE
build: remove deprecated lint rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,6 @@
   "rulesDirectory": ["./lint-rules/tslint"],
   "rules": {
     "ts-node-loader": true,
-    "no-shadowed-variable": true,
     "validate-import-for-esm-cjs-interop": [
       true,
       {


### PR DESCRIPTION
Remove the no-shadow lint rule as its deprecated and no longer works