### PR TITLE
ci: update renovate workflow to use `ubuntu-24.04` as runner

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: yarn --cwd .github/ng-renovate install --immutable


### PR DESCRIPTION
This version of runner uses Node.js 20 by default which is needed by Renovate.

```
Unsupported node environment detected. Please update your node version
```

See: https://github.com/actions/runner-images/issues/9848 and https://github.com/angular/dev-infra/actions/runs/10139617149