### PR TITLE
refactor(docs): use utils pattern for cookie consent function

### DIFF
--- a/docs/components/cookie-popup/BUILD.bazel
+++ b/docs/components/cookie-popup/BUILD.bazel
@@ -15,6 +15,7 @@ ng_module(
     ],
     deps = [
         "//docs/providers",
+        "//docs/utils",
         "@npm//@angular/common",
         "@npm//@angular/core",
     ],

--- a/docs/components/cookie-popup/cookie-popup.component.ts
+++ b/docs/components/cookie-popup/cookie-popup.component.ts
@@ -9,6 +9,7 @@
 import {ChangeDetectionStrategy, Component, inject, signal} from '@angular/core';
 import {NgIf} from '@angular/common';
 import {LOCAL_STORAGE} from '../../providers/index';
+import {setCookieConsent} from '../../utils/analytics.utils';
 
 /**
  * Decelare gtag as part of the window in this file as gtag is expected to already be loaded.
@@ -16,35 +17,6 @@ import {LOCAL_STORAGE} from '../../providers/index';
 declare const window: Window & typeof globalThis & {gtag?: Function};
 
 export const STORAGE_KEY = 'docs-accepts-cookies';
-export function setCookieConsent(state: 'denied' | 'granted'): void {
-  try {
-    if (window.gtag) {
-      const consentOptions = {
-        ad_user_data: state,
-        ad_personalization: state,
-        ad_storage: state,
-        analytics_storage: state,
-      };
-
-      if (state === 'denied') {
-        window.gtag('consent', 'default', {
-          ...consentOptions,
-          wait_for_update: 500,
-        });
-      } else if (state === 'granted') {
-        window.gtag('consent', 'update', {
-          ...consentOptions,
-        });
-      }
-    }
-  } catch {
-    if (state === 'denied') {
-      console.error('Unable to set default cookie consent.');
-    } else if (state === 'granted') {
-      console.error('Unable to grant cookie consent.');
-    }
-  }
-}
 
 @Component({
   selector: 'docs-cookie-popup',

--- a/docs/components/cookie-popup/cookie-popup.component.ts
+++ b/docs/components/cookie-popup/cookie-popup.component.ts
@@ -9,7 +9,7 @@
 import {ChangeDetectionStrategy, Component, inject, signal} from '@angular/core';
 import {NgIf} from '@angular/common';
 import {LOCAL_STORAGE} from '../../providers/index';
-import {setCookieConsent} from '../../utils/analytics.utils';
+import {setCookieConsent} from '../../utils';
 
 /**
  * Decelare gtag as part of the window in this file as gtag is expected to already be loaded.

--- a/docs/utils/analytics.utils.ts
+++ b/docs/utils/analytics.utils.ts
@@ -1,0 +1,43 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+declare global {
+  interface Window {
+    gtag: (...args: any[]) => void;
+  }
+}
+
+export const setCookieConsent = (state: 'denied' | 'granted'): void => {
+  try {
+    if (window.gtag) {
+      const consentOptions = {
+        ad_user_data: state,
+        ad_personalization: state,
+        ad_storage: state,
+        analytics_storage: state,
+      };
+
+      if (state === 'denied') {
+        window.gtag('consent', 'default', {
+          ...consentOptions,
+          wait_for_update: 500,
+        });
+      } else if (state === 'granted') {
+        window.gtag('consent', 'update', {
+          ...consentOptions,
+        });
+      }
+    }
+  } catch {
+    if (state === 'denied') {
+      console.error('Unable to set default cookie consent.');
+    } else if (state === 'granted') {
+      console.error('Unable to grant cookie consent.');
+    }
+  }
+};

--- a/docs/utils/index.ts
+++ b/docs/utils/index.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+export * from './analytics.utils';
 export * from './animations.utils';
 export * from './device.utils';
 export * from './filesystem.utils';


### PR DESCRIPTION
It looks like the export function pattern I was using is not being picked up by BAZEL and thus not available in the build when being referenced in angular/angular.

So I used the utils pattern currently in use for other functions and believe this should expose the function correctly to the package.

Let me know if I'm mistaken though!