### PR TITLE
fix(shared-docs): extract captured group from heading custom id regexp

### DIFF
--- a/docs/pipeline/guides/testing/heading/heading.spec.ts
+++ b/docs/pipeline/guides/testing/heading/heading.spec.ts
@@ -81,7 +81,7 @@ describe('markdown to html', () => {
     const h2AnchorHref = h2Anchor?.getAttribute('href');
     const h2AnchorContent = h2Anchor?.textContent?.trim();
 
-    expect(h2HeaderId).toContain('my-custom-id');
+    expect(h2HeaderId).toBe('my-custom-id');
     expect(h2AnchorHref).toBe(`#${h2HeaderId}`);
     expect(h2AnchorContent).toBe('My heading');
   });

--- a/docs/pipeline/guides/tranformations/heading.ts
+++ b/docs/pipeline/guides/tranformations/heading.ts
@@ -31,7 +31,7 @@ export const headingRender: RendererApi['heading'] = (text, level, raw) => {
   // extract the extended markdown heading id
   // ex:  ## MyHeading {# myId}
   const customIdRegex = /{#\s*([\w-]+)\s*}/g;
-  const customId = anchorLessText.match(customIdRegex)?.[1];
+  const customId = customIdRegex.exec(anchorLessText)?.[1];
   const link = customId ?? getHeaderId(anchorLessText);
   const label = anchorLessText
     .replaceAll(/`(.*?)`/g, '<code>$1</code>')


### PR DESCRIPTION
`String#match` doesn't return captured group for a "global" pattern. To get it, `RegExp#exec()` is appropriate. The previous test case was passed with a string that converted the entire header to an ID even though the capture failed, so it was fixed to match the custom id exactly.

This PR fixes my fault in #2195 