### PR TITLE
fix(github-actions): remove the `Apache-2.0 AND BSD-3-Clause` license from the allow licenses list

### DIFF
--- a/github-actions/linting/licenses/dependency-review-config.yml
+++ b/github-actions/linting/licenses/dependency-review-config.yml
@@ -1,7 +1,6 @@
 vulnerability_check: false
 allow_licenses:
   - '0BSD'
-  - 'Apache-2.0 AND BSD-3-Clause' # Needed for google-protobuf
   - 'Apache-2.0'
   - 'Artistic-2.0'
   - 'BlueOak-1.0.0'


### PR DESCRIPTION
Remove `Apache-2.0 AND BSD-3-Clause` from the list as the change in parser for the license check action no longer properly handles this license string.