### PR TITLE
refactor(ng-dev): rename validation to no longer reference primitives

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -77176,7 +77176,7 @@ var defaultConfig = {
   assertCompletedReviews: true,
   assertEnforcedStatuses: true,
   assertMinimumReviews: true,
-  assertIsolatePrimitives: false,
+  assertIsolatedSeparateFiles: false,
   assertEnforceTested: false
 };
 function createPullRequestValidationConfig(config) {
@@ -77368,7 +77368,7 @@ var G3Stats = class {
 };
 
 // 
-var isolatePrimitivesValidation = createPullRequestValidation({ name: "assertIsolatePrimitives", canBeForceIgnored: true }, () => Validation4);
+var isolatedSeparateFilesValidation = createPullRequestValidation({ name: "assertIsolatedSeparateFiles", canBeForceIgnored: true }, () => Validation4);
 var Validation4 = class extends PullRequestValidation {
   async assert(config, prNumber, gitClient) {
     try {
@@ -77574,7 +77574,7 @@ async function assertValidPullRequest(pullRequest, validationConfig, ngDevConfig
     breakingChangeInfoValidation.run(validationConfig, commitsInPr, labels),
     passingCiValidation.run(validationConfig, pullRequest),
     enforcedStatusesValidation.run(validationConfig, pullRequest, ngDevConfig.pullRequest),
-    isolatePrimitivesValidation.run(validationConfig, ngDevConfig, pullRequest.number, gitClient),
+    isolatedSeparateFilesValidation.run(validationConfig, ngDevConfig, pullRequest.number, gitClient),
     enforceTestedValidation.run(validationConfig, pullRequest, gitClient.github)
   ];
   if (activeReleaseTrains !== null) {

--- a/ng-dev/pr/common/test/common.spec.ts
+++ b/ng-dev/pr/common/test/common.spec.ts
@@ -26,7 +26,7 @@ import {PullRequestConfig, PullRequestValidationConfig} from '../../config/index
 import {PullRequestTarget} from '../targeting/target-label.js';
 import {AuthenticatedGitClient} from '../../../utils/git/authenticated-git-client.js';
 import {installVirtualGitClientSpies, mockNgDevConfig} from '../../../utils/testing/index.js';
-import {PullRequestFiles} from '../validation/assert-isolate-primitives.js';
+import {PullRequestFiles} from '../validation/assert-isolated-separate-files.js';
 import {G3Stats} from '../../../utils/g3.js';
 
 const API_ENDPOINT = `https://api.github.com`;
@@ -150,7 +150,7 @@ describe('pull request validation', () => {
 
   describe('assert-isolate-primitives', () => {
     it('should pass when no google sync config present', async () => {
-      const config = createIsolatedValidationConfig({assertIsolatePrimitives: true});
+      const config = createIsolatedValidationConfig({assertIsolatedSeparateFiles: true});
       let pr = createTestPullRequest();
       const files = ['packages/core/primitives/rando.ts'];
       const fileHelper = PullRequestFiles.create(git, pr.number, googleSyncConfig);
@@ -161,7 +161,7 @@ describe('pull request validation', () => {
     });
 
     it('should prevent merging when primitives have been merged already and PR does not include primitives files', async () => {
-      const config = createIsolatedValidationConfig({assertIsolatePrimitives: true});
+      const config = createIsolatedValidationConfig({assertIsolatedSeparateFiles: true});
       let pr = createTestPullRequest();
       const files = ['packages/router/blah.ts'];
       const fileHelper = PullRequestFiles.create(git, pr.number, googleSyncConfig);
@@ -178,7 +178,7 @@ describe('pull request validation', () => {
     });
 
     it('should prevent merging when framework changes have been merged already and PR includes primitives files', async () => {
-      const config = createIsolatedValidationConfig({assertIsolatePrimitives: true});
+      const config = createIsolatedValidationConfig({assertIsolatedSeparateFiles: true});
       let pr = createTestPullRequest();
       const files = ['packages/core/primitives/rando.ts'];
       const fileHelper = PullRequestFiles.create(git, pr.number, googleSyncConfig);
@@ -195,7 +195,7 @@ describe('pull request validation', () => {
     });
 
     it('should allow merging when framework changes have been merged already and PR does not include primitives files', async () => {
-      const config = createIsolatedValidationConfig({assertIsolatePrimitives: true});
+      const config = createIsolatedValidationConfig({assertIsolatedSeparateFiles: true});
       let pr = createTestPullRequest();
       const files = ['packages/router/blah.ts'];
       const fileHelper = PullRequestFiles.create(git, pr.number, googleSyncConfig);
@@ -208,7 +208,7 @@ describe('pull request validation', () => {
     });
 
     it('should allow merging when primitives changes have been merged already and PR includes primitives files', async () => {
-      const config = createIsolatedValidationConfig({assertIsolatePrimitives: true});
+      const config = createIsolatedValidationConfig({assertIsolatedSeparateFiles: true});
       let pr = createTestPullRequest();
       const files = ['packages/core/primitives/rando.ts'];
       const fileHelper = PullRequestFiles.create(git, pr.number, googleSyncConfig);

--- a/ng-dev/pr/common/validation/assert-isolated-separate-files.ts
+++ b/ng-dev/pr/common/validation/assert-isolated-separate-files.ts
@@ -24,8 +24,8 @@ import {fetchPullRequestFilesFromGithub} from '../fetch-pull-request.js';
 
 /** Assert the pull request has passing enforced statuses. */
 // TODO: update typings to make sure portability is properly handled for windows build.
-export const isolatePrimitivesValidation = createPullRequestValidation(
-  {name: 'assertIsolatePrimitives', canBeForceIgnored: true},
+export const isolatedSeparateFilesValidation = createPullRequestValidation(
+  {name: 'assertIsolatedSeparateFiles', canBeForceIgnored: true},
   () => Validation,
 );
 

--- a/ng-dev/pr/common/validation/validate-pull-request.ts
+++ b/ng-dev/pr/common/validation/validate-pull-request.ts
@@ -15,7 +15,7 @@ import {PullRequestTarget} from '../targeting/target-label.js';
 import {changesAllowForTargetLabelValidation} from './assert-allowed-target-label.js';
 import {breakingChangeInfoValidation} from './assert-breaking-change-info.js';
 import {completedReviewsValidation} from './assert-completed-reviews.js';
-import {isolatePrimitivesValidation} from './assert-isolate-primitives.js';
+import {isolatedSeparateFilesValidation} from './assert-isolated-separate-files.js';
 import {enforcedStatusesValidation} from './assert-enforced-statuses.js';
 import {enforceTestedValidation} from './assert-enforce-tested.js';
 import {mergeReadyValidation} from './assert-merge-ready.js';
@@ -57,7 +57,12 @@ export async function assertValidPullRequest(
     breakingChangeInfoValidation.run(validationConfig, commitsInPr, labels),
     passingCiValidation.run(validationConfig, pullRequest),
     enforcedStatusesValidation.run(validationConfig, pullRequest, ngDevConfig.pullRequest),
-    isolatePrimitivesValidation.run(validationConfig, ngDevConfig, pullRequest.number, gitClient),
+    isolatedSeparateFilesValidation.run(
+      validationConfig,
+      ngDevConfig,
+      pullRequest.number,
+      gitClient,
+    ),
     enforceTestedValidation.run(validationConfig, pullRequest, gitClient.github),
   ];
 

--- a/ng-dev/pr/common/validation/validation-config.ts
+++ b/ng-dev/pr/common/validation/validation-config.ts
@@ -22,7 +22,7 @@ const defaultConfig: PullRequestValidationConfig = {
   assertCompletedReviews: true,
   assertEnforcedStatuses: true,
   assertMinimumReviews: true,
-  assertIsolatePrimitives: false,
+  assertIsolatedSeparateFiles: false,
   assertEnforceTested: false,
 };
 


### PR DESCRIPTION
This renames the isolated primitives validation to not reference primitives and instead be more generic.