### PR TITLE
feat(apps): create an application and associated function for perform DNS redirects to URLs

### DIFF
--- a/apps/.firebaserc
+++ b/apps/.firebaserc
@@ -5,6 +5,9 @@
       "hosting": {
         "code-of-conduct": [
           "code-of-conduct"
+        ],
+        "dns-redirecting": [
+          "dns-redirecting"
         ]
       }
     }

--- a/apps/BUILD.bazel
+++ b/apps/BUILD.bazel
@@ -55,7 +55,5 @@ nodejs_binary(
         # TODO: Find a way to do this without relying on the copy_to_bin that works cross platform.
         "$$(rlocation dev-infra/apps/firebase.json)",
         "deploy",
-        "--only",
-        "hosting",
     ],
 )

--- a/apps/firebase.json
+++ b/apps/firebase.json
@@ -5,6 +5,15 @@
   },
   "hosting": [
     {
+      "target": "dns-redirecting",
+      "rewrites": [
+        {
+          "source": "**",
+          "function": "dnsRedirecting"
+        }
+      ]
+    },
+    {
       "target": "code-of-conduct",
       "public": "./code-of-conduct",
       "ignore": ["**/.*"],

--- a/apps/functions/BUILD.bazel
+++ b/apps/functions/BUILD.bazel
@@ -18,6 +18,7 @@ ts_library(
     ],
     deps = [
         "//apps/functions/code-of-conduct",
+        "//apps/functions/dns-redirecting",
         "//apps/functions/githubWebhook",
         "//apps/functions/ng-dev",
         "@npm//firebase-admin",

--- a/apps/functions/dns-redirecting/BUILD.bazel
+++ b/apps/functions/dns-redirecting/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:private"])
+
+ts_library(
+    name = "dns-redirecting",
+    srcs = [
+        "index.ts",
+    ],
+    visibility = [
+        "//apps/functions:__pkg__",
+    ],
+    deps = [
+        "@npm//firebase-functions",
+    ],
+)

--- a/apps/functions/dns-redirecting/index.ts
+++ b/apps/functions/dns-redirecting/index.ts
@@ -1,0 +1,27 @@
+import * as functions from 'firebase-functions';
+
+export const dnsRedirecting = functions
+  .runWith({
+    invoker: 'public',
+    timeoutSeconds: 5,
+    minInstances: 1,
+    maxInstances: 2,
+  })
+  .https.onRequest(async (request, response) => {
+    if (request.hostname === 'update.angular.dev') {
+      response.redirect(301, 'https://angular.dev/update-guide');
+    }
+    if (request.hostname === 'update.angular.io') {
+      response.redirect(301, 'https://angular.dev/update-guide');
+    }
+    if (request.hostname === 'cli.angular.io') {
+      response.redirect(301, 'https://angular.dev/cli');
+    }
+    if (request.hostname === 'cli.angular.dev') {
+      response.redirect(301, 'https://angular.dev/cli');
+    }
+
+    // If no redirect is matched, we return a failure message
+    response.status(404);
+    response.send(`No redirect defined for ${request.originalUrl}`);
+  });

--- a/apps/functions/index.ts
+++ b/apps/functions/index.ts
@@ -1,6 +1,7 @@
 export * from './githubWebhook/index.js';
 export * from './ng-dev/index.js';
 export * from './code-of-conduct/index.js';
+export * from './dns-redirecting/index.js';
 import * as admin from 'firebase-admin';
 
 admin.initializeApp();


### PR DESCRIPTION
Create a firebase app which executes a cloud function that redirects known subdomains to specific URLs. This is necessary as a replacement to the feature being available from Google Domains as we have moved away from Google Domains. This initial setup properly redirects update.angular.{io,dev} and cli.angular.{io,dev} to the correct locations