### PR TITLE
feat(ng-dev): allow providing ESM config to ts-circular-dependencies

### DIFF
--- a/ng-dev/ts-circular-dependencies/config.ts
+++ b/ng-dev/ts-circular-dependencies/config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {dirname, isAbsolute, resolve} from 'path';
+import {dirname, extname, isAbsolute, resolve} from 'path';
 
 import {Log} from '../utils/logging.js';
 
@@ -42,12 +42,39 @@ export interface CircularDependenciesTestConfig extends CircularDependenciesPars
  * Loads the configuration for the circular dependencies test. If the config cannot be
  * loaded, an error will be printed and the process exists with a non-zero exit code.
  */
-export function loadTestConfig(configPath: string): CircularDependenciesTestConfig {
+export async function loadTestConfig(configPath: string): Promise<CircularDependenciesTestConfig> {
   const configBaseDir = dirname(configPath);
   const resolveRelativePath = (relativePath: string) => resolve(configBaseDir, relativePath);
 
   try {
-    const config = require(configPath) as CircularDependenciesTestConfig;
+    let config: CircularDependenciesTestConfig;
+    switch (extname(configPath)) {
+      case '.mjs':
+        // Load the ESM configuration file using the TypeScript dynamic import workaround.
+        // Once TypeScript provides support for keeping the dynamic import this workaround can be
+        // changed to a direct dynamic import.
+        config = await loadEsmModule<CircularDependenciesTestConfig>(configPath);
+        break;
+      case '.cjs':
+        config = require(configPath);
+        break;
+      default:
+        // The file could be either CommonJS or ESM.
+        // CommonJS is tried first then ESM if loading fails.
+        try {
+          config = require(configPath);
+        } catch (e) {
+          if ((e as any).code === 'ERR_REQUIRE_ESM') {
+            // Load the ESM configuration file using the TypeScript dynamic import workaround.
+            // Once TypeScript provides support for keeping the dynamic import this workaround can be
+            // changed to a direct dynamic import.
+            config = await loadEsmModule<CircularDependenciesTestConfig>(configPath);
+          }
+
+          throw e;
+        }
+    }
+
     if (!isAbsolute(config.baseDir)) {
       config.baseDir = resolveRelativePath(config.baseDir);
     }
@@ -63,4 +90,30 @@ export function loadTestConfig(configPath: string): CircularDependenciesTestConf
     Log.error(`Failed with error:`, e);
     process.exit(1);
   }
+}
+
+/**
+ * Lazily compiled dynamic import loader function.
+ */
+let load: (<T>(modulePath: string | URL) => Promise<T>) | undefined;
+
+/**
+ * This uses a dynamic import to load a module which may be ESM.
+ * CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
+ * will currently, unconditionally downlevel dynamic import into a require call.
+ * require calls cannot load ESM code and will result in a runtime error. To workaround
+ * this, a Function constructor is used to prevent TypeScript from changing the dynamic import.
+ * Once TypeScript provides support for keeping the dynamic import this workaround can
+ * be dropped.
+ *
+ * @param modulePath The path of the module to load.
+ * @returns A Promise that resolves to the dynamically imported module.
+ */
+export function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
+  load ??= new Function('modulePath', `return import(modulePath);`) as Exclude<
+    typeof load,
+    undefined
+  >;
+
+  return load(modulePath);
 }

--- a/ng-dev/ts-circular-dependencies/index.ts
+++ b/ng-dev/ts-circular-dependencies/index.ts
@@ -35,10 +35,10 @@ export function tsCircularDependenciesBuilder(localYargs: Argv) {
       'check',
       'Checks if the circular dependencies have changed.',
       (args) => args,
-      (argv) => {
+      async (argv) => {
         const {config: configArg, warnings} = argv;
         const configPath = isAbsolute(configArg) ? configArg : resolve(configArg);
-        const config = loadTestConfig(configPath);
+        const config = await loadTestConfig(configPath);
         process.exit(main(false, config, !!warnings));
       },
     )
@@ -46,10 +46,10 @@ export function tsCircularDependenciesBuilder(localYargs: Argv) {
       'approve',
       'Approves the current circular dependencies.',
       (args) => args,
-      (argv) => {
+      async (argv) => {
         const {config: configArg, warnings} = argv;
         const configPath = isAbsolute(configArg) ? configArg : resolve(configArg);
-        const config = loadTestConfig(configPath);
+        const config = await loadTestConfig(configPath);
         process.exit(main(true, config, !!warnings));
       },
     );


### PR DESCRIPTION
This commits add support for ESM config support.