### PR TITLE
refactor(shared-docs): Zoneless updates 

### DIFF
--- a/docs/components/algolia-icon/algolia-icon.component.ts
+++ b/docs/components/algolia-icon/algolia-icon.component.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'docs-algolia-icon',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [],
   templateUrl: './algolia-icon.component.html',
 })

--- a/docs/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/docs/components/breadcrumb/breadcrumb.component.spec.ts
@@ -13,6 +13,7 @@ import {NavigationState} from '../../services';
 import {NavigationItem} from '../../interfaces';
 import {By} from '@angular/platform-browser';
 import {RouterTestingModule} from '@angular/router/testing';
+import {provideExperimentalZonelessChangeDetection} from '@angular/core';
 
 describe('Breadcrumb', () => {
   let fixture: ComponentFixture<Breadcrumb>;
@@ -24,6 +25,7 @@ describe('Breadcrumb', () => {
     TestBed.configureTestingModule({
       imports: [Breadcrumb, RouterTestingModule],
       providers: [
+        provideExperimentalZonelessChangeDetection(),
         {
           provide: NavigationState,
           useValue: navigationStateSpy,

--- a/docs/components/cookie-popup/cookie-popup.component.spec.ts
+++ b/docs/components/cookie-popup/cookie-popup.component.spec.ts
@@ -11,6 +11,7 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {CookiePopup, STORAGE_KEY} from './cookie-popup.component';
 import {LOCAL_STORAGE} from '../../providers/index';
 import {MockLocalStorage} from '../../testing/index';
+import {provideExperimentalZonelessChangeDetection} from '@angular/core';
 
 describe('CookiePopup', () => {
   let fixture: ComponentFixture<CookiePopup>;
@@ -20,6 +21,7 @@ describe('CookiePopup', () => {
     TestBed.configureTestingModule({
       imports: [CookiePopup],
       providers: [
+        provideExperimentalZonelessChangeDetection(),
         {
           provide: LOCAL_STORAGE,
           useValue: mockLocalStorage,

--- a/docs/components/navigation-list/navigation-list.component.spec.ts
+++ b/docs/components/navigation-list/navigation-list.component.spec.ts
@@ -12,7 +12,7 @@ import {NavigationList} from './navigation-list.component';
 import {By} from '@angular/platform-browser';
 import {NavigationItem} from '../../interfaces';
 import {RouterTestingModule} from '@angular/router/testing';
-import {signal} from '@angular/core';
+import {provideExperimentalZonelessChangeDetection, signal} from '@angular/core';
 import {NavigationState} from '../../services';
 
 const navigationItems: NavigationItem[] = [
@@ -38,7 +38,10 @@ describe('NavigationList', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NavigationList, RouterTestingModule],
-      providers: [{provide: NavigationState, useClass: FakeNavigationListState}],
+      providers: [
+        {provide: NavigationState, useClass: FakeNavigationListState},
+        provideExperimentalZonelessChangeDetection(),
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(NavigationList);
     component = fixture.componentInstance;

--- a/docs/components/search-dialog/search-dialog.component.spec.ts
+++ b/docs/components/search-dialog/search-dialog.component.spec.ts
@@ -16,6 +16,7 @@ import {By} from '@angular/platform-browser';
 import {AlgoliaIcon} from '../algolia-icon/algolia-icon.component';
 import {RouterTestingModule} from '@angular/router/testing';
 import {Router} from '@angular/router';
+import {provideExperimentalZonelessChangeDetection} from '@angular/core';
 
 describe('SearchDialog', () => {
   let fixture: ComponentFixture<SearchDialog>;
@@ -33,6 +34,7 @@ describe('SearchDialog', () => {
     await TestBed.configureTestingModule({
       imports: [SearchDialog, RouterTestingModule],
       providers: [
+        provideExperimentalZonelessChangeDetection(),
         {
           provide: Search,
           useValue: fakeSearch,

--- a/docs/components/search-dialog/search-dialog.component.ts
+++ b/docs/components/search-dialog/search-dialog.component.ts
@@ -8,6 +8,7 @@
 
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   ElementRef,
@@ -39,6 +40,7 @@ import {RelativeLink} from '../../pipes/relative-link.pipe';
 @Component({
   selector: 'docs-search-dialog',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ClickOutside,
     TextField,

--- a/docs/components/select/select.component.spec.ts
+++ b/docs/components/select/select.component.spec.ts
@@ -9,6 +9,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {Select} from './select.component';
+import {provideExperimentalZonelessChangeDetection} from '@angular/core';
 
 describe('Select', () => {
   let component: Select;
@@ -17,6 +18,7 @@ describe('Select', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [Select],
+      providers: [provideExperimentalZonelessChangeDetection()],
     });
     fixture = TestBed.createComponent(Select);
     component = fixture.componentInstance;

--- a/docs/components/select/select.component.ts
+++ b/docs/components/select/select.component.ts
@@ -7,7 +7,7 @@
  */
 
 import {ControlValueAccessor, NG_VALUE_ACCESSOR, FormsModule} from '@angular/forms';
-import {Component, Input, forwardRef, signal} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, forwardRef, signal} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 type SelectOptionValue = string | number | boolean;
@@ -20,6 +20,7 @@ export interface SelectOption {
 @Component({
   selector: 'docs-select',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule],
   templateUrl: './select.component.html',
   styleUrls: ['./select.component.scss'],

--- a/docs/components/slide-toggle/slide-toggle.component.spec.ts
+++ b/docs/components/slide-toggle/slide-toggle.component.spec.ts
@@ -9,6 +9,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {SlideToggle} from './slide-toggle.component';
+import {provideExperimentalZonelessChangeDetection} from '@angular/core';
 
 describe('SlideToggle', () => {
   let component: SlideToggle;
@@ -17,6 +18,7 @@ describe('SlideToggle', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [SlideToggle],
+      providers: [provideExperimentalZonelessChangeDetection()],
     });
     fixture = TestBed.createComponent(SlideToggle);
     component = fixture.componentInstance;

--- a/docs/components/slide-toggle/slide-toggle.component.ts
+++ b/docs/components/slide-toggle/slide-toggle.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Component, Input, forwardRef, signal} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, forwardRef, signal} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
@@ -14,6 +14,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
   selector: 'docs-slide-toggle',
   standalone: true,
   imports: [CommonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './slide-toggle.component.html',
   styleUrls: ['./slide-toggle.component.scss'],
   providers: [

--- a/docs/components/table-of-contents/table-of-contents.component.spec.ts
+++ b/docs/components/table-of-contents/table-of-contents.component.spec.ts
@@ -12,11 +12,11 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {TableOfContentsItem, TableOfContentsLevel} from '../../interfaces/index';
 import {TableOfContentsScrollSpy, TableOfContentsLoader} from '../../services/index';
 import {WINDOW} from '../../providers/index';
+import {provideExperimentalZonelessChangeDetection, signal} from '@angular/core';
 
 describe('TableOfContents', () => {
   let component: TableOfContents;
   let fixture: ComponentFixture<TableOfContents>;
-  let tableOfContentsLoaderSpy: jasmine.SpyObj<TableOfContentsLoader>;
   let scrollSpy: jasmine.SpyObj<TableOfContentsScrollSpy>;
   const items: TableOfContentsItem[] = [
     {
@@ -52,28 +52,24 @@ describe('TableOfContents', () => {
     scrollSpy.startListeningToScroll.and.returnValue();
     scrollSpy.activeItemId.and.returnValue(items[0].id);
     scrollSpy.scrollbarThumbOnTop.and.returnValue(false);
-    tableOfContentsLoaderSpy = jasmine.createSpyObj<TableOfContentsLoader>(
-      'TableOfContentsLoader',
-      ['buildTableOfContent'],
-    );
-    tableOfContentsLoaderSpy.buildTableOfContent.and.returnValue();
-    tableOfContentsLoaderSpy.tableOfContentItems = items;
 
     await TestBed.configureTestingModule({
       imports: [TableOfContents, RouterTestingModule],
       providers: [
+        provideExperimentalZonelessChangeDetection(),
         {
           provide: WINDOW,
           useValue: fakeWindow,
         },
       ],
     }).compileComponents();
-    TestBed.overrideProvider(TableOfContentsLoader, {
-      useValue: tableOfContentsLoaderSpy,
-    });
     TestBed.overrideProvider(TableOfContentsScrollSpy, {
       useValue: scrollSpy,
     });
+
+    const tableOfContentsLoaderSpy = TestBed.inject(TableOfContentsLoader);
+    spyOn(tableOfContentsLoaderSpy, 'buildTableOfContent').and.returnValue();
+    tableOfContentsLoaderSpy.tableOfContentItems.set(items);
     fixture = TestBed.createComponent(TableOfContents);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/docs/components/table-of-contents/table-of-contents.component.ts
+++ b/docs/components/table-of-contents/table-of-contents.component.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgFor, NgIf} from '@angular/common';
-import {Component, Input, computed, inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, computed, inject} from '@angular/core';
 import {RouterLink} from '@angular/router';
 import {TableOfContentsLevel} from '../../interfaces/index';
 import {TableOfContentsLoader} from '../../services/table-of-contents-loader.service';
@@ -17,7 +17,7 @@ import {IconComponent} from '../icon/icon.component';
 @Component({
   selector: 'docs-table-of-contents',
   standalone: true,
-  providers: [TableOfContentsLoader, TableOfContentsScrollSpy],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './table-of-contents.component.html',
   styleUrls: ['./table-of-contents.component.scss'],
   imports: [NgIf, NgFor, RouterLink, IconComponent],
@@ -28,14 +28,11 @@ export class TableOfContents {
 
   private readonly scrollSpy = inject(TableOfContentsScrollSpy);
   private readonly tableOfContentsLoader = inject(TableOfContentsLoader);
+  tableOfContentItems = this.tableOfContentsLoader.tableOfContentItems;
 
   activeItemId = this.scrollSpy.activeItemId;
   shouldDisplayScrollToTop = computed(() => !this.scrollSpy.scrollbarThumbOnTop());
   TableOfContentsLevel = TableOfContentsLevel;
-
-  tableOfContentItems() {
-    return this.tableOfContentsLoader.tableOfContentItems;
-  }
 
   ngAfterViewInit() {
     this.tableOfContentsLoader.buildTableOfContent(this.contentSourceElement);

--- a/docs/components/text-field/text-field.component.spec.ts
+++ b/docs/components/text-field/text-field.component.spec.ts
@@ -9,6 +9,7 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {TextField} from './text-field.component';
+import {provideExperimentalZonelessChangeDetection} from '@angular/core';
 
 describe('TextField', () => {
   let component: TextField;
@@ -17,6 +18,7 @@ describe('TextField', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [TextField],
+      providers: [provideExperimentalZonelessChangeDetection()],
     });
     fixture = TestBed.createComponent(TextField);
     component = fixture.componentInstance;

--- a/docs/components/text-field/text-field.component.ts
+++ b/docs/components/text-field/text-field.component.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  ChangeDetectionStrategy,
   Component,
   ElementRef,
   Input,
@@ -22,6 +23,7 @@ import {IconComponent} from '../icon/icon.component';
 @Component({
   selector: 'docs-text-field',
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [CommonModule, FormsModule, IconComponent],
   templateUrl: './text-field.component.html',
   styleUrls: ['./text-field.component.scss'],

--- a/docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
+++ b/docs/components/viewers/docs-viewer/docs-viewer.component.spec.ts
@@ -19,6 +19,7 @@ import {Breadcrumb} from '../../breadcrumb/breadcrumb.component';
 import {NavigationState} from '../../../services';
 import {CopySourceCodeButton} from '../../copy-source-code-button/copy-source-code-button.component';
 import {TableOfContents} from '../../table-of-contents/table-of-contents.component';
+import {provideExperimentalZonelessChangeDetection} from '@angular/core';
 
 describe('DocViewer', () => {
   let fixture: ComponentFixture<DocViewer>;
@@ -81,6 +82,7 @@ describe('DocViewer', () => {
     await TestBed.configureTestingModule({
       imports: [DocViewer, NoopAnimationsModule, RouterTestingModule],
       providers: [
+        provideExperimentalZonelessChangeDetection(),
         {provide: EXAMPLE_VIEWER_CONTENT_LOADER, useValue: exampleContentSpy},
         {provide: NavigationState, useValue: navigationStateSpy},
       ],

--- a/docs/components/viewers/example-viewer/example-viewer.component.spec.ts
+++ b/docs/components/viewers/example-viewer/example-viewer.component.spec.ts
@@ -10,7 +10,7 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {ExampleViewer} from './example-viewer.component';
 import {DocsContentLoader, ExampleMetadata, ExampleViewerContentLoader} from '../../../interfaces';
 import {DOCS_CONTENT_LOADER, EXAMPLE_VIEWER_CONTENT_LOADER} from '../../../providers';
-import {Component} from '@angular/core';
+import {Component, provideExperimentalZonelessChangeDetection} from '@angular/core';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {HarnessLoader} from '@angular/cdk/testing';
 import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
@@ -37,6 +37,7 @@ describe('ExampleViewer', () => {
     await TestBed.configureTestingModule({
       imports: [ExampleViewer, NoopAnimationsModule],
       providers: [
+        provideExperimentalZonelessChangeDetection(),
         {provide: EXAMPLE_VIEWER_CONTENT_LOADER, useValue: exampleContentSpy},
         {provide: DOCS_CONTENT_LOADER, useValue: contentServiceSpy},
         {provide: ActivatedRoute, useValue: {snapshot: {fragment: 'fragment'}}},

--- a/docs/services/table-of-contents-loader.service.spec.ts
+++ b/docs/services/table-of-contents-loader.service.spec.ts
@@ -29,7 +29,7 @@ describe('TableOfContentsLoader', () => {
 
     service.buildTableOfContent(element);
 
-    expect(service.tableOfContentItems).toEqual([]);
+    expect(service.tableOfContentItems()).toEqual([]);
   });
 
   it('should create empty table of content list when there is only h1 elements', () => {
@@ -37,7 +37,7 @@ describe('TableOfContentsLoader', () => {
 
     service.buildTableOfContent(element);
 
-    expect(service.tableOfContentItems).toEqual([]);
+    expect(service.tableOfContentItems()).toEqual([]);
   });
 
   it('should create table of content list with h2 and h3 when h2 and h3 headings exists', () => {
@@ -45,24 +45,24 @@ describe('TableOfContentsLoader', () => {
 
     service.buildTableOfContent(element);
 
-    expect(service.tableOfContentItems.length).toEqual(5);
-    expect(service.tableOfContentItems[0].id).toBe('item-2');
-    expect(service.tableOfContentItems[1].id).toBe('item-3');
-    expect(service.tableOfContentItems[2].id).toBe('item-5');
-    expect(service.tableOfContentItems[3].id).toBe('item-6');
-    expect(service.tableOfContentItems[4].id).toBe('item-7');
+    expect(service.tableOfContentItems().length).toEqual(5);
+    expect(service.tableOfContentItems()[0].id).toBe('item-2');
+    expect(service.tableOfContentItems()[1].id).toBe('item-3');
+    expect(service.tableOfContentItems()[2].id).toBe('item-5');
+    expect(service.tableOfContentItems()[3].id).toBe('item-6');
+    expect(service.tableOfContentItems()[4].id).toBe('item-7');
 
-    expect(service.tableOfContentItems[0].level).toBe('h2');
-    expect(service.tableOfContentItems[1].level).toBe('h3');
-    expect(service.tableOfContentItems[2].level).toBe('h3');
-    expect(service.tableOfContentItems[3].level).toBe('h2');
-    expect(service.tableOfContentItems[4].level).toBe('h3');
+    expect(service.tableOfContentItems()[0].level).toBe('h2');
+    expect(service.tableOfContentItems()[1].level).toBe('h3');
+    expect(service.tableOfContentItems()[2].level).toBe('h3');
+    expect(service.tableOfContentItems()[3].level).toBe('h2');
+    expect(service.tableOfContentItems()[4].level).toBe('h3');
 
-    expect(service.tableOfContentItems[0].title).toBe('H2 - first');
-    expect(service.tableOfContentItems[1].title).toBe('H3 - first');
-    expect(service.tableOfContentItems[2].title).toBe('H3 - second');
-    expect(service.tableOfContentItems[3].title).toBe('H2 - second');
-    expect(service.tableOfContentItems[4].title).toBe('H3 - third');
+    expect(service.tableOfContentItems()[0].title).toBe('H2 - first');
+    expect(service.tableOfContentItems()[1].title).toBe('H3 - first');
+    expect(service.tableOfContentItems()[2].title).toBe('H3 - second');
+    expect(service.tableOfContentItems()[3].title).toBe('H2 - second');
+    expect(service.tableOfContentItems()[4].title).toBe('H3 - third');
   });
 
   it('should not display in ToC h2,h3 without ids', () => {
@@ -70,7 +70,7 @@ describe('TableOfContentsLoader', () => {
 
     service.buildTableOfContent(element);
 
-    expect(service.tableOfContentItems.length).toBe(0);
+    expect(service.tableOfContentItems().length).toBe(0);
   });
 
   it('should not display in ToC h2,h3 which are childrens of docs-example-viewer', () => {
@@ -78,7 +78,7 @@ describe('TableOfContentsLoader', () => {
 
     service.buildTableOfContent(element);
 
-    expect(service.tableOfContentItems.length).toBe(0);
+    expect(service.tableOfContentItems().length).toBe(0);
   });
 
   it(`should not display in ToC heading with ${TOC_SKIP_CONTENT_MARKER} attr`, () => {
@@ -86,8 +86,8 @@ describe('TableOfContentsLoader', () => {
 
     service.buildTableOfContent(element);
 
-    expect(service.tableOfContentItems.length).toBe(1);
-    expect(service.tableOfContentItems[0].id).toBe('item-1');
+    expect(service.tableOfContentItems().length).toBe(1);
+    expect(service.tableOfContentItems()[0].id).toBe('item-1');
   });
 });
 

--- a/docs/services/table-of-contents-scroll-spy.service.spec.ts
+++ b/docs/services/table-of-contents-scroll-spy.service.spec.ts
@@ -17,7 +17,6 @@ import {TableOfContentsLevel} from '../interfaces';
 
 describe('TableOfContentsScrollSpy', () => {
   let service: TableOfContentsScrollSpy;
-  let tableOfContentsLoaderSpy: jasmine.SpyObj<TableOfContentsLoader>;
   const fakeWindow = {
     addEventListener: () => {},
     removeEventListener: () => {},
@@ -57,12 +56,6 @@ describe('TableOfContentsScrollSpy', () => {
   ];
 
   beforeEach(() => {
-    tableOfContentsLoaderSpy = jasmine.createSpyObj<TableOfContentsLoader>(
-      'TableOfContentsLoader',
-      ['tableOfContentItems', 'updateHeadingsTopValue'],
-    );
-    tableOfContentsLoaderSpy.tableOfContentItems = fakeToCItems;
-
     TestBed.configureTestingModule({
       providers: [
         TableOfContentsScrollSpy,
@@ -70,12 +63,10 @@ describe('TableOfContentsScrollSpy', () => {
           provide: WINDOW,
           useValue: fakeWindow,
         },
-        {
-          provide: TableOfContentsLoader,
-          useValue: tableOfContentsLoaderSpy,
-        },
       ],
     });
+    const tableOfContentsLoaderSpy = TestBed.inject(TableOfContentsLoader);
+    tableOfContentsLoaderSpy.tableOfContentItems.set(fakeToCItems);
     service = TestBed.inject(TableOfContentsScrollSpy);
   });
 

--- a/docs/services/table-of-contents-scroll-spy.service.ts
+++ b/docs/services/table-of-contents-scroll-spy.service.ts
@@ -26,7 +26,7 @@ import {TableOfContentsLoader} from './table-of-contents-loader.service';
 export const SCROLL_EVENT_DELAY = 20;
 export const SCROLL_FINISH_DELAY = SCROLL_EVENT_DELAY * 2;
 
-@Injectable()
+@Injectable({providedIn: 'root'})
 // The service is responsible for listening for scrolling and resizing,
 // thanks to which it sets the active item in the Table of contents
 export class TableOfContentsScrollSpy {
@@ -78,7 +78,7 @@ export class TableOfContentsScrollSpy {
     fromEvent(this.window, 'resize')
       .pipe(debounceTime(RESIZE_EVENT_DELAY), takeUntilDestroyed(this.destroyRef), startWith())
       .subscribe(() => {
-        this.ngZone.run(() => this.updateHeadingsTopAfterResize());
+        this.updateHeadingsTopAfterResize();
       });
 
     // We need to observe the height of the docs-viewer because it may change after the
@@ -118,7 +118,7 @@ export class TableOfContentsScrollSpy {
   }
 
   private setActiveItemId(): void {
-    const tableOfContentItems = this.tableOfContentsLoader.tableOfContentItems;
+    const tableOfContentItems = this.tableOfContentsLoader.tableOfContentItems();
 
     if (tableOfContentItems.length === 0) return;
 
@@ -140,19 +140,19 @@ export class TableOfContentsScrollSpy {
 
       // When active item was changed then trigger change detection
       if (isActive && this.activeItemId() !== currentLink.id) {
-        this.ngZone.run(() => this.activeItemId.set(currentLink.id));
+        this.activeItemId.set(currentLink.id);
         return;
       }
     }
 
     if (scrollOffset < tableOfContentItems[0].top && this.activeItemId() !== null) {
-      this.ngZone.run(() => this.activeItemId.set(null));
+      this.activeItemId.set(null);
     }
 
     const scrollOffsetZero = scrollOffset === 0;
     if (scrollOffsetZero !== this.scrollbarThumbOnTop()) {
       // we want to trigger change detection only when the value changes
-      this.ngZone.run(() => this.scrollbarThumbOnTop.set(scrollOffsetZero));
+      this.scrollbarThumbOnTop.set(scrollOffsetZero);
     }
   }
 


### PR DESCRIPTION
* Use ChangeDetectionStrategy.OnPush
* Use signals where components were relying on Default change detection
* Remove zone.run when setting signals because it's not needed in v18
* provide zoneless for component tests to ensure they are compatible