### PR TITLE
feat(bazel/browsers): update firefox and chromium

### DIFF
--- a/bazel/browsers/chromium/chromium.bzl
+++ b/bazel/browsers/chromium/chromium.bzl
@@ -12,11 +12,11 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromium_linux_x64",
         licenses = ["notice"],  # BSD 3-clause (maybe more?)
-        sha256 = "4e89a56b61db2fe494d4072d551b24e81833608318c5ba347b5d16a19687674e",
+        sha256 = "e45b0439b7f69e0e885d6cae9535a9f1e5f0c206fd619044288e9a53e8a004c7",
         # 114.0.5673.0
         urls = [
-            "https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1121551/chrome-linux.zip",
-            "https://storage.googleapis.com/dev-infra-mirror/chromium/1121551/linux_x64/browser-bin.zip",
+            "https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1263141/chrome-linux.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/1263141/linux_x64/browser-bin.zip",
         ],
         named_files = {
             "CHROMIUM": "chrome-linux/chrome",
@@ -31,11 +31,11 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromium_macos_x64",
         licenses = ["notice"],  # BSD 3-clause (maybe more?)
-        sha256 = "c03e32f338dffee3404881b4950563d26812d0246c1372ad2f4800547382bb91",
+        sha256 = "c18ba7a79fda6bc82229fd9ff685ff0d7b41ab32845b7fb989daecd8a2b10a00",
         # 114.0.5673.0
         urls = [
-            "https://storage.googleapis.com/chromium-browser-snapshots/Mac/1121551/chrome-mac.zip",
-            "https://storage.googleapis.com/dev-infra-mirror/chromium/1121551/mac_x64/browser-bin.zip",
+            "https://storage.googleapis.com/chromium-browser-snapshots/Mac/1263141/chrome-mac.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/1263141/mac_x64/browser-bin.zip",
         ],
         named_files = {
             "CHROMIUM": "chrome-mac/Chromium.app/Contents/MacOS/Chromium",
@@ -50,11 +50,11 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromium_macos_arm64",
         licenses = ["notice"],  # BSD 3-clause (maybe more?)
-        sha256 = "4eb94b113fc995d20fafeca366b4b0cddf172ac1b2cdedc053464b764b74d1c0",
+        sha256 = "2debe4e82002cd898a7573a1e132fafd2cb21a5af70c811fda50ebe9abe37d08",
         # 114.0.5673.0
         urls = [
-            "https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1121551/chrome-mac.zip",
-            "https://storage.googleapis.com/dev-infra-mirror/chromium/1121551/mac_arm64/browser-bin.zip",
+            "https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1263141/chrome-mac.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/1263141/mac_arm64/browser-bin.zip",
         ],
         named_files = {
             "CHROMIUM": "chrome-mac/Chromium.app/Contents/MacOS/Chromium",
@@ -69,11 +69,11 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromium_windows",
         licenses = ["notice"],  # BSD 3-clause (maybe more?)
-        sha256 = "fdc221bb1e898ab851c4a5bc50ca1f88a5b388acb5510df4c4606c87d8be0230",
+        sha256 = "05f0d21f822531ab05e1daa33fb7bf1fcec51a2b6103a3f8b2b3edf3a3cd0ce0",
         # 114.0.5673.0
         urls = [
-            "https://storage.googleapis.com/chromium-browser-snapshots/Win/1121551/chrome-win.zip",
-            "https://storage.googleapis.com/dev-infra-mirror/chromium/1121551/windows_x64/browser-bin.zip",
+            "https://storage.googleapis.com/chromium-browser-snapshots/Win/1263141/chrome-win.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/1263141/windows_x64/browser-bin.zip",
         ],
         named_files = {
             "CHROMIUM": "chrome-win/chrome.exe",
@@ -90,10 +90,10 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromedriver_linux_x64",
         licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-        sha256 = "8b9823d07706db02d0f83189c7d658fff14796ccb07f3eac3b327f3f0230f6c7",
+        sha256 = "3bd1ed0fee4153ab78eb61109c73657a965f6eabbbba8d0895626967b068beaa",
         urls = [
-            "https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1121551/chromedriver_linux64.zip",
-            "https://storage.googleapis.com/dev-infra-mirror/chromium/1121551/linux_x64/driver-bin.zip",
+            "https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1263141/chromedriver_linux64.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/1263141/linux_x64/driver-bin.zip",
         ],
         named_files = {
             "CHROMEDRIVER": "chromedriver_linux64/chromedriver",
@@ -103,10 +103,10 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromedriver_macos_x64",
         licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-        sha256 = "1c66bd01e53ee406f9f30d5f9ccbf4ea0f9c0f1b959c6ace9758cf0d35a6e4b3",
+        sha256 = "1a08bdfb06bd395caafbbb5fe9be982edf5c3c5d07e8082b06f0cf416389a5af",
         urls = [
-            "https://storage.googleapis.com/chromium-browser-snapshots/Mac/1121551/chromedriver_mac64.zip",
-            "https://storage.googleapis.com/dev-infra-mirror/chromium/1121551/mac_x64/driver-bin.zip",
+            "https://storage.googleapis.com/chromium-browser-snapshots/Mac/1263141/chromedriver_mac64.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/1263141/mac_x64/driver-bin.zip",
         ],
         named_files = {
             "CHROMEDRIVER": "chromedriver_mac64/chromedriver",
@@ -116,10 +116,10 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromedriver_macos_arm64",
         licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-        sha256 = "7eba8dd97537ca787628ae11346e5c897473c0c0871df0fc4a313bd4a48a83dc",
+        sha256 = "0548bc04cd7d3a9016002034bc30b1df18283612fe99bb7cf1811a60258d60a0",
         urls = [
-            "https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1121551/chromedriver_mac64.zip",
-            "https://storage.googleapis.com/dev-infra-mirror/chromium/1121551/mac_arm64/driver-bin.zip",
+            "https://storage.googleapis.com/chromium-browser-snapshots/Mac_Arm/1263141/chromedriver_mac64.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/1263141/mac_arm64/driver-bin.zip",
         ],
         named_files = {
             "CHROMEDRIVER": "chromedriver_mac64/chromedriver",
@@ -129,10 +129,10 @@ def define_chromium_repositories():
     browser_archive(
         name = "org_chromium_chromedriver_windows",
         licenses = ["reciprocal"],  # BSD 3-clause, ICU, MPL 1.1, libpng (BSD/MIT-like), Academic Free License v. 2.0, BSD 2-clause, MIT
-        sha256 = "db94b7f35041e3a76fa9a50808f196e61c27f43762df99526c1876244a196526",
+        sha256 = "fe9dd78b5257a804bb46d81225af84da6eaa5308ce7a69a4b96d31fb31e2c834",
         urls = [
-            "https://storage.googleapis.com/chromium-browser-snapshots/Win/1121551/chromedriver_win32.zip",
-            "https://storage.googleapis.com/dev-infra-mirror/chromium/1121551/windows_x64/driver-bin.zip",
+            "https://storage.googleapis.com/chromium-browser-snapshots/Win/1263141/chromedriver_win32.zip",
+            "https://storage.googleapis.com/dev-infra-mirror/chromium/1263141/windows_x64/driver-bin.zip",
         ],
         named_files = {
             "CHROMEDRIVER": "chromedriver_win32/chromedriver.exe",

--- a/bazel/browsers/firefox/firefox.bzl
+++ b/bazel/browsers/firefox/firefox.bzl
@@ -12,11 +12,11 @@ def define_firefox_repositories():
     browser_archive(
         name = "org_mozilla_firefox_linux_x64",
         licenses = ["reciprocal"],  # MPL 2.0
-        sha256 = "3d0f74790fe6ff5e38324222ab0c47e10edb31970ed67c6dd7a1c84e7017d1a5",
-        # Firefox v97.0
+        sha256 = "0f702f7690b02953e336fac27874276d9d471c9d264dc0feb7fcc6693d63bd4b",
+        # Firefox v125.0.1
         urls = [
-            "https://ftp.mozilla.org/pub/firefox/releases/97.0/linux-x86_64/en-US/firefox-97.0.tar.bz2",
-            "https://storage.googleapis.com/dev-infra-mirror/firefox/97.0/linux_x64/browser-bin.tar.bz2",
+            "https://ftp.mozilla.org/pub/firefox/releases/125.0.1/linux-x86_64/en-US/firefox-125.0.1.tar.bz2",
+            "https://storage.googleapis.com/dev-infra-mirror/firefox/125.0.1/linux_x64/browser-bin.tar.bz2",
         ],
         named_files = {
             "FIREFOX": "firefox/firefox",
@@ -27,11 +27,11 @@ def define_firefox_repositories():
         # Firefox has a launcher that conditionally starts x64/arm64
         name = "org_mozilla_firefox_macos",
         licenses = ["reciprocal"],  # MPL 2.0
-        sha256 = "c06c4e58179acaf55d05c3be41d0d4cdd68f811a75322a39557d91121aa2ef74",
-        # Firefox v97.0
+        sha256 = "3f431079d423e5397987a4120a63948217252426219f23348cb6b6bbded3acf3",
+        # Firefox v125.0.1
         urls = [
-            "https://ftp.mozilla.org/pub/firefox/releases/97.0/mac/en-US/Firefox%2097.0.dmg",
-            "https://storage.googleapis.com/dev-infra-mirror/firefox/97.0/mac_x64/browser-bin.dmg",
+            "https://ftp.mozilla.org/pub/firefox/releases/125.0.1/mac/en-US/Firefox%20125.0.1.dmg",
+            "https://storage.googleapis.com/dev-infra-mirror/firefox/125.0.1/mac_x64/browser-bin.dmg",
         ],
         named_files = {
             "FIREFOX": "Firefox.app/Contents/MacOS/firefox",
@@ -41,11 +41,11 @@ def define_firefox_repositories():
     browser_archive(
         name = "org_mozilla_geckodriver_linux_x64",
         licenses = ["reciprocal"],  # MPL 2.0
-        sha256 = "12c37f41d11ed982b7be43d02411ff2c75fb7a484e46966d000b47d1665baa88",
-        # Geckodriver v0.30.0
+        sha256 = "79b2e77edd02c0ec890395140d7cdc04a7ff0ec64503e62a0b74f88674ef1313",
+        # Geckodriver v0.34.0
         urls = [
-            "https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz",
-            "https://storage.googleapis.com/dev-infra-mirror/firefox/97.0/linux_x64/driver-bin.tar.gz",
+            "https://github.com/mozilla/geckodriver/releases/download/v0.34.0/geckodriver-v0.34.0-linux64.tar.gz",
+            "https://storage.googleapis.com/dev-infra-mirror/firefox/125.0.1/linux_x64/driver-bin.tar.gz",
         ],
         named_files = {
             "GECKODRIVER": "geckodriver",
@@ -55,11 +55,11 @@ def define_firefox_repositories():
     browser_archive(
         name = "org_mozilla_geckodriver_macos_x64",
         licenses = ["reciprocal"],  # MPL 2.0
-        sha256 = "560ba192666c1fe8796404153cfdf2d12551515601c4b3937aabcba6ee300f8c",
-        # Geckodriver v0.30.0
+        sha256 = "d33232d29d764018d83e7e4e0c25ac274b5548658c605421c4373e64ba81d904",
+        # Geckodriver v0.34.0
         urls = [
-            "https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-macos.tar.gz",
-            "https://storage.googleapis.com/dev-infra-mirror/firefox/97.0/mac_x64/driver-bin.tar.gz",
+            "https://github.com/mozilla/geckodriver/releases/download/v0.34.0/geckodriver-v0.34.0-macos.tar.gz",
+            "https://storage.googleapis.com/dev-infra-mirror/firefox/125.0.1/mac_x64/driver-bin.tar.gz",
         ],
         named_files = {
             "GECKODRIVER": "geckodriver",
@@ -69,11 +69,11 @@ def define_firefox_repositories():
     browser_archive(
         name = "org_mozilla_geckodriver_macos_arm64",
         licenses = ["reciprocal"],  # MPL 2.0
-        sha256 = "895bc2146edaea434d57a3b5d9a141be5cb3c5f8e8804916bd4869978ddfd4db",
-        # Geckodriver v0.30.0
+        sha256 = "9cec1546585b532959782c8220599aa97c1f99265bb2d75ad00cd56ef98f650c",
+        # Geckodriver v0.34.0
         urls = [
-            "https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-macos-aarch64.tar.gz",
-            "https://storage.googleapis.com/dev-infra-mirror/firefox/97.0/mac_arm64/driver-bin.tar.gz",
+            "https://github.com/mozilla/geckodriver/releases/download/v0.34.0/geckodriver-v0.34.0-macos-aarch64.tar.gz",
+            "https://storage.googleapis.com/dev-infra-mirror/firefox/125.0.1/mac_arm64/driver-bin.tar.gz",
         ],
         named_files = {
             "GECKODRIVER": "geckodriver",


### PR DESCRIPTION
Updates Firefox and geckodriver to the latest stable version (125.0.1)
Updates Chromium and chromedriver to latest stable version (124.0.6325.0)