### PR TITLE
fix(github-actions): include branches which can merge merge failures are found

### DIFF
--- a/.github/local-actions/branch-manager/lib/main.ts
+++ b/.github/local-actions/branch-manager/lib/main.ts
@@ -142,7 +142,10 @@ async function main(repo: {owner: string; repo: string}, token: string, pr: numb
       let description: string;
       if (e instanceof MergeConflictsFatalError) {
         core.info('Merge conflict found');
-        description = `Unable to merge into: ${e.failedBranches.join(', ')}`;
+        const passingBranches = pullRequest.targetBranches.filter(
+          (branch) => !e.failedBranches.includes(branch),
+        );
+        description = `Unable to merge into: ${e.failedBranches.join(', ')} | Can merge into: ${passingBranches.join(',')}`;
       } else {
         core.info('Unknown error found when checking merge:');
         core.error(e as Error);

--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -70492,7 +70492,8 @@ async function main(repo2, token2, pr2) {
       let description;
       if (e instanceof MergeConflictsFatalError) {
         core.info("Merge conflict found");
-        description = `Unable to merge into: ${e.failedBranches.join(", ")}`;
+        const passingBranches = pullRequest.targetBranches.filter((branch) => !e.failedBranches.includes(branch));
+        description = `Unable to merge into: ${e.failedBranches.join(", ")} | Can merge into: ${passingBranches.join(",")}`;
       } else {
         core.info("Unknown error found when checking merge:");
         core.error(e);


### PR DESCRIPTION
Include which branches are able to merge when showing the mergeability failure checks.