### PR TITLE
ci: fix yarn cache in renovate

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
-            .github/ng-renovate/.yarn/cache
+            .github/ng-renovate/node-modules
             /tmp/renovate
           key: v2-renovate-${{hashFiles('.github/ng-renovate/yarn.lock')}}-${{ steps.date.outputs.date }}
       - run: yarn --cwd .github/ng-renovate install --immutable


### PR DESCRIPTION
I fixed the path of yarn cache in renovate, this should shave few seconds of the build.

As you can see in the following build step:

https://github.com/angular/dev-infra/actions/runs/9123170934/job/25085177609#step:5:12

yarn is downloading the packages all the time.

The path for caching was incorrect.

```
$ yarn --version                                    
4.2.2
$ yarn config | grep -A 3 cacheFolder 
├─ cacheFolder
│  ├─ Description: Folder where the cache files must be written
│  ├─ Source: <internal>
│  └─ Value: '/home/redpanda83/.yarn/berry/cache'               
```