### PR TITLE
release: switch from ts-node to tsx for release scripting

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -105,7 +105,7 @@ build:remote-cache --google_default_credentials
 # will have a version composed with the current SHA from the SCM stamping info.
 # Note: We usually would use the `ng-dev` tool directly, but that one would need to be
 # built with Bazel and building with Bazel inside the Bazel-invoked workspace status
-# script does not work. To workaround this, we have a `ts-node`-based stamping script.
+# script does not work. To workaround this, we have a `tsx`-based stamping script.
 # TODO: Consider using `ng-dev` directly if this is possible.
 build:release --workspace_status_command="yarn build-env-stamp --mode=release --include-version=false"
 build:release --stamp

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "prepare": "husky install",
     "ng-dev": "bash ./tools/local-dev.sh",
     "lint": "yarn tslint -c tslint.json --project tsconfig.json",
-    "build-env-stamp": "ts-node --transpile-only --esm --project tsconfig.json ./ng-dev/release/stamping/_private_main.ts build-env-stamp",
-    "update-generated-files": "ts-node --transpile-only --esm --project tsconfig.json ./tools/update-generated-files.ts",
+    "build-env-stamp": "tsx --tsconfig tsconfig.json ./ng-dev/release/stamping/_private_main.ts build-env-stamp",
+    "update-generated-files": "tsx --tsconfig tsconfig.json ./tools/update-generated-files.ts",
     "pack": "bazel run //:npm_package.pack --config=release"
   },
   "exports": {
@@ -54,6 +54,7 @@
     "tmp": "^0.2.1",
     "true-case-path": "^2.2.1",
     "tslib": "^2.5.2",
+    "tsx": "^4.15.7",
     "typescript": "5.4.5",
     "uuid": "^10.0.0",
     "yargs": "^17.0.0"
@@ -181,7 +182,7 @@
     "stylelint": "^16.0.0",
     "supports-color": "9.4.0",
     "terser": "5.31.1",
-    "ts-node": "^10.8.1",
+    "ts-node": "^10.9.2",
     "tslint": "^6.1.3",
     "typed-graphqlify": "^3.1.1",
     "wait-on": "^7.0.0",

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -22,4 +22,4 @@ export TS_NODE_PROJECT=${PWD}/.ng-dev/tsconfig.json
 
 # Execute the built ng-dev command in the current working directory
 # and pass-through arguments unmodified.
-node --no-warnings --loader ts-node/esm ${ngDevBinFile} ${@}
+node node_modules/.bin/tsx ${ngDevBinFile} ${@}

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,9 +530,10 @@ __metadata:
     terser: "npm:5.31.1"
     tmp: "npm:^0.2.1"
     true-case-path: "npm:^2.2.1"
-    ts-node: "npm:^10.8.1"
+    ts-node: "npm:^10.9.2"
     tslib: "npm:^2.5.2"
     tslint: "npm:^6.1.3"
+    tsx: "npm:^4.15.7"
     typed-graphqlify: "npm:^3.1.1"
     typescript: "npm:5.4.5"
     uuid: "npm:^10.0.0"
@@ -8250,7 +8251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:0.21.5, esbuild@npm:^0.21.3":
+"esbuild@npm:0.21.5, esbuild@npm:^0.21.3, esbuild@npm:~0.21.4":
   version: 0.21.5
   resolution: "esbuild@npm:0.21.5"
   dependencies:
@@ -9266,6 +9267,15 @@ __metadata:
   version: 8.0.0
   resolution: "get-stdin@npm:8.0.0"
   checksum: 10c0/b71b72b83928221052f713b3b6247ebf1ceaeb4ef76937778557537fd51ad3f586c9e6a7476865022d9394b39b74eed1dc7514052fa74d80625276253571b76f
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:^4.7.5":
+  version: 4.7.5
+  resolution: "get-tsconfig@npm:4.7.5"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/a917dff2ba9ee187c41945736bf9bbab65de31ce5bc1effd76267be483a7340915cff232199406379f26517d2d0a4edcdbcda8cca599c2480a0f2cf1e1de3efa
   languageName: node
   linkType: hard
 
@@ -14020,6 +14030,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
+  languageName: node
+  linkType: hard
+
 "resolve@npm:1.22.8, resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.19.0, resolve@npm:^1.3.2, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
@@ -15692,7 +15709,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-node@npm:^10.8.1":
+"ts-node@npm:^10.9.2":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
   dependencies:
@@ -15797,6 +15814,22 @@ __metadata:
   peerDependencies:
     typescript: ">=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev"
   checksum: 10c0/e37794513526dbf1cf960414d0a65b956ad319dbc93171bccfe08e3fece1eea35b4e130153f41d917a0f28ecac04f3ca78e9a99c4bddc64a5f225925abc0cf14
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.15.7":
+  version: 4.15.7
+  resolution: "tsx@npm:4.15.7"
+  dependencies:
+    esbuild: "npm:~0.21.4"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.5"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 10c0/e960f4ee084b48cd3183e65946725fd9b0de4afae32a0fd9cd47416a41259fb2c72838b7aeba26adaecc2d89d70e976add9722e72ea5c876b3b493f137cbbf12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use tsx as ts-node does not work with newer version of node