### PR TITLE
feat(bazel): support api generation for initializer APIs

### DIFF
--- a/bazel/api-gen/rendering/entities.ts
+++ b/bazel/api-gen/rendering/entities.ts
@@ -20,11 +20,13 @@ export enum EntryType {
   Element = 'element',
   Enum = 'enum',
   Function = 'function',
+  FunctionWithOverloads = 'function_with_overloads',
   Interface = 'interface',
   NgModule = 'ng_module',
   Pipe = 'pipe',
   TypeAlias = 'type_alias',
   UndecoratedClass = 'undecorated_class',
+  InitializerApiFunction = 'initializer_api_function',
 }
 
 /** Types of class members */
@@ -74,8 +76,6 @@ export interface DocEntry {
   description: string;
   rawComment: string;
   jsdocTags: JsDocTagEntry[];
-  isDeprecated: boolean;
-  isDeveloperPreview: boolean;
 }
 
 /** Documentation entity for a constant. */
@@ -126,6 +126,7 @@ export interface FunctionEntry extends DocEntry {
   params: ParameterEntry[];
   returnType: string;
   generics: GenericEntry[];
+  isNewType: boolean;
 }
 
 /** Sub-entry for a single class or enum member. */
@@ -161,4 +162,27 @@ export interface ParameterEntry {
   type: string;
   isOptional: boolean;
   isRestParam: boolean;
+}
+
+export interface FunctionWithOverloads {
+  name: string;
+  signatures: FunctionEntry[];
+  implementation: FunctionEntry | null;
+}
+
+export interface InitializerApiFunctionEntry extends DocEntry {
+  callFunction: FunctionWithOverloads;
+  subFunctions: FunctionWithOverloads[];
+
+  __adevMetadata__?: {
+    /**
+     * Whether types are should be shown in the signature
+     * preview of docs.
+     *
+     * By default, for readability purposes, types are omitted, but
+     * shorter initializer API functions like `output` may decide to
+     * render these types.
+     */
+    showTypesInSignaturePreview?: boolean;
+  };
 }

