### PR TITLE
refactor(ng-dev): Add area labels to commit message github action

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -65836,6 +65836,11 @@ var managedLabels = createTypedObject()({
     description: "Related the build and CI infrastructure of the project",
     name: "area: build & ci",
     commitCheck: (c) => c.type === "build" || c.type === "ci"
+  },
+  DETECTED_PERF_CHANGE: {
+    description: "Issues related to performance",
+    name: "area: performance",
+    commitCheck: (c) => c.type === "perf"
   }
 });
 

--- a/.github/local-actions/labels-sync/main.js
+++ b/.github/local-actions/labels-sync/main.js
@@ -26014,6 +26014,11 @@ var managedLabels = createTypedObject()({
     description: "Related the build and CI infrastructure of the project",
     name: "area: build & ci",
     commitCheck: (c) => c.type === "build" || c.type === "ci"
+  },
+  DETECTED_PERF_CHANGE: {
+    description: "Issues related to performance",
+    name: "area: performance",
+    commitCheck: (c) => c.type === "perf"
   }
 });
 

--- a/github-actions/branch-manager/main.js
+++ b/github-actions/branch-manager/main.js
@@ -26014,6 +26014,11 @@ var managedLabels = createTypedObject()({
     description: "Related the build and CI infrastructure of the project",
     name: "area: build & ci",
     commitCheck: (c) => c.type === "build" || c.type === "ci"
+  },
+  DETECTED_PERF_CHANGE: {
+    description: "Issues related to performance",
+    name: "area: performance",
+    commitCheck: (c) => c.type === "perf"
   }
 });
 

--- a/github-actions/unified-status-check/main.js
+++ b/github-actions/unified-status-check/main.js
@@ -29307,6 +29307,11 @@ var managedLabels = createTypedObject()({
     description: "Related the build and CI infrastructure of the project",
     name: "area: build & ci",
     commitCheck: (c) => c.type === "build" || c.type === "ci"
+  },
+  DETECTED_PERF_CHANGE: {
+    description: "Issues related to performance",
+    name: "area: performance",
+    commitCheck: (c) => c.type === "perf"
   }
 });
 

--- a/ng-dev/pr/common/labels/managed.ts
+++ b/ng-dev/pr/common/labels/managed.ts
@@ -32,4 +32,9 @@ export const managedLabels = createTypedObject<ManagedLabel>()({
     name: 'area: build & ci',
     commitCheck: (c: Commit) => c.type === 'build' || c.type === 'ci',
   },
+  DETECTED_PERF_CHANGE: {
+    description: 'Issues related to performance',
+    name: 'area: performance',
+    commitCheck: (c: Commit) => c.type === 'perf',
+  },
 });


### PR DESCRIPTION
This queries the repository for the list of area labels and determines whether they should apply by commit scope.