### PR TITLE
feat(apps): allow for query param usage in testing redirects

### DIFF
--- a/apps/functions/dns-redirecting/index.ts
+++ b/apps/functions/dns-redirecting/index.ts
@@ -8,20 +8,31 @@ export const dnsRedirecting = functions
     maxInstances: 2,
   })
   .https.onRequest(async (request, response) => {
-    if (request.hostname === 'update.angular.dev') {
-      response.redirect(301, 'https://angular.dev/update-guide');
+    let redirectType = 301;
+    /** The hostname that was used for the request. */
+    let hostname = request.hostname;
+
+    // If a hostname is provided as a query param, use it instead. This allows us to verify redirects prior to the
+    // DNS records being setup. We use a 302 redirect for this as its a temporary check.
+    if (request.query['hostname']) {
+      hostname = request.query['hostname'] as string;
+      redirectType = 302;
     }
-    if (request.hostname === 'update.angular.io') {
-      response.redirect(301, 'https://angular.dev/update-guide');
+
+    if (hostname === 'update.angular.dev') {
+      response.redirect(redirectType, 'https://angular.dev/update-guide');
     }
-    if (request.hostname === 'cli.angular.io') {
-      response.redirect(301, 'https://angular.dev/cli');
+    if (hostname === 'update.angular.io') {
+      response.redirect(redirectType, 'https://angular.dev/update-guide');
     }
-    if (request.hostname === 'cli.angular.dev') {
-      response.redirect(301, 'https://angular.dev/cli');
+    if (hostname === 'cli.angular.io') {
+      response.redirect(redirectType, 'https://angular.dev/cli');
     }
-    if (request.hostname === 'blog.angular.io') {
-      response.redirect(301, 'https://blog.angular.dev');
+    if (hostname === 'cli.angular.dev') {
+      response.redirect(redirectType, 'https://angular.dev/cli');
+    }
+    if (hostname === 'blog.angular.io') {
+      response.redirect(redirectType, 'https://blog.angular.dev');
     }
 
     // If no redirect is matched, we return a failure message


### PR DESCRIPTION
By using query parameters, we are able to test if a redirect works as expected and goes to the correct location before the DNS record is set up and active.