### PR TITLE
ci: allow renovate with AGPL license

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,6 +39,8 @@ jobs:
         # We use this action pinned at main because we need to have an actual version for the config to load.
         # Since using the local version would end up nearly using `main` anyway, this is essentially equivalent.
         uses: angular/dev-infra/github-actions/linting/licenses@main
+        with:
+          allow-dependencies-licenses: 'pkg:npm/renovate'
 
   test:
     timeout-minutes: 15


### PR DESCRIPTION
Allow renovate as a dependency with an agpl license