### PR TITLE
docs: remove margin-top negative style

### DIFF
--- a/docs/styles/docs/_steps.scss
+++ b/docs/styles/docs/_steps.scss
@@ -5,7 +5,6 @@
 @mixin docs-steps() {
   .docs-steps {
     --gutter: 4rem;
-    margin-top: -1.5rem; // even out docs-anchor margin-block-start
     padding-inline-start: var(--gutter);
     counter-reset: code-steps-list;
     list-style-type: none;


### PR DESCRIPTION
**What is the current behavior?**
Currently the **docs-steps** component has the margin-top property with a negative value, which causes some layout breaks, as you can see in the report in this issue: https://github.com/angular/angular/issues/54476

**What is the new behavior?**
Remove the negative margin-top property to avoid breaks and leave the layout with its normal behavior.
