### PR TITLE
fix(shared-docs): add missing `mermaid` dep

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,8 @@
     "html-entities": "~2.5.2",
     "jsdom": "~24.0.0",
     "jszip": "~3.10.1",
-    "marked": "~12.0.2"
+    "marked": "~12.0.2",
+    "mermaid": "^10.8.0"
   },
   "exports": {
     "./styles/*": {


### PR DESCRIPTION
This is required by the docs pipeline

Should fix https://github.com/angular/angular/issues/55657