### PR TITLE
fix(ng-dev): clarify isolate primitives validation rules

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -68106,7 +68106,7 @@ var Validation4 = class extends PullRequestValidation {
     if (diffStats.separateFiles > 0 && !hasSeparateSyncFiles) {
       throw this._createError(`This PR cannot be merged as Shared Primitives code has already been merged. Primitives and Framework code must be merged and synced separately. Try again after a g3sync has finished.`);
     }
-    if (diffStats.files > 0 && hasSeparateSyncFiles) {
+    if (diffStats.files > 0 && diffStats.separateFiles === 0 && hasSeparateSyncFiles) {
       throw this._createError(`This PR cannot be merged as Angular framework code has already been merged. Primitives and Framework code must be merged and synced separately. Try again after a g3sync has finished.`);
     }
   }

--- a/ng-dev/pr/common/test/common.spec.ts
+++ b/ng-dev/pr/common/test/common.spec.ts
@@ -212,6 +212,19 @@ describe('pull request validation', () => {
       const results = await assertValidPullRequest(pr, config, ngDevConfig, null, prTarget, git);
       expect(results.length).toBe(0);
     });
+
+    it('should allow merging when primitives changes have been merged already and PR has primitives and fw code', async () => {
+      const config = createIsolatedValidationConfig({assertIsolatedSeparateFiles: true});
+      let pr = createTestPullRequest();
+      const files = ['packages/core/primitives/rando.ts', 'packages/router/blah.ts'];
+      const fileHelper = PullRequestFiles.create(git, pr.number, googleSyncConfig);
+      const diffStats = {insertions: 0, deletions: 0, files: 1, separateFiles: 1, commits: 3};
+      spyOn(PullRequestFiles, 'create').and.returnValue(fileHelper);
+      spyOn(G3Stats, 'getDiffStats').and.returnValue(diffStats);
+      spyOn(fileHelper, 'loadPullRequestFiles').and.returnValue(Promise.resolve(files));
+      const results = await assertValidPullRequest(pr, config, ngDevConfig, null, prTarget, git);
+      expect(results.length).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
This updates the isolate primitives validation to ensure that it is clear that once primitives code has been merged, PRs can include FW code as long as primitives code is present in the PR. In that case, those changes are related, which is fine. Pure FW PRs should not be merged in this case.