### PR TITLE
fix(shared-docs): properly stringify the visible files from regions for parsing by the element

### DIFF
--- a/docs/markdown/guides/extensions/docs-code/format/index.ts
+++ b/docs/markdown/guides/extensions/docs-code/format/index.ts
@@ -71,7 +71,7 @@ function applyContainerAttributesAndClasses(el: Element, token: CodeToken) {
     el.setAttribute('path', token.path);
   }
   if (token.visibleLines) {
-    el.setAttribute('visibleLines', expandRangeStringValues(token.visibleLines).toString());
+    el.setAttribute('visibleLines', JSON.stringify(expandRangeStringValues(token.visibleLines)));
   }
   if (token.header) {
     el.setAttribute('header', token.header);


### PR DESCRIPTION
Properly stringify with a wrapping `[]`, as expected by the docs-code component element.