### PR TITLE
fix(shared-docs): properly generate hiddenFiles

### DIFF
--- a/docs/pipeline/tutorials/metadata.ts
+++ b/docs/pipeline/tutorials/metadata.ts
@@ -26,7 +26,7 @@ export async function generateMetadata(
     tutorialFiles,
     answerFiles: await getAnswerFiles(path, config, files),
     hiddenFiles: config.openFiles
-      ? Object.keys(tutorialFiles).filter((filename) => !config.openFiles!.includes(filename))
+      ? Object.keys(files).filter((filename) => !config.openFiles!.includes(filename))
       : [],
     dependencies: {
       ...dependencies,


### PR DESCRIPTION
Fixes that the `hiddenFiles` array was always coming up empty because we were filtering on the files that were filtered already.