### PR TITLE
fix(shared-docs): include hiddenFiles in generated metadata

### DIFF
--- a/docs/pipeline/tutorials/metadata.ts
+++ b/docs/pipeline/tutorials/metadata.ts
@@ -25,7 +25,9 @@ export async function generateMetadata(
     allFiles: Object.keys(files),
     tutorialFiles,
     answerFiles: await getAnswerFiles(path, config, files),
-    hiddenFiles: [],
+    hiddenFiles: config.openFiles
+      ? Object.keys(tutorialFiles).filter((filename) => !config.openFiles!.includes(filename))
+      : [],
     dependencies: {
       ...dependencies,
       ...devDependencies,


### PR DESCRIPTION
Updates the metadata script to generate the `hiddenFiles` field.