### PR TITLE
fix(shared-docs): use content path for the tutorial step files with numbers

### DIFF
--- a/docs/markdown/tutorial/routes.ts
+++ b/docs/markdown/tutorial/routes.ts
@@ -32,10 +32,10 @@ export async function generateTutorialRoutes(
     )
     .map(([path, config], idx) => {
       // Remove the number prefix from the step directory name for the path.
-      path = path.replace(/^\d+\-/, '');
+      const pathWithoutNumber = path.replace(/^\d+\-/, '');
       return {
         label: config.title,
-        path: `tutorials/${tutorialName}/${path}`,
+        path: `tutorials/${tutorialName}/${pathWithoutNumber}`,
         contentPath: `tutorials/${tutorialName}/steps/${path}/README`,
         tutorialData: {
           title: config.title,


### PR DESCRIPTION
The content files for steps in the tutorials are created with numbers in the file name, despite wanting the numbers removed in the visible url we still need the numbers in the content path to find the asset