### PR TITLE
fix(ng-dev): attempt to parse yarn 2+ lock files via yaml

### DIFF
--- a/ng-dev/BUILD.bazel
+++ b/ng-dev/BUILD.bazel
@@ -40,6 +40,7 @@ ts_library(
         "//ng-dev/ts-circular-dependencies",
         "//ng-dev/utils",
         "@npm//@types/yargs",
+        "@npm//yaml",
         "@npm//yargs",
     ],
 )

--- a/ng-dev/package.json
+++ b/ng-dev/package.json
@@ -23,6 +23,7 @@
     "semver": "^7.5.4",
     "supports-color": "9.4.0",
     "typed-graphqlify": "^3.1.1",
-    "typescript": "~4.9.0"
+    "typescript": "~4.9.0",
+    "yaml": "2.4.5"
   }
 }


### PR DESCRIPTION
Yarn lock files for version 2 and higher now use a Yaml compatible format and do not require a special parser. To support both legacy 1.x and newer lock files, the existing special parser is first tried and if that fails a Yaml parser is then used.