### PR TITLE
refactor(ng-dev): Add pr url support to merge tool params

### DIFF
--- a/ng-dev/pr/merge/cli.ts
+++ b/ng-dev/pr/merge/cli.ts
@@ -9,9 +9,8 @@
 import {Argv, Arguments, CommandModule} from 'yargs';
 import {addDryRunFlag} from '../../utils/dry-run.js';
 
-import {mergePullRequest} from './merge-pull-request.js';
+import {mergePullRequest, parsePrNumber} from './merge-pull-request.js';
 import {addGithubTokenOption} from '../../utils/git/github-yargs.js';
-
 /** The options available to the merge command via CLI. */
 export interface MergeCommandOptions {
   pr: number;
@@ -28,7 +27,8 @@ async function builder(argv: Argv) {
     .strict()
     .positional('pr', {
       demandOption: true,
-      type: 'number',
+      coerce: (prUrlOrNumber: string) => parsePrNumber(prUrlOrNumber),
+      type: 'string',
       description: 'The PR to be merged.',
     })
     .option('branch-prompt' as 'branchPrompt', {

--- a/ng-dev/pr/merge/integration.spec.ts
+++ b/ng-dev/pr/merge/integration.spec.ts
@@ -25,7 +25,7 @@ import {
   PackageJson,
 } from '../../release/versioning/index.js';
 import {Prompt} from '../../utils/prompt.js';
-
+import {parsePrNumber} from './merge-pull-request.js';
 const API_ENDPOINT = `https://api.github.com`;
 
 describe('default target labels', () => {
@@ -620,5 +620,29 @@ describe('default target labels', () => {
 
       expect(await getBranchesForLabel('target: minor', '12.2.x')).toEqual(['12.2.x']);
     });
+  });
+});
+
+describe('pr number validation', () => {
+  it('should succeed with a PR number', () => {
+    expect(parsePrNumber('12345')).toBe(12345);
+  });
+
+  it('should succeed with a full github url', () => {
+    expect(parsePrNumber('https://github.com/angular/angular/pull/12345')).toBe(12345);
+  });
+
+  it('should fail with a random string', () => {
+    try {
+      expect(parsePrNumber('baldfey')).toThrow(
+        'Pull Request was unable to be parsed from the parameters',
+      );
+    } catch {}
+  });
+
+  it('should fail with an empty string', () => {
+    try {
+      expect(parsePrNumber('')).toThrow('Pull Request was unable to be parsed from the parameters');
+    } catch {}
   });
 });

--- a/ng-dev/pr/merge/merge-pull-request.ts
+++ b/ng-dev/pr/merge/merge-pull-request.ts
@@ -19,7 +19,6 @@ import {
   PullRequestValidationError,
   UserAbortedMergeToolError,
 } from './failures.js';
-import {createPullRequestValidationConfig} from '../common/validation/validation-config.js';
 import {
   InvalidTargetBranchError,
   InvalidTargetLabelError,
@@ -133,4 +132,18 @@ async function createPullRequestMergeTool(flags: PullRequestMergeFlags) {
     }
     throw e;
   }
+}
+
+/**
+ * Parses the pull request number from either the number or url string
+ */
+export function parsePrNumber(prUrlOrNumber: string): number {
+  // There is no url validation here other than presence of `/`.
+  // So whatever is the last segment of that string, url or not, will be
+  // parsed as a PR number.
+  const prNumber = parseInt(prUrlOrNumber.split('/').pop()!);
+  if (isNaN(prNumber)) {
+    throw new Error('Pull Request was unable to be parsed from the parameters');
+  }
+  return prNumber;
 }


### PR DESCRIPTION
This adds support and parsing for pasting a full github url into the pr merge tool.