### PR TITLE
fix(ng-dev/format): remove obsolete load-on-top buildifier warning usage

### DIFF
--- a/ng-dev/format/formatters/buildifier.ts
+++ b/ng-dev/format/formatters/buildifier.ts
@@ -50,6 +50,6 @@ export class Buildifier extends Formatter {
 const BAZEL_WARNING_FLAG =
   `--warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,` +
   `attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,` +
-  `duplicated-name,filetype,git-repository,http-archive,integer-division,load,load-on-top,` +
+  `duplicated-name,filetype,git-repository,http-archive,integer-division,load,` +
   `native-build,native-package,output-group,package-name,package-on-top,positional-args,` +
   `redefined-variable,repository-name,same-origin-load,string-iteration,unused-variable`;


### PR DESCRIPTION
The buildifier `load-on-top` warning is now obsolete and will be automatically applied when formatting. The presence of the warning name on the format command line will result in an error (`unexpected warning "load-on-top"`) on newer versions of buildifier.

https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#load-statements-should-be-at-the-top-of-the-file