### PR TITLE
fix(ng-dev): fixes match function for primitives

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -71867,7 +71867,7 @@ function transformConfigIntoMatcher(config) {
   const alwaysExternalFilePatterns = config.alwaysExternalFilePatterns.map((p) => new Minimatch(p));
   const separateFilePatterns = config.separateFilePatterns.map((p) => new Minimatch(p));
   const ngSyncMatchFn = (projectRelativePath) => syncedFilePatterns.some((p) => p.match(projectRelativePath)) && alwaysExternalFilePatterns.every((p) => !p.match(projectRelativePath)) && separateFilePatterns.every((p) => !p.match(projectRelativePath));
-  const separateSyncMatchFn = (projectRelativePath) => separateFilePatterns.some((p) => p.match(projectRelativePath)) && alwaysExternalFilePatterns.every((p) => !p.match(projectRelativePath)) && syncedFilePatterns.every((p) => !p.match(projectRelativePath));
+  const separateSyncMatchFn = (projectRelativePath) => separateFilePatterns.some((p) => p.match(projectRelativePath)) && alwaysExternalFilePatterns.every((p) => !p.match(projectRelativePath));
   return { ngSyncMatchFn, separateSyncMatchFn };
 }
 async function getGoogleSyncConfig(absolutePath) {

--- a/github-actions/google-internal-tests/main.js
+++ b/github-actions/google-internal-tests/main.js
@@ -28539,7 +28539,7 @@ function transformConfigIntoMatcher(config) {
   const alwaysExternalFilePatterns = config.alwaysExternalFilePatterns.map((p) => new Minimatch(p));
   const separateFilePatterns = config.separateFilePatterns.map((p) => new Minimatch(p));
   const ngSyncMatchFn = (projectRelativePath) => syncedFilePatterns.some((p) => p.match(projectRelativePath)) && alwaysExternalFilePatterns.every((p) => !p.match(projectRelativePath)) && separateFilePatterns.every((p) => !p.match(projectRelativePath));
-  const separateSyncMatchFn = (projectRelativePath) => separateFilePatterns.some((p) => p.match(projectRelativePath)) && alwaysExternalFilePatterns.every((p) => !p.match(projectRelativePath)) && syncedFilePatterns.every((p) => !p.match(projectRelativePath));
+  const separateSyncMatchFn = (projectRelativePath) => separateFilePatterns.some((p) => p.match(projectRelativePath)) && alwaysExternalFilePatterns.every((p) => !p.match(projectRelativePath));
   return { ngSyncMatchFn, separateSyncMatchFn };
 }
 async function getGoogleSyncConfig(absolutePath) {

--- a/ng-dev/utils/g3-sync-config.ts
+++ b/ng-dev/utils/g3-sync-config.ts
@@ -53,8 +53,8 @@ export function transformConfigIntoMatcher(config: GoogleSyncConfig): {
   // match only files that need to be synced separately
   const separateSyncMatchFn = (projectRelativePath: string) =>
     separateFilePatterns.some((p) => p.match(projectRelativePath)) &&
-    alwaysExternalFilePatterns.every((p) => !p.match(projectRelativePath)) &&
-    syncedFilePatterns.every((p) => !p.match(projectRelativePath));
+    alwaysExternalFilePatterns.every((p) => !p.match(projectRelativePath));
+
   return {ngSyncMatchFn, separateSyncMatchFn};
 }
 


### PR DESCRIPTION
the primitives match function was skipping all primitives files. This change ensures that does not happen.