### PR TITLE
fix(ng-dev): include which branches are merged into in the comment during pr merge

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -67857,7 +67857,9 @@ var AutosquashMergeStrategy = class extends MergeStrategy {
     await this.git.github.issues.createComment({
       ...this.git.remoteParams,
       issue_number: pullRequest.prNumber,
-      body: `This PR was merged into the repository by commit ${sha}.`
+      body: `This PR was merged into the repository by commit ${sha}.
+
+The changes were merged into the following branches: ${targetBranches.join(", ")}`
     });
     if (githubTargetBranch !== this.git.mainBranchName) {
       await this.git.github.pulls.update({

--- a/ng-dev/pr/merge/strategies/api-merge.ts
+++ b/ng-dev/pr/merge/strategies/api-merge.ts
@@ -142,6 +142,14 @@ export class GithubApiMergeStrategy extends MergeStrategy {
     }
 
     this.pushTargetBranchesUpstream(cherryPickTargetBranches);
+
+    // Because our process brings changes into multiple branchces, we include a comment which
+    // expresses all of the branches the changes were merged into.
+    await this.git.github.issues.createComment({
+      ...this.git.remoteParams,
+      issue_number: pullRequest.prNumber,
+      body: `The changes were merged into the following branches: ${targetBranches.join(', ')}`,
+    });
   }
 
   /**

--- a/ng-dev/pr/merge/strategies/autosquash-merge.ts
+++ b/ng-dev/pr/merge/strategies/autosquash-merge.ts
@@ -95,11 +95,13 @@ export class AutosquashMergeStrategy extends MergeStrategy {
     // Github automatically closes PRs whose commits are merged into the main branch on Github.
     // However, it does not note them as merged using the purple merge badge as occurs when done via
     // the UI. To inform users that the PR was in fact merged, add a comment expressing the fact
-    // that the PR is merged
+    // that the PR is merged and what branches the changes were merged into.
     await this.git.github.issues.createComment({
       ...this.git.remoteParams,
       issue_number: pullRequest.prNumber,
-      body: `This PR was merged into the repository by commit ${sha}.`,
+      body:
+        `This PR was merged into the repository by commit ${sha}.\n\n` +
+        `The changes were merged into the following branches: ${targetBranches.join(', ')}`,
     });
 
     // For PRs which do not target the `main` branch on Github, Github does not automatically


### PR DESCRIPTION
We include a comment after performing a merge which includes the list of all branches the pull request was merged into.