### PR TITLE
fix(ng-dev/format): remove obsolete load-on-top buildifier warning

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -70368,7 +70368,7 @@ var Buildifier = class extends Formatter {
     };
   }
 };
-var BAZEL_WARNING_FLAG = `--warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,native-build,native-package,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,same-origin-load,string-iteration,unused-variable`;
+var BAZEL_WARNING_FLAG = `--warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,native-build,native-package,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,string-iteration,unused-variable`;
 
 // 
 import { join as join3 } from "path";

--- a/ng-dev/format/formatters/buildifier.ts
+++ b/ng-dev/format/formatters/buildifier.ts
@@ -52,4 +52,4 @@ const BAZEL_WARNING_FLAG =
   `attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,` +
   `duplicated-name,filetype,git-repository,http-archive,integer-division,load,` +
   `native-build,native-package,output-group,package-name,package-on-top,positional-args,` +
-  `redefined-variable,repository-name,same-origin-load,string-iteration,unused-variable`;
+  `redefined-variable,repository-name,string-iteration,unused-variable`;


### PR DESCRIPTION
The buildifier `same-origin-load` warning is now obsolete and will be automatically applied when formatting. The presence of the warning name on the format command line will result in an error (`unexpected warning "same-origin-load"`) on newer versions of buildifier.

https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#same-origin-load