### PR TITLE
docs: remove circleci from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # dev-infra
 Angular Development Infrastructure
-
-[![CircleCI](https://dl.circleci.com/insights-snapshot/gh/angular/dev-infra/main/default_workflow/badge.svg?window=7d)](https://app.circleci.com/insights/github/angular/dev-infra/workflows/default_workflow/overview?branch=main&reporting-window=last-7-days&insights-snapshot=true)


### PR DESCRIPTION
Remove CircleCI status widget from readme as we no longer rely on it