### PR TITLE
refactor(api-gen): parse links with descriptions

### DIFF
--- a/bazel/api-gen/rendering/entities/renderables.ts
+++ b/bazel/api-gen/rendering/entities/renderables.ts
@@ -106,6 +106,7 @@ export interface CodeLineRenderable {
 export interface LinkEntryRenderable {
   label: string;
   url: string;
+  title?: string;
 }
 
 export type CliOptionRenderable = CliOption & {

--- a/bazel/api-gen/rendering/templates/docs-pill-row.tsx
+++ b/bazel/api-gen/rendering/templates/docs-pill-row.tsx
@@ -15,11 +15,11 @@ export function DocsPillRow(props: {links: LinkEntryRenderable[]}) {
 
   return (
     <nav class="docs-pill-row">
-      {
-        props.links.map((link) => (<a class="docs-pill" href={link.url}>
+      {props.links.map((link) => (
+        <a class="docs-pill" href={link.url} title={link.title}>
           {link.label}
-        </a>))
-      }
+        </a>
+      ))}
     </nav>
   );
 }

--- a/bazel/api-gen/rendering/test/BUILD.bazel
+++ b/bazel/api-gen/rendering/test/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel/api-gen/rendering:render_api_to_html.bzl", "render_api_to_html")
+load("//tools:defaults.bzl", "jasmine_node_test", "ts_library")
 
 render_api_to_html(
     name = "test",
@@ -6,4 +7,25 @@ render_api_to_html(
         "fake-cli-entries.json",
         "fake-entries.json",
     ],
+)
+
+ts_library(
+    name = "unit_test_lib",
+    testonly = True,
+    srcs = glob(
+        [
+            "**/*.spec.ts",
+        ],
+    ),
+    deps = [
+        "//bazel/api-gen/rendering:render_api_to_html_lib",
+        "@npm//@types/jasmine",
+    ],
+)
+
+jasmine_node_test(
+    name = "unit_tests",
+    data = [],
+    external = [],
+    specs = [":unit_test_lib"],
 )

--- a/bazel/api-gen/rendering/test/transforms/jsdoc-transforms.spec.ts
+++ b/bazel/api-gen/rendering/test/transforms/jsdoc-transforms.spec.ts
@@ -1,0 +1,50 @@
+import {addHtmlAdditionalLinks} from '../../transforms/jsdoc-transforms';
+
+// @ts-ignore This compiles fine, but Webstorm doesn't like the ESM import in a CJS context.
+describe('jsdoc transforms', () => {
+  it('should transform links', () => {
+    const entry = addHtmlAdditionalLinks({
+      jsdocTags: [
+        {
+          name: 'see',
+          comment: '[Angular](https://angular.io)',
+        },
+        {
+          name: 'see',
+          comment: '[Angular](https://angular.io "Angular")',
+        },
+        {
+          name: 'see',
+          comment: '{@link Route}',
+        },
+        {
+          name: 'see',
+          comment: '{@link Route Something else}',
+        },
+      ],
+      moduleName: 'test',
+    });
+
+    expect(entry.additionalLinks[0]).toEqual({
+      label: 'Angular',
+      url: 'https://angular.io',
+      title: undefined,
+    });
+
+    expect(entry.additionalLinks[1]).toEqual({
+      label: 'Angular',
+      url: 'https://angular.io',
+      title: 'Angular',
+    });
+
+    expect(entry.additionalLinks[2]).toEqual({
+      label: 'Route',
+      url: 'api/test/Route',
+    });
+
+    expect(entry.additionalLinks[3]).toEqual({
+      label: 'Something else',
+      url: 'api/test/Route',
+    });
+  });
+});

--- a/bazel/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/bazel/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -192,7 +192,14 @@ function convertJsDocExampleToHtmlExample(text: string): string {
 }
 
 function convertLinks(text: string, entry: HasModuleName) {
-  return text.replace(jsDoclinkRegex, (_, symbol) => {
-    return `<a href="${getLinkToModule(entry.moduleName)}/${symbol}"><code>${symbol}</code></a>`;
+  return text.replace(jsDoclinkRegex, (_, link) => {
+    const [symbol, description] = link.split(/\s(.+)/);
+    if (symbol && description) {
+      // {@link Route Some route with description}
+      return `<a href="${getLinkToModule(entry.moduleName)}/${symbol}"><code>${description}</code></a>`;
+    } else {
+      // {@link Route}
+      return `<a href="${getLinkToModule(entry.moduleName)}/${symbol}"><code>${symbol}</code></a>`;
+    }
   });
 }

--- a/bazel/api-gen/rendering/transforms/jsdoc-transforms.ts
+++ b/bazel/api-gen/rendering/transforms/jsdoc-transforms.ts
@@ -129,7 +129,7 @@ export function setEntryFlags<T extends HasJsDocTags & HasModuleName>(
 function getHtmlAdditionalLinks<T extends HasJsDocTags & HasModuleName>(
   entry: T,
 ): LinkEntryRenderable[] {
-  const markdownLinkRule = /\[([^\]]+)\]\(([^)]+)\)/;
+  const markdownLinkRule = /\[(.*?)\]\((.*?)(?: "(.*?)")?\)/;
 
   const seeAlsoLinks = entry.jsdocTags
     .filter((tag) => tag.name === JS_DOC_SEE_TAG)
@@ -141,6 +141,7 @@ function getHtmlAdditionalLinks<T extends HasJsDocTags & HasModuleName>(
         return {
           label: markdownLinkMatch[1],
           url: markdownLinkMatch[2],
+          title: markdownLinkMatch[3],
         };
       }
 


### PR DESCRIPTION
We already parsed the links correctly for the pills but didn't for function descriptions

2nd commits also support markdown links with titles. 

fixes angular/angular#56856
fixes angular/angular#56857