### PR TITLE
fix(shared-docs): include query string in examples' copied link to enable right navigation

### DIFF
--- a/docs/components/example-viewer/example-viewer.component.ts
+++ b/docs/components/example-viewer/example-viewer.component.ts
@@ -127,7 +127,7 @@ export class ExampleViewer {
 
   copyLink(): void {
     // Reconstruct the URL using `origin + pathname` so we drop any pre-existing hash.
-    const fullUrl = location.origin + location.pathname + '#example-' + this.exampleMetadata()?.id;
+    const fullUrl = location.origin + location.pathname + location.search + '#example-' + this.exampleMetadata()?.id;
     this.clipboard.copy(fullUrl);
   }
 

--- a/docs/components/example-viewer/example-viewer.component.ts
+++ b/docs/components/example-viewer/example-viewer.component.ts
@@ -77,22 +77,20 @@ export class ExampleViewer {
   expanded = signal<boolean>(false);
   exampleMetadata = signal<ExampleMetadata | null>(null);
   snippetCode = signal<Snippet | undefined>(undefined);
-  tabs = computed(
-    () =>
-      this.exampleMetadata()?.files.map((file) => ({
-        name:
-          file.title ??
-          (this.shouldDisplayFullName() ? file.name : this.getFileExtension(file.name)),
-        code: file.content,
-      })),
+  tabs = computed(() =>
+    this.exampleMetadata()?.files.map((file) => ({
+      name:
+        file.title ?? (this.shouldDisplayFullName() ? file.name : this.getFileExtension(file.name)),
+      code: file.content,
+    })),
   );
   view = computed(() =>
     this.exampleMetadata()?.files.length === 1
       ? CodeExampleViewMode.SNIPPET
       : CodeExampleViewMode.MULTI_FILE,
   );
-  expandable = computed(
-    () => this.exampleMetadata()?.files.some((file) => !!file.visibleLinesRange),
+  expandable = computed(() =>
+    this.exampleMetadata()?.files.some((file) => !!file.visibleLinesRange),
   );
 
   async renderExample(): Promise<void> {
@@ -127,7 +125,12 @@ export class ExampleViewer {
 
   copyLink(): void {
     // Reconstruct the URL using `origin + pathname` so we drop any pre-existing hash.
-    const fullUrl = location.origin + location.pathname + location.search + '#example-' + this.exampleMetadata()?.id;
+    const fullUrl =
+      location.origin +
+      location.pathname +
+      location.search +
+      '#example-' +
+      this.exampleMetadata()?.id;
     this.clipboard.copy(fullUrl);
   }
 


### PR DESCRIPTION
Since we are using tabs and using the query params to catch the current active one, I believe we should direct users to the tab that has this example in it.

### Example
copying the link of [ injectable api ref page example](https://angular.dev/api/core/Injectable?tab=usage-notes)
![image](https://github.com/angular/dev-infra/assets/65634467/bb0320c3-6335-4b47-ba79-75482d1864da)

#### Before: 
If you hit the copied link, it will direct you to the page, but it will show the first tab (which this example is not part of).

![image](https://github.com/angular/dev-infra/assets/65634467/ceaeed40-1641-4df2-a576-9a1b5d7e50c8)


#### After:
You will be directed to the right tab and even scrolled to your example by the browser using the fragment, and that gives a better experience.
![image](https://github.com/angular/dev-infra/assets/65634467/e2d22067-9167-4206-b3c4-1bcf23ac94b6)