--- a/bazel/api-gen/rendering/entities.ts
+++ b/bazel/api-gen/rendering/entities.ts
@@ -174,7 +174,7 @@ export interface InitializerApiFunctionEntry extends DocEntry {
   callFunction: FunctionWithOverloads;
   subFunctions: FunctionWithOverloads[];
 
-  __adevMetadata__?: {
+  __docsMetadata__?: {
     /**
      * Whether types are should be shown in the signature
      * preview of docs.

--- a/bazel/api-gen/rendering/entities.ts
+++ b/bazel/api-gen/rendering/entities.ts
@@ -20,7 +20,6 @@ export enum EntryType {
   Element = 'element',
   Enum = 'enum',
   Function = 'function',
-  FunctionWithOverloads = 'function_with_overloads',
   Interface = 'interface',
   NgModule = 'ng_module',
   Pipe = 'pipe',

--- a/bazel/api-gen/rendering/entities/categorization.ts
+++ b/bazel/api-gen/rendering/entities/categorization.ts
@@ -1,4 +1,3 @@
-import {CliCommand} from '../cli-entities';
 import {
   ClassEntry,
   ConstantEntry,
@@ -6,6 +5,7 @@ import {
   EntryType,
   EnumEntry,
   FunctionEntry,
+  InitializerApiFunctionEntry,
   InterfaceEntry,
   MemberEntry,
   MemberType,
@@ -13,17 +13,21 @@ import {
   PropertyEntry,
   TypeAliasEntry,
 } from '../entities';
+
+import {CliCommand} from '../cli-entities';
+
 import {
   ClassEntryRenderable,
+  CliCommandRenderable,
   ConstantEntryRenderable,
   DocEntryRenderable,
   EnumEntryRenderable,
   FunctionEntryRenderable,
+  InitializerApiFunctionRenderable,
   InterfaceEntryRenderable,
   MemberEntryRenderable,
   MethodEntryRenderable,
   TypeAliasEntryRenderable,
-  CliCommandRenderable,
 } from './renderables';
 import {HasJsDocTags} from './traits';
 
@@ -83,6 +87,18 @@ export function isFunctionEntry(entry: DocEntryRenderable): entry is FunctionEnt
 export function isFunctionEntry(entry: DocEntry): entry is FunctionEntry;
 export function isFunctionEntry(entry: DocEntry): entry is FunctionEntry {
   return entry.entryType === EntryType.Function;
+}
+
+export function isInitializerApiFunctionEntry(
+  entry: DocEntryRenderable,
+): entry is InitializerApiFunctionRenderable;
+export function isInitializerApiFunctionEntry(
+  entry: DocEntry,
+): entry is InitializerApiFunctionEntry;
+export function isInitializerApiFunctionEntry(
+  entry: DocEntry,
+): entry is InitializerApiFunctionEntry {
+  return entry.entryType === EntryType.InitializerApiFunction;
 }
 
 /** Gets whether the given entry represents a property */

--- a/bazel/api-gen/rendering/entities/renderables.ts
+++ b/bazel/api-gen/rendering/entities/renderables.ts
@@ -6,18 +6,22 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {CliCommand, CliOption} from '../cli-entities';
 import {
   ClassEntry,
   ConstantEntry,
   DocEntry,
   EnumEntry,
   FunctionEntry,
+  InitializerApiFunctionEntry,
   JsDocTagEntry,
   MemberEntry,
   ParameterEntry,
   TypeAliasEntry,
 } from '../entities';
+
+import {CliCommand, CliOption} from '../cli-entities';
+
+import {HasRenderableToc} from './traits';
 
 /** JsDoc tag info augmented with transformed content for rendering. */
 export interface JsDocTagRenderable extends JsDocTagEntry {
@@ -32,6 +36,8 @@ export interface DocEntryRenderable extends DocEntry {
   jsdocTags: JsDocTagRenderable[];
   additionalLinks: LinkEntryRenderable[];
   htmlUsageNotes: string;
+  isDeprecated: boolean;
+  isDeveloperPreview: boolean;
 }
 
 /** Documentation entity for a constant augmented transformed content for rendering. */
@@ -118,3 +124,8 @@ export type CliCommandRenderable = CliCommand & {
   hasOptions: boolean;
   subcommands?: CliCommandRenderable[];
 };
+
+export interface InitializerApiFunctionRenderable
+  extends Omit<InitializerApiFunctionEntry, 'jsdocTags'>,
+    DocEntryRenderable,
+    HasRenderableToc {}

--- a/bazel/api-gen/rendering/entities/traits.ts
+++ b/bazel/api-gen/rendering/entities/traits.ts
@@ -1,9 +1,10 @@
 import {JsDocTagEntry, MemberEntry, ParameterEntry} from '../entities';
+
 import {
   CodeLineRenderable,
   JsDocTagRenderable,
-  MemberEntryRenderable,
   LinkEntryRenderable,
+  MemberEntryRenderable,
   ParameterEntryRenderable,
 } from './renderables';
 
@@ -79,4 +80,8 @@ export interface HasRenderableParams {
 
 export interface HasDeprecatedFlag {
   isDeprecated: boolean;
+}
+
+export interface HasDeveloperPreviewFlag {
+  isDeveloperPreview: boolean;
 }

--- a/bazel/api-gen/rendering/processing.ts
+++ b/bazel/api-gen/rendering/processing.ts
@@ -7,30 +7,34 @@
  */
 
 import {DocEntry} from './entities';
+
 import {CliCommand} from './cli-entities';
 import {
   isClassEntry,
+  isCliEntry,
   isConstantEntry,
   isEnumEntry,
-  isInterfaceEntry,
   isFunctionEntry,
+  isInitializerApiFunctionEntry,
+  isInterfaceEntry,
   isTypeAliasEntry,
-  isCliEntry,
 } from './entities/categorization';
 import {CliCommandRenderable, DocEntryRenderable} from './entities/renderables';
 import {getClassRenderable} from './transforms/class-transforms';
+import {getCliRenderable} from './transforms/cli-transforms';
 import {getConstantRenderable} from './transforms/constant-transforms';
 import {getEnumRenderable} from './transforms/enum-transforms';
-import {getInterfaceRenderable} from './transforms/interface-transforms';
 import {getFunctionRenderable} from './transforms/function-transforms';
+import {getInitializerApiFunctionRenderable} from './transforms/initializer-api-functions-transform';
+import {getInterfaceRenderable} from './transforms/interface-transforms';
 import {
   addHtmlAdditionalLinks,
   addHtmlDescription,
   addHtmlJsDocTagComments,
   addHtmlUsageNotes,
+  setEntryFlags,
 } from './transforms/jsdoc-transforms';
 import {addModuleName} from './transforms/module-name';
-import {getCliRenderable} from './transforms/cli-transforms';
 import {getTypeAliasRenderable} from './transforms/type-alias-transforms';
 
 export function getRenderable(
@@ -55,14 +59,19 @@ export function getRenderable(
   if (isTypeAliasEntry(entry)) {
     return getTypeAliasRenderable(entry, moduleName);
   }
+  if (isInitializerApiFunctionEntry(entry)) {
+    return getInitializerApiFunctionRenderable(entry, moduleName);
+  }
   if (isCliEntry(entry)) {
     return getCliRenderable(entry);
   }
 
   // Fallback to an uncategorized renderable.
-  return addHtmlAdditionalLinks(
-    addHtmlDescription(
-      addHtmlUsageNotes(addHtmlJsDocTagComments(addModuleName(entry, moduleName))),
+  return setEntryFlags(
+    addHtmlAdditionalLinks(
+      addHtmlDescription(
+        addHtmlUsageNotes(addHtmlJsDocTagComments(addModuleName(entry, moduleName))),
+      ),
     ),
   );
 }

--- a/bazel/api-gen/rendering/rendering.ts
+++ b/bazel/api-gen/rendering/rendering.ts
@@ -7,23 +7,26 @@
  */
 
 import {render} from 'preact-render-to-string';
+
 import {
   isClassEntry,
+  isCliEntry,
   isConstantEntry,
   isEnumEntry,
-  isInterfaceEntry,
   isFunctionEntry,
+  isInitializerApiFunctionEntry,
+  isInterfaceEntry,
   isTypeAliasEntry,
-  isCliEntry,
 } from './entities/categorization';
 import {CliCommandRenderable, DocEntryRenderable} from './entities/renderables';
 import {ClassReference} from './templates/class-reference';
+import {CliCommandReference} from './templates/cli-reference';
 import {ConstantReference} from './templates/constant-reference';
+import {DocsReference} from './templates/docs-reference';
 import {EnumReference} from './templates/enum-reference';
 import {FunctionReference} from './templates/function-reference';
-import {CliCommandReference} from './templates/cli-reference';
+import {InitializerApiFunction} from './templates/initializer-api-function';
 import {TypeAliasReference} from './templates/type-alias-reference';
-import {DocsReference} from './templates/docs-reference';
 
 /** Given a doc entry, get the transformed version of the entry for rendering. */
 export function renderEntry(renderable: DocEntryRenderable | CliCommandRenderable): string {
@@ -45,6 +48,9 @@ export function renderEntry(renderable: DocEntryRenderable | CliCommandRenderabl
   }
   if (isTypeAliasEntry(renderable)) {
     return render(TypeAliasReference(renderable));
+  }
+  if (isInitializerApiFunctionEntry(renderable)) {
+    return render(InitializerApiFunction(renderable));
   }
 
   // Fall back rendering nothing while in development.

--- a/bazel/api-gen/rendering/templates/header-api.tsx
+++ b/bazel/api-gen/rendering/templates/header-api.tsx
@@ -18,7 +18,7 @@ import {
 import {DocsPillRow} from './docs-pill-row';
 
 /** Component to render a header of the API page. */
-export function HeaderApi(props: {entry: DocEntryRenderable}) {
+export function HeaderApi(props: {entry: DocEntryRenderable, showFullDescription?: boolean}) {
   const entry = props.entry;
 
   return (
@@ -50,7 +50,7 @@ export function HeaderApi(props: {entry: DocEntryRenderable}) {
 
       <p
         className={'docs-reference-description'}
-        dangerouslySetInnerHTML={{__html: entry.shortHtmlDescription}}
+        dangerouslySetInnerHTML={{__html: props.showFullDescription ? entry.htmlDescription : entry.shortHtmlDescription}}
       ></p>
 
       <DocsPillRow links={entry.additionalLinks} />
@@ -66,6 +66,8 @@ function getEntryTypeDisplayName(entryType: EntryType | string): string {
       return 'Type Alias';
     case EntryType.UndecoratedClass:
       return 'Class';
+    case EntryType.InitializerApiFunction:
+      return 'Initializer API';
   }
   return entryType;
 }

--- a/bazel/api-gen/rendering/templates/highlight-ts.tsx
+++ b/bazel/api-gen/rendering/templates/highlight-ts.tsx
@@ -1,0 +1,20 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import highlightJs from 'highlight.js';
+import { h } from 'preact';
+import { RawHtml } from './raw-html';
+
+/** Component to render a header of the CLI page. */
+export function HighlightTypeScript(props: {code: string}) {
+  const result = highlightJs.highlight(props.code, {language: 'typescript'}).value;
+
+  return (
+    <RawHtml value={result} />
+  );
+}

--- a/bazel/api-gen/rendering/templates/initializer-api-function.tsx
+++ b/bazel/api-gen/rendering/templates/initializer-api-function.tsx
@@ -1,0 +1,102 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {h, JSX} from 'preact';
+import {FunctionEntryRenderable, InitializerApiFunctionRenderable} from '../entities/renderables';
+import {HeaderApi} from './header-api';
+import {TabApi} from './tab-api';
+import {TabUsageNotes} from './tab-usage-notes';
+import {
+  REFERENCE_MEMBERS,
+  REFERENCE_MEMBERS_CONTAINER,
+  REFERENCE_MEMBER_CARD,
+  REFERENCE_MEMBER_CARD_BODY,
+} from '../styling/css-classes';
+import {printInitializerFunctionSignatureLine} from '../transforms/code-transforms';
+import {HighlightTypeScript} from './highlight-ts';
+import {ClassMethodInfo} from './class-method-info';
+import {getFunctionRenderable} from '../transforms/function-transforms';
+
+/** Component to render a constant API reference document. */
+export function InitializerApiFunction(entry: InitializerApiFunctionRenderable) {
+  // Use signatures as header if there are multiple signatures.
+  const printSignaturesAsHeader =
+    entry.callFunction.signatures.length > 1 ||
+    entry.subFunctions.some((sub) => sub.signatures.length > 1);
+
+  // If the initializer API function is just a function, checked by existence of an
+  // implementation, and the descriptions of the "API" and the first function match,
+  // avoid rendering it another time in the member card.
+  if (
+    entry.callFunction.signatures.length === 1 &&
+    entry.callFunction.implementation !== null &&
+    entry.description === entry.callFunction.signatures[0].description
+  ) {
+    entry.callFunction.signatures[0].description = '';
+  }
+
+  const signatureCard = (name: string, signature: FunctionEntryRenderable, opts: {id: string}) => {
+    return (
+      <div class={REFERENCE_MEMBER_CARD} id={opts.id} tabIndex={-1}>
+        <header>
+          {printSignaturesAsHeader ? (
+            <code>
+              <HighlightTypeScript
+                code={printInitializerFunctionSignatureLine(
+                  name,
+                  signature,
+                  // Always omit types in signature headers, to keep them short.
+                  true,
+                )}
+              />
+            </code>
+          ) : (
+            <h3>{`${name}()`}</h3>
+          )}
+        </header>
+        <div class={REFERENCE_MEMBER_CARD_BODY}>
+          <ClassMethodInfo entry={signature} />
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div class="api">
+      <HeaderApi entry={entry} showFullDescription={true} />
+      <TabApi entry={entry} />
+      <TabUsageNotes entry={entry} />
+
+      <div class={REFERENCE_MEMBERS_CONTAINER}>
+        <div class={REFERENCE_MEMBERS}>
+          {entry.callFunction.signatures.map((s, i) =>
+            signatureCard(s.name, getFunctionRenderable(s, entry.moduleName), {
+              id: `${s.name}_${i}`,
+            }),
+          )}
+
+          {entry.subFunctions.reduce(
+            (elements, subFunction) => [
+              ...elements,
+              ...subFunction.signatures.map((s, i) =>
+                signatureCard(
+                  `${entry.name}.${s.name}`,
+                  getFunctionRenderable(s, entry.moduleName),
+                  {
+                    id: `${entry.name}_${s.name}_${i}`,
+                  },
+                ),
+              ),
+            ],
+            [] as JSX.Element[],
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/bazel/api-gen/rendering/transforms/code-transforms.ts
+++ b/bazel/api-gen/rendering/transforms/code-transforms.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import highlightJs from 'highlight.js';
 import {
   DocEntry,
   FunctionEntry,
@@ -15,6 +14,8 @@ import {
   ParameterEntry,
   PropertyEntry,
 } from '../entities';
+import highlightJs from 'highlight.js';
+
 import {
   isClassEntry,
   isClassMethodEntry,
@@ -23,12 +24,14 @@ import {
   isEnumEntry,
   isFunctionEntry,
   isGetterEntry,
+  isInitializerApiFunctionEntry,
   isInterfaceEntry,
   isSetterEntry,
   isTypeAliasEntry,
 } from '../entities/categorization';
 import {CodeLineRenderable} from '../entities/renderables';
 import {HasModuleName, HasRenderableToc} from '../entities/traits';
+
 import {filterLifecycleMethods, mergeGettersAndSetters} from './member-transforms';
 
 // Allows to generate links for code lines.
@@ -131,6 +134,51 @@ export function mapDocEntryToCode(entry: DocEntry): CodeTableOfContentsData {
     };
   }
 
+  if (isInitializerApiFunctionEntry(entry)) {
+    const codeLineNumbersWithIdentifiers = new Map<number, string>();
+    const showTypesInSignaturePreview = !!entry.__adevMetadata__?.showTypesInSignaturePreview;
+
+    let lines: string[] = [];
+    for (const [index, callSignature] of entry.callFunction.signatures.entries()) {
+      lines.push(
+        printInitializerFunctionSignatureLine(
+          callSignature.name,
+          callSignature,
+          showTypesInSignaturePreview,
+        ),
+      );
+      const id = `${callSignature.name}_${index}`;
+      codeLineNumbersWithIdentifiers.set(lines.length - 1, id);
+    }
+
+    if (Object.keys(entry.subFunctions).length > 0) {
+      lines.push('');
+
+      for (const [i, subFunction] of entry.subFunctions.entries()) {
+        for (const [index, subSignature] of subFunction.signatures.entries()) {
+          lines.push(
+            printInitializerFunctionSignatureLine(
+              `${entry.name}.${subFunction.name}`,
+              subSignature,
+              showTypesInSignaturePreview,
+            ),
+          );
+          const id = `${entry.name}_${subFunction.name}_${index}`;
+          codeLineNumbersWithIdentifiers.set(lines.length - 1, id);
+        }
+        if (i < entry.subFunctions.length - 1) {
+          lines.push('');
+        }
+      }
+    }
+
+    return {
+      contents: lines.join('\n'),
+      codeLineNumbersWithIdentifiers,
+      deprecatedLineNumbers: [],
+    };
+  }
+
   if (isTypeAliasEntry(entry)) {
     const isDeprecated = isDeprecatedEntry(entry);
     const contents = `type ${entry.name} = ${entry.type}`;
@@ -166,7 +214,8 @@ function getCodeTocData(members: MemberEntry[], hasPrefixLine: boolean): CodeTab
     codeLineNumbersWithIdentifiers: new Map<number, string>(),
     deprecatedLineNumbers: [],
   };
-  // In case when hasPrefixLine is true we should take it into account when we're generating `codeLineNumbersWithIdentifiers` below.
+  // In case when hasPrefixLine is true we should take it into account when we're generating
+  // `codeLineNumbersWithIdentifiers` below.
   const skip = !!hasPrefixLine ? 1 : 0;
 
   return members.reduce((acc: CodeTableOfContentsData, curr: MemberEntry, index: number) => {
@@ -211,13 +260,11 @@ function getMethodCodeLine(
     }`;
   };
 
-  return `${memberTags.join(' ')} ${member.name}(${
-    displayParamsInNewLines ? '\n  ' : ''
-  }${member.params
+  return `${memberTags.join(' ')} ${member.name}(${displayParamsInNewLines ? '\n  ' : ''}${member.params
     .map((param) => mapParamEntry(param))
-    .join(`,${displayParamsInNewLines ? '\n  ' : ' '}`)}${displayParamsInNewLines ? '\n' : ''}): ${
-    member.returnType
-  };`.trim();
+    .join(`,${displayParamsInNewLines ? '\n  ' : ' '}`)}${
+    displayParamsInNewLines ? '\n' : ''
+  }): ${member.returnType};`.trim();
 }
 
 function getGetterCodeLine(member: PropertyEntry): string {
@@ -248,6 +295,49 @@ function getTags(member: PropertyEntry): string[] {
 
 function getNumberOfLinesOfCode(contents: string): number {
   return contents.split('\n').length;
+}
+
+/** Prints an initializer function signature into a single line. */
+export function printInitializerFunctionSignatureLine(
+  name: string,
+  signature: FunctionEntry,
+  showTypesInSignaturePreview: boolean,
+): string {
+  let res = name;
+  if (signature.generics.length > 0) {
+    res += '<';
+    for (let i = 0; i < signature.generics.length; i++) {
+      const generic = signature.generics[i];
+      res += generic.name;
+      if (generic.default !== undefined) {
+        res += ` = ${generic.default}`;
+      }
+      if (i < signature.generics.length - 1) {
+        res += ', ';
+      }
+    }
+    res += '>';
+  }
+  res += '(';
+  for (let i = 0; i < signature.params.length; i++) {
+    const param = signature.params[i];
+    if (param.isRestParam) {
+      res += '...';
+    }
+    res += `${param.name}${markOptional(param.isOptional)}`;
+    if (showTypesInSignaturePreview) {
+      res += `: ${param.type}`;
+    }
+    if (i < signature.params.length - 1) {
+      res += ', ';
+    }
+  }
+  res += ')';
+  if (showTypesInSignaturePreview) {
+    res += `: ${signature.returnType}`;
+  }
+  res += ';';
+  return res;
 }
 
 function appendPrefixAndSuffix(entry: DocEntry, codeTocData: CodeTableOfContentsData): void {

--- a/bazel/api-gen/rendering/transforms/code-transforms.ts
+++ b/bazel/api-gen/rendering/transforms/code-transforms.ts
@@ -136,7 +136,7 @@ export function mapDocEntryToCode(entry: DocEntry): CodeTableOfContentsData {
 
   if (isInitializerApiFunctionEntry(entry)) {
     const codeLineNumbersWithIdentifiers = new Map<number, string>();
-    const showTypesInSignaturePreview = !!entry.__adevMetadata__?.showTypesInSignaturePreview;
+    const showTypesInSignaturePreview = !!entry.__docsMetadata__?.showTypesInSignaturePreview;
 
     let lines: string[] = [];
     for (const [index, callSignature] of entry.callFunction.signatures.entries()) {

--- a/bazel/api-gen/rendering/transforms/initializer-api-functions-transform.ts
+++ b/bazel/api-gen/rendering/transforms/initializer-api-functions-transform.ts
@@ -1,0 +1,28 @@
+import {InitializerApiFunctionEntry} from '../entities';
+
+import {InitializerApiFunctionRenderable} from '../entities/renderables';
+
+import {addRenderableCodeToc} from './code-transforms';
+import {
+  addHtmlAdditionalLinks,
+  addHtmlDescription,
+  addHtmlJsDocTagComments,
+  addHtmlUsageNotes,
+  setEntryFlags,
+} from './jsdoc-transforms';
+import {addModuleName} from './module-name';
+
+export function getInitializerApiFunctionRenderable(
+  entry: InitializerApiFunctionEntry,
+  moduleName: string,
+): InitializerApiFunctionRenderable {
+  return setEntryFlags(
+    addRenderableCodeToc(
+      addHtmlJsDocTagComments(
+        addHtmlUsageNotes(
+          addHtmlDescription(addHtmlAdditionalLinks(addModuleName(entry, moduleName))),
+        ),
+      ),
+    ),
+  );
+}

--- a/bazel/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/bazel/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -6,21 +6,24 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {marked} from 'marked';
-import {rewriteLinks} from '../backwards-compatibility/links-mapper';
 import {JsDocTagEntry} from '../entities';
+import {marked} from 'marked';
+
+import {rewriteLinks} from '../backwards-compatibility/links-mapper';
 import {isDeprecatedEntry, isDeveloperPreview} from '../entities/categorization';
 import {LinkEntryRenderable} from '../entities/renderables';
 import {
   HasAdditionalLinks,
   HasDeprecatedFlag,
   HasDescription,
+  HasDeveloperPreviewFlag,
   HasHtmlDescription,
   HasHtmlUsageNotes,
   HasJsDocTags,
   HasModuleName,
   HasRenderableJsDocTags,
 } from '../entities/traits';
+
 import {getLinkToModule} from './url-transforms';
 
 export const JS_DOC_USAGE_NOTES_TAG = 'usageNotes';
@@ -95,7 +98,9 @@ export function getHtmlForJsDocText(text: string): string {
   return marked.parse(wrapExampleHtmlElementsWithCode(text)) as string;
 }
 
-export function setEntryFlags<T extends HasJsDocTags>(entry: T): T & HasDeprecatedFlag {
+export function setEntryFlags<T extends HasJsDocTags>(
+  entry: T,
+): T & HasDeprecatedFlag & HasDeveloperPreviewFlag {
   return {
     ...entry,
     isDeprecated: isDeprecatedEntry(entry),
@@ -143,9 +148,11 @@ function getHtmlAdditionalLinks<T extends HasJsDocTags & HasModuleName>(
   return seeAlsoLinks;
 }
 
-/** Some descriptions in the text contain HTML elements like `input` or `img`,
+/**
+ * Some descriptions in the text contain HTML elements like `input` or `img`,
  *  we should wrap such elements using `code`.
- *  Otherwise DocViewer will try to render those elements. */
+ *  Otherwise DocViewer will try to render those elements.
+ */
 function wrapExampleHtmlElementsWithCode(text: string) {
   return text
     .replaceAll(`'<input>'`, `<code><input></code>`)

--- a/bazel/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/bazel/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -150,8 +150,8 @@ function getHtmlAdditionalLinks<T extends HasJsDocTags & HasModuleName>(
 
 /**
  * Some descriptions in the text contain HTML elements like `input` or `img`,
- *  we should wrap such elements using `code`.
- *  Otherwise DocViewer will try to render those elements.
+ * we should wrap such elements using `code`.
+ * Otherwise DocViewer will try to render those elements.
  */
 function wrapExampleHtmlElementsWithCode(text: string) {
   return text

--- a/bazel/api-gen/rendering/transforms/member-transforms.ts
+++ b/bazel/api-gen/rendering/transforms/member-transforms.ts
@@ -7,9 +7,11 @@
  */
 
 import {MemberEntry, MemberTags, MemberType} from '../entities';
+
 import {isClassMethodEntry} from '../entities/categorization';
 import {MemberEntryRenderable} from '../entities/renderables';
 import {HasMembers, HasRenderableMembers, HasRenderableMembersGroups} from '../entities/traits';
+
 import {addHtmlDescription, addHtmlJsDocTagComments, setEntryFlags} from './jsdoc-transforms';
 
 const lifecycleMethods = [

--- a/bazel/api-gen/rendering/transforms/module-name.ts
+++ b/bazel/api-gen/rendering/transforms/module-name.ts
@@ -7,6 +7,7 @@
  */
 
 import {DocEntry} from '../entities';
+
 import {HasModuleName} from '../entities/traits';
 
 export function addModuleName<T extends DocEntry>(entry: T, moduleName: string): T & HasModuleName {


### PR DESCRIPTION
Adds support for API generation of initializer APIs like the new `input`, `model`, `output` etc.

This commit:

* Updates `entities.ts` to match upcoming changes in the compiler to identify initializer APIs. Unfortunately cannot use the direct import yet- due to a circular dep.
* Adds a new renderable entry for initializer API
* Implements the rendering of the initializer API
* Fixes an issue where the `isDeveloperPreview` detection accidentally worked— but in practice is a field only for renderable entries.
* Syncs the `entities.ts` for other fields like `isNewType`


![image](https://github.com/angular/dev-infra/assets/4987015/0f466b0e-55f8-4eaa-bb3a-bc6249f6750f)
