### PR TITLE
refactor(shared-docs): Use the router on absolute url that are on the…

### DIFF
--- a/docs/components/viewers/docs-viewer/docs-viewer.component.ts
+++ b/docs/components/viewers/docs-viewer/docs-viewer.component.ts
@@ -312,10 +312,30 @@ export class DocViewer implements OnChanges {
       if (isExternalLink) {
         return;
       }
+
       fromEvent(anchor, 'click')
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe((e) => {
-          handleHrefClickEventWithRouter(e, this.router);
+          const closestAnchor = (e.target as Element).closest('a');
+          if (closestAnchor?.target && closestAnchor.target !== 'self') {
+            return;
+          }
+
+          const hrefAttr = closestAnchor?.getAttribute?.('href');
+          if (!hrefAttr) {
+            return;
+          }
+
+          let relativeUrl: string;
+          if (hrefAttr.startsWith('http')) {
+            // Url is absolute but we're targeting the same domain
+            const url = new URL(hrefAttr);
+            relativeUrl = `${url.pathname}${url.hash}${url.search}`;
+          } else {
+            relativeUrl = hrefAttr;
+          }
+
+          handleHrefClickEventWithRouter(e, this.router, relativeUrl);
         });
     });
   }

--- a/docs/utils/navigation.utils.ts
+++ b/docs/utils/navigation.utils.ts
@@ -131,7 +131,7 @@ export const getBaseUrlAfterRedirects = (url: string, router: Router): string =>
   return normalizePath(route.toString());
 };
 
-export function handleHrefClickEventWithRouter(e: Event, router: Router) {
+export function handleHrefClickEventWithRouter(e: Event, router: Router, relativeUrl: string) {
   const pointerEvent = e as PointerEvent;
   if (
     pointerEvent.ctrlKey ||
@@ -142,16 +142,8 @@ export function handleHrefClickEventWithRouter(e: Event, router: Router) {
     return;
   }
 
-  const closestAnchor = (e.target as Element).closest('a');
-  if (closestAnchor?.target && closestAnchor.target !== 'self') {
-    return;
-  }
-
-  const relativeUrl = closestAnchor?.getAttribute?.('href');
-  if (relativeUrl) {
-    e.preventDefault();
-    router.navigateByUrl(relativeUrl);
-  }
+  e.preventDefault();
+  router.navigateByUrl(relativeUrl);
 }
 
 export function getActivatedRouteSnapshotFromRouter(router: Router): ActivatedRouteSnapshot {


### PR DESCRIPTION
… same domain

The CLI docs produce absolute URLs that may target the same domain (exception is next.angular.dev).

When we ecounter those URLs, we remove the domain and feed them to `navigateByUrl` so they are handled as a local navigation

fixes angular/angular#56437