### PR TITLE
fix(bazel): conditionally add esbuild optimization plugins

### DIFF
--- a/bazel/spec-bundling/spec-bundle.bzl
+++ b/bazel/spec-bundling/spec-bundle.bzl
@@ -60,11 +60,15 @@ def spec_bundle(
         linker_unknown_declaration_handling = linker_unknown_declaration_handling,
     )
 
+    esbuild_config_deps = []
+    if run_angular_linker or downlevel_async_await:
+        esbuild_config_deps = ["//shared-scripts/angular-optimization:js_lib"]
+
     esbuild_config(
         name = "%s_config" % name,
         config_file = ":%s_config_file" % name,
         testonly = True,
-        deps = ["//shared-scripts/angular-optimization:js_lib"],
+        deps = esbuild_config_deps,
     )
 
     if is_browser_test and not workspace_name:


### PR DESCRIPTION

This update prevents the inclusion of esbuild optimization plugins when both linking and downleveling are disabled. It also removes //shared-scripts/angular-optimization:js_lib from the spec-bundle unless explicit linking is required. This change addresses a circular dependency issue previously observed with this rule in the Angular CLI, leading to the removal of a related patch. For more details, see: https://github.com/angular/angular-cli/blob/3c9697a8c34a5e0f3470bde73f11f9f32107f42e/.yarn/patches/%40angular-build-tooling-https-06f4984cdf.patch