### PR TITLE
fix(ng-dev): prevent failure on googler check

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -68178,9 +68178,12 @@ var Validation5 = class extends PullRequestValidation {
 
 // 
 async function isGooglerOrgMember(client, username) {
-  const response = await client.orgs.checkMembershipForUser({ org: "googlers", username });
-  if (response.status === 204) {
-    return true;
+  try {
+    const response = await client.orgs.checkMembershipForUser({ org: "googlers", username });
+    if (response.status === 204) {
+      return true;
+    }
+  } catch {
   }
   return false;
 }

--- a/ng-dev/utils/git/github-macros.ts
+++ b/ng-dev/utils/git/github-macros.ts
@@ -14,10 +14,12 @@ async function isGooglerOrgMember(
   client: AuthenticatedGithubClient,
   username: string,
 ): Promise<boolean> {
-  const response = await client.orgs.checkMembershipForUser({org: 'googlers', username});
-  if ((response.status as number) === 204) {
-    return true;
-  }
+  try {
+    const response = await client.orgs.checkMembershipForUser({org: 'googlers', username});
+    if ((response.status as number) === 204) {
+      return true;
+    }
+  } catch {}
   return false;
 }
 


### PR DESCRIPTION
This adds a try catch around the googler org check to make sure the script does not error out when merging