### PR TITLE
build: add missing file to npm output

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -2,6 +2,7 @@ filegroup(
     name = "static_files",
     srcs = [
         "BUILD.bazel",
+        "defaults.bzl",
         "expand_template.bzl",
         "extract_js_module_output.bzl",
         "extract_types.bzl",


### PR DESCRIPTION
Fixes that the `defaults.bzl` from #2084 wasn't included in the npm package.