### PR TITLE
ci: use angular/team Github team for minimum review set

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -30,4 +30,4 @@ groups:
       reviewed_for: ignored # All reviews apply to this group whether noted via Reviewed-for or not
     reviewers:
       teams:
-        - ~dev-infra
+        - team


### PR DESCRIPTION
Use the angular/team Github team to define the list of eligible minimum reviewer set so that it can be reused accross the organization