### PR TITLE
refactor(ng-dev): export non esm bundled code in ng-dev

### DIFF
--- a/ng-dev/BUILD.bazel
+++ b/ng-dev/BUILD.bazel
@@ -82,6 +82,7 @@ pkg_npm(
     substitutions = NPM_PACKAGE_SUBSTITUTIONS,
     deps = [
         ":bundles",
+        ":ng-dev",
         ":types",
     ],
 )

--- a/ng-dev/package.json
+++ b/ng-dev/package.json
@@ -3,13 +3,11 @@
   "version": "0.0.0-{SCM_HEAD_SHA}",
   "type": "module",
   "private": true,
-  "bin": {
-    "ng-dev": "./bundles/cli.mjs"
-  },
+  "bin": "./bundles/cli.mjs",
   "exports": {
     ".": {
       "types": "./index.d.ts",
-      "default": "./bundles/index.mjs"
+      "default": "./index.js"
     },
     "./*": {
       "types": "./*.d.ts",
@@ -17,7 +15,14 @@
     }
   },
   "dependencies": {
+    "@octokit/rest": "20.1.0",
+    "@types/semver": "^7.3.6",
+    "@types/supports-color": "^8.1.1",
     "@yarnpkg/lockfile": "^1.1.0",
+    "chalk": "^5.0.1",
+    "semver": "^7.5.4",
+    "supports-color": "9.4.0",
+    "typed-graphqlify": "^3.1.1",
     "typescript": "~4.9.0"
   }
 }


### PR DESCRIPTION
In ng-dev instead of exporting the esm bundles when importing from the @angular/ng-dev entrypoint, we instead should export the non bundled code.

When we don't do this, if we try to bundle the imported code again, we get issues with multiple `createRequire` imports.