### PR TITLE
fix(github-actions): allow `Apache-2.0 AND BSD-3-Clause` license

### DIFF
--- a/github-actions/linting/licenses/dependency-review-config.yml
+++ b/github-actions/linting/licenses/dependency-review-config.yml
@@ -1,6 +1,7 @@
 vulnerability_check: false
 allow_licenses:
   - '0BSD'
+  - 'Apache-2.0 AND BSD-3-Clause' # Needed for google-protobuf
   - 'Apache-2.0'
   - 'Artistic-2.0'
   - 'BlueOak-1.0.0'


### PR DESCRIPTION
google-protobuf is licensed under a combination of two licenses: Apache-2.0 and BSD-3-Clause.