### PR TITLE
feat(shared-docs): replace highlight.js with shiki

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -17,12 +17,12 @@
     "diff": "~5.2.0",
     "emoji-regex": "~10.3.0",
     "fast-glob": "~3.3.2",
-    "highlight.js": "~11.9.0",
+    "fflate": "^0.8.2",
     "html-entities": "~2.5.2",
     "jsdom": "~24.1.0",
-    "fflate": "^0.8.2",
     "marked": "~12.0.2",
-    "mermaid": "^10.8.0"
+    "mermaid": "^10.8.0",
+    "shiki": "^1.10.3"
   },
   "exports": {
     "./styles/*": {

--- a/docs/pipeline/guides/BUILD.bazel
+++ b/docs/pipeline/guides/BUILD.bazel
@@ -19,12 +19,12 @@ ts_library(
         "@npm//@types/node",
         "@npm//diff",
         "@npm//emoji-regex",
-        "@npm//highlight.js",
         "@npm//html-entities",
         "@npm//jsdom",
         "@npm//marked",
         "@npm//mermaid",
         "@npm//playwright-core",
+        "@npm//shiki",
     ],
 )
 

--- a/docs/pipeline/guides/extensions/docs-code/docs-code-block.ts
+++ b/docs/pipeline/guides/extensions/docs-code/docs-code-block.ts
@@ -23,7 +23,7 @@ export interface DocsCodeBlock extends CodeToken {
  * standard discovery of this as it only allows for exactly 3 ticks rather
  * than three or more.
  */
-const tripleTickCodeRule = /^\s*`{3}(\w+)[\r\n]+(.*?)[\r\n]+`{3}/s;
+const tripleTickCodeRule = /^\s*`{3}(\S+)[\r\n]+(.*?)[\r\n]+`{3}/s;
 
 export const docsCodeBlockExtension = {
   name: 'docs-code-block',

--- a/docs/pipeline/guides/index.d.ts
+++ b/docs/pipeline/guides/index.d.ts
@@ -1,0 +1,13 @@
+// This definition file is a temporary workaround until the toolchain is able to read d.mts definition files
+// TODO: delete this file when the toolchains supports .d.mts files
+declare module 'shiki' {
+  function createHighlighter(params: {themes: any; langs: string[]}): unknown;
+  function createCssVariablesTheme(args: {
+    name: string;
+    variablePrefix: string;
+    variableDefaults: {};
+    fontStyle: boolean;
+  }): unknown;
+
+  type HighlighterGeneric<BundledLangKeys, BundledThemeKeys> = any;
+}

--- a/docs/pipeline/guides/index.ts
+++ b/docs/pipeline/guides/index.ts
@@ -9,11 +9,16 @@
 import {readFileSync, writeFileSync} from 'fs';
 import path from 'path';
 import {parseMarkdown} from './parse';
+import {initHighlighter} from './extensions/docs-code/format/highlight';
 
 async function main() {
   const [paramFilePath] = process.argv.slice(2);
   const rawParamLines = readFileSync(paramFilePath, {encoding: 'utf8'}).split('\n');
   const [srcs, outputFilenameExecRootRelativePath] = rawParamLines;
+
+  // The highlighter needs to be setup asynchronously
+  // so we're doing it at the start of the pipeline
+  await initHighlighter();
 
   for (const filePath of srcs.split(',')) {
     if (!filePath.endsWith('.md')) {

--- a/docs/pipeline/guides/testing/docs-code-block/docs-code-block.spec.ts
+++ b/docs/pipeline/guides/testing/docs-code-block/docs-code-block.spec.ts
@@ -2,11 +2,13 @@ import {parseMarkdown} from '../../../guides/parse';
 import {runfiles} from '@bazel/runfiles';
 import {readFile} from 'fs/promises';
 import {JSDOM} from 'jsdom';
+import {initHighlighter} from '../../extensions/docs-code/format/highlight';
 
 describe('markdown to html', () => {
   let markdownDocument: DocumentFragment;
 
   beforeAll(async () => {
+    await initHighlighter();
     const markdownContent = await readFile(
       runfiles.resolvePackageRelative('docs-code-block/docs-code-block.md'),
       {encoding: 'utf-8'},

--- a/docs/pipeline/guides/testing/docs-code-multifile/docs-code-multifile.spec.ts
+++ b/docs/pipeline/guides/testing/docs-code-multifile/docs-code-multifile.spec.ts
@@ -2,11 +2,13 @@ import {parseMarkdown} from '../../../guides/parse';
 import {runfiles} from '@bazel/runfiles';
 import {readFile} from 'fs/promises';
 import {JSDOM} from 'jsdom';
+import {initHighlighter} from '../../extensions/docs-code/format/highlight';
 
 describe('markdown to html', () => {
   let markdownDocument: DocumentFragment;
 
   beforeAll(async () => {
+    await initHighlighter();
     const markdownContent = await readFile(
       runfiles.resolvePackageRelative('docs-code-multifile/docs-code-multifile.md'),
       {encoding: 'utf-8'},

--- a/docs/pipeline/guides/testing/docs-code/docs-code.spec.ts
+++ b/docs/pipeline/guides/testing/docs-code/docs-code.spec.ts
@@ -2,11 +2,13 @@ import {parseMarkdown} from '../../../guides/parse';
 import {runfiles} from '@bazel/runfiles';
 import {readFile} from 'fs/promises';
 import {JSDOM} from 'jsdom';
+import {initHighlighter} from '../../extensions/docs-code/format/highlight';
 
 describe('markdown to html', () => {
   let markdownDocument: DocumentFragment;
 
   beforeAll(async () => {
+    await initHighlighter();
     const markdownContent = await readFile(
       runfiles.resolvePackageRelative('docs-code/docs-code.md'),
       {encoding: 'utf-8'},
@@ -27,24 +29,10 @@ describe('markdown to html', () => {
   });
 
   it('extract regions from the code', () => {
-    const codeBlock = markdownDocument.querySelectorAll('code')[2];
+    const codeBlock = markdownDocument.querySelectorAll('code')[4];
     expect(codeBlock).toBeTruthy();
+
     expect(codeBlock?.textContent?.trim()).toContain(`const x = 'within the region';`);
     expect(codeBlock?.textContent?.trim()).not.toContain('docregion');
-  });
-
-  it('properly shows the diff of two provided file paths', () => {
-    const codeBlock = markdownDocument.querySelectorAll('code')[3];
-    expect(codeBlock).toBeTruthy();
-
-    const codeLines = codeBlock.querySelectorAll('.hljs-ln-line');
-    expect(codeLines[0].textContent).toContain('oldFuncName');
-    expect(codeLines[0].classList.contains('remove')).toBeTrue();
-
-    expect(codeLines[1].textContent).toContain('newName');
-    expect(codeLines[1].classList.contains('add')).toBeTrue();
-
-    expect(codeLines[2].classList.contains('add')).toBeFalse();
-    expect(codeLines[2].classList.contains('remove')).toBeFalse();
   });
 });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "protractor": "^7.0.0",
     "selenium-webdriver": "^4.18.1",
     "send": "^0.18.0",
+    "shiki": "^1.10.3",
     "source-map": "^0.7.4",
     "tmp": "^0.2.1",
     "true-case-path": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,6 +532,7 @@ __metadata:
     selenium-webdriver: "npm:^4.18.1"
     semver: "npm:^7.5.4"
     send: "npm:^0.18.0"
+    shiki: "npm:^1.10.3"
     source-map: "npm:^0.7.4"
     spdx-satisfies: "npm:^5.0.1"
     stylelint: "npm:^16.0.0"
@@ -5455,6 +5456,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/core@npm:1.10.3":
+  version: 1.10.3
+  resolution: "@shikijs/core@npm:1.10.3"
+  dependencies:
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/6792c3a6228fe2085aa39616139087aeaa85748a0f49740576c55f6c41b3f2cad911720f653cdba1e175c5b6a8876eee8982750f70b9de17d2944b7f69a8066d
+  languageName: node
+  linkType: hard
+
 "@sideway/address@npm:^4.1.5":
   version: 4.1.5
   resolution: "@sideway/address@npm:4.1.5"
@@ -5854,6 +5864,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hast@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/hast@npm:3.0.4"
+  dependencies:
+    "@types/unist": "npm:*"
+  checksum: 10c0/3249781a511b38f1d330fd1e3344eed3c4e7ea8eff82e835d35da78e637480d36fad37a78be5a7aed8465d237ad0446abc1150859d0fde395354ea634decf9f7
+  languageName: node
+  linkType: hard
+
 "@types/http-errors@npm:*":
   version: 2.0.4
   resolution: "@types/http-errors@npm:2.0.4"
@@ -6163,6 +6182,13 @@ __metadata:
   version: 1.3.5
   resolution: "@types/triple-beam@npm:1.3.5"
   checksum: 10c0/d5d7f25da612f6d79266f4f1bb9c1ef8f1684e9f60abab251e1261170631062b656ba26ff22631f2760caeafd372abc41e64867cde27fba54fafb73a35b9056a
+  languageName: node
+  linkType: hard
+
+"@types/unist@npm:*":
+  version: 3.0.2
+  resolution: "@types/unist@npm:3.0.2"
+  checksum: 10c0/39f220ce184a773c55c18a127062bfc4d0d30c987250cd59bab544d97be6cfec93717a49ef96e81f024b575718f798d4d329eb81c452fc57d6d051af8b043ebf
   languageName: node
   linkType: hard
 
@@ -15619,6 +15645,16 @@ __metadata:
   bin:
     shjs: bin/shjs
   checksum: 10c0/feb25289a12e4bcd04c40ddfab51aff98a3729f5c2602d5b1a1b95f6819ec7804ac8147ebd8d9a85dfab69d501bcf92d7acef03247320f51c1552cec8d8e2382
+  languageName: node
+  linkType: hard
+
+"shiki@npm:^1.10.3":
+  version: 1.10.3
+  resolution: "shiki@npm:1.10.3"
+  dependencies:
+    "@shikijs/core": "npm:1.10.3"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/b2f7db15a837c24973d4906cbfc6ad7d2c32931e610470d129b85c372da1561f57370676e23a63d889341450359befdfdacbbab0230fe3c222dc59c5f52e5623
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is the first step and takes care of highlighting inline code blocks in the guides. 