### PR TITLE
ci: update renovate to update generated files after renovate update

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -9,7 +9,7 @@ module.exports = {
   forkModeDisallowMaintainerEdits: true,
   onboarding: false,
   persistRepoData: true,
-  allowedPostUpgradeCommands: ['.'],
+  allowedPostUpgradeCommands: ['.', '^yarn update-generated-files$'],
   repositories: [
     'angular/angular',
     'angular/dev-infra',

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,10 @@
   "ignoreDeps": ["rules_pkg", "@angular-devkit/build-angular"],
   "enabledManagers": ["npm", "bazel", "github-actions"],
   "baseBranches": ["main"],
+  "postUpgradeTasks": {
+    "commands": ["yarn update-generated-files"],
+    "executionMode": "update"
+  },
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
Automatically run the update-generated-files script after renovate updates.