### PR TITLE
ci: remove publish_to_github for docs

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -35,4 +35,3 @@ jobs:
         run: |
           ./tools/publish_to_github.sh "@angular/build-tooling" "dev-infra-private-build-tooling-builds" "dist/bin/npm_package"
           ./tools/publish_to_github.sh "@angular/ng-dev" "dev-infra-private-ng-dev-builds" "dist/bin/ng-dev/npm_package"
-          ./tools/publish_to_github.sh "@angular/docs" "dev-infra-private-docs-builds" "dist/bin/docs/npm_package"


### PR DESCRIPTION
Remove publish_to_github usage for publishing docs as we no longer publish them