### PR TITLE
fix(ng-dev): TypeError: Cannot assign to read only property 'baseDir' of object '[object Module]'

### DIFF
--- a/ng-dev/ts-circular-dependencies/config.ts
+++ b/ng-dev/ts-circular-dependencies/config.ts
@@ -75,6 +75,9 @@ export async function loadTestConfig(configPath: string): Promise<CircularDepend
         }
     }
 
+    // Clone to config object. This is needed because in ESM the properties are non writeable
+    config = {...config};
+
     if (!isAbsolute(config.baseDir)) {
       config.baseDir = resolveRelativePath(config.baseDir);
     }


### PR DESCRIPTION


Fix issue with proprties in configuration are not writable when the config is in ESM format.