### PR TITLE
refactor(shared-docs): Update return type of content loader to includ…

### DIFF
--- a/docs/interfaces/docs-content-loader.ts
+++ b/docs/interfaces/docs-content-loader.ts
@@ -10,5 +10,5 @@ import {DocContent} from './doc-content';
 
 /** The service responsible for fetching static content for docs pages */
 export interface DocsContentLoader {
-  getContent(path: string): Promise<DocContent | undefined>;
+  getContent(path: string): Promise<DocContent|undefined>;
 }

--- a/docs/providers/docs-content-loader.ts
+++ b/docs/providers/docs-content-loader.ts
@@ -7,11 +7,24 @@
  */
 
 import {InjectionToken, inject} from '@angular/core';
-import {ResolveFn} from '@angular/router';
+import {RedirectCommand, ResolveFn, Router} from '@angular/router';
 import {DocContent, DocsContentLoader} from '../interfaces/index';
 
 export const DOCS_CONTENT_LOADER = new InjectionToken<DocsContentLoader>('DOCS_CONTENT_LOADER');
 
-export function contentResolver(contentPath: string): ResolveFn<DocContent | undefined> {
-  return () => inject(DOCS_CONTENT_LOADER).getContent(contentPath);
+export function contentResolver(contentPath: string): ResolveFn<DocContent | RedirectCommand> {
+  return async () => {
+    const router = inject(Router);
+    const loader = inject(DOCS_CONTENT_LOADER);
+    const result = await loader.getContent(contentPath)
+    if (!result) {
+      const notFoundPage = router.createUrlTree(['/404']);
+      const currentNavigation = router.getCurrentNavigation();
+      // If there is a current navigation, redirect to 404 page without changing the target URL
+      const browserUrl = currentNavigation?.finalUrl ? currentNavigation.finalUrl : notFoundPage;
+      return new RedirectCommand(notFoundPage, {browserUrl});
+    } 
+
+    return result;
+  };
 }


### PR DESCRIPTION
…e RedirectCommand

The content loader is only used as a resolver and can return a `RedirectCommand` to imperatively redirect in the router rather than causing a new navigation in the error case for fetching the data.