### PR TITLE
fix(shared-docs): ensure that the algolia icon takes space

### DIFF
--- a/docs/components/search-dialog/search-dialog.component.scss
+++ b/docs/components/search-dialog/search-dialog.component.scss
@@ -138,6 +138,7 @@ dialog {
   border-radius: 0 0 0.25rem 0.25rem;
 
   docs-algolia-icon {
+    display: inline-flex;
     margin-block-start: 0.12rem;
     margin-inline-start: 0.15rem;
     width: 4rem;


### PR DESCRIPTION
Change algolia icon to inline-flex to ensure it takes space and is visible.