### PR TITLE
feat(ng-dev): detect missing check status when merging

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -72321,7 +72321,10 @@ var Validation8 = class extends PullRequestValidation {
 var passingCiValidation = createPullRequestValidation({ name: "assertPassingCi", canBeForceIgnored: true }, () => Validation9);
 var Validation9 = class extends PullRequestValidation {
   assert(pullRequest) {
-    const { combinedStatus } = getStatusesForPullRequest(pullRequest);
+    const { combinedStatus, statuses } = getStatusesForPullRequest(pullRequest);
+    if (statuses.find((status) => status.name === "lint") === void 0) {
+      throw this._createError("Pull request is missing expected status checks. Check the pull request for pending workflows");
+    }
     if (combinedStatus === PullRequestStatus.PENDING) {
       throw this._createError("Pull request has pending status checks.");
     }


### PR DESCRIPTION
Detect if an expected check status is missing, and if so fail the merge check as having missing check statuses. This is necessary as its not possible to check via API if there are pending workflow runs to be approved for a pull request.