### PR TITLE
build: set es2020 in bazel ts_library usages

### DIFF
--- a/bazel/api-gen/extraction/BUILD.bazel
+++ b/bazel/api-gen/extraction/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//bazel/esbuild:index.bzl", "esbuild")
+load("//bazel:defaults.bzl", "ts_library")
 
 package(default_visibility = ["//bazel/api-gen:__subpackages__"])
 

--- a/bazel/api-gen/manifest/BUILD.bazel
+++ b/bazel/api-gen/manifest/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:defaults.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("//bazel/esbuild:index.bzl", "esbuild_esm_bundle")
 

--- a/bazel/api-gen/rendering/BUILD.bazel
+++ b/bazel/api-gen/rendering/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:defaults.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 package(default_visibility = ["//bazel/api-gen:__subpackages__"])

--- a/bazel/api-golden/BUILD.bazel
+++ b/bazel/api-golden/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:defaults.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/bazel/benchmark/component_benchmark/component_benchmark.bzl
+++ b/bazel/benchmark/component_benchmark/component_benchmark.bzl
@@ -2,7 +2,7 @@ load("//bazel/app-bundling:index.bzl", "app_bundle")
 load("//bazel/http-server:index.bzl", "http_server")
 load("//bazel:expand_template.bzl", "expand_template")
 load("@npm//@angular/bazel:index.bzl", "ng_module")
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:defaults.bzl", "ts_library")
 load(":benchmark_test.bzl", "benchmark_test")
 
 def copy_default_index_html(output_name, bundle_target_name):

--- a/bazel/benchmark/driver-utilities/BUILD.bazel
+++ b/bazel/benchmark/driver-utilities/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:defaults.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/bazel/defaults.bzl
+++ b/bazel/defaults.bzl
@@ -1,0 +1,21 @@
+load("@npm//@bazel/concatjs:index.bzl", _ts_library = "ts_library")
+
+def ts_library(name, testonly = False, deps = [], srcs = [], devmode_module = None, **kwargs):
+    current_pkg = native.package_name()
+
+    if current_pkg != "bazel" and not current_pkg.startswith("bazel/"):
+        fail("Cannot use `bazel/defaults.bzl` outside of the `bazel` directory. " +
+             "Use //tools:defaults.bzl instead")
+
+    _ts_library(
+        name = name,
+        devmode_module = devmode_module if devmode_module != None else "umd",
+        devmode_target = "es2020",
+        prodmode_module = "esnext",
+        prodmode_target = "es2020",
+        tsconfig = kwargs.pop("tsconfig", "//:tsconfig"),
+        testonly = testonly,
+        deps = deps,
+        srcs = srcs,
+        **kwargs
+    )

--- a/bazel/http-server/BUILD.bazel
+++ b/bazel/http-server/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:defaults.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/bazel/integration/test_runner/BUILD.bazel
+++ b/bazel/integration/test_runner/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:defaults.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/bazel/map-size-tracking/BUILD.bazel
+++ b/bazel/map-size-tracking/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:defaults.bzl", "ts_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/bazel/test/BUILD.bazel
+++ b/bazel/test/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_test")
-load("@npm//@bazel/concatjs:index.bzl", "ts_library")
+load("//bazel:defaults.bzl", "ts_library")
 load("//bazel:extract_types.bzl", "extract_types")
 load("//bazel:extract_js_module_output.bzl", "extract_js_module_output")
 


### PR DESCRIPTION
Currently the default `target` for the code compiled with `ts_library` is set through the `ts_library` exposed in `defaults.bzl`, however the code under the `bazel` directory isn't allowed to use `defaults.bzl` which meant that it was defaulting to es2015.

These changes add a `defaults.bzl` specific to the `bazel` directory which allows us to maintain the defaults in a single place.

This came up due to a breakage in https://github.com/angular/angular/pull/56096.