### PR TITLE
build: perform build of genfiles in parallel before updates

### DIFF
--- a/tools/update-generated-files.ts
+++ b/tools/update-generated-files.ts
@@ -31,6 +31,9 @@ if (queryProcess.status !== 0) {
 
 const updateTargets = queryProcess.stdout.trim().split(/\r?\n/);
 
+// Build all of the targets in parallel.
+spawnSync(bazelPath, ['build', updateTargets.join(' ')], {...spawnOptions, stdio: 'inherit'});
+
 for (const targetName of updateTargets) {
   const proc = spawnSync(bazelPath, ['run', targetName], {...spawnOptions, stdio: 'inherit'});
   if (proc.status !== 0) {


### PR DESCRIPTION
Build all of the generated file targets before running the update command to allow the targets to be build in parallel.