### PR TITLE
fix(github-actions): handle input of sha to the branch manager

### DIFF
--- a/.github/workflows/branch-manager.yml
+++ b/.github/workflows/branch-manager.yml
@@ -12,6 +12,10 @@ on:
       pr:
         type: number
         required: true
+      # sha is optional, and unused in this action.
+      sha:
+        type: string
+        required: false
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Properly handle when a sha is provided to the branch manager by the downstream actions