### PR TITLE
feat(github-actions): create action to validate all licenses in dependencies are support

### DIFF
--- a/github-actions/linting/licenses/action.yml
+++ b/github-actions/linting/licenses/action.yml
@@ -1,0 +1,21 @@
+name: 'Check Package Licenses'
+description: 'Check all dependencies to confirm licenses are allowed'
+author: 'Angular'
+
+inputs:
+  allow-dependencies-licenses:
+    description: 'Any package(s) in purl format'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Check Package Licenses
+      uses: actions/dependency-review-action@72eb03d02c7872a771aacd928f3123ac62ad6d3a # v4.3.3
+      env:
+        # The action ref here allows us to import the config file from the same sha we rely on in the downstream usage
+        ACTION_REF: ${{ github.action_ref }}
+        ACTION_REPO: ${{ github.action_repository }}
+      with:
+        config-file: '${{ env.ACTION_REPO }}/github-actions/linting/licenses/dependency-review-config.yml@${{ env.ACTION_REF }}'
+        allow-dependencies-licenses: '${{inputs.allow-dependencies-licenses}}'

--- a/github-actions/linting/licenses/dependency-review-config.yml
+++ b/github-actions/linting/licenses/dependency-review-config.yml
@@ -1,0 +1,14 @@
+vulnerability_check: false
+allow_licenses:
+  - '0BSD'
+  - 'Apache-2.0'
+  - 'Artistic-2.0'
+  - 'BlueOak-1.0.0'
+  - 'BSD-2-Clause'
+  - 'BSD-3-Clause'
+  - 'CC-BY-4.0'
+  - 'CC0-1.0'
+  - 'ISC'
+  - 'MIT'
+  - 'Python-2.0'
+  - 'Unlicense'


### PR DESCRIPTION
Leverage the dependency-review-action to centralize our validation of licensess in our repos.