### PR TITLE
fix(github-actions): add MIT-0 as a permissible license

### DIFF
--- a/github-actions/linting/licenses/dependency-review-config.yml
+++ b/github-actions/linting/licenses/dependency-review-config.yml
@@ -10,5 +10,6 @@ allow_licenses:
   - 'CC0-1.0'
   - 'ISC'
   - 'MIT'
+  - 'MIT-0'
   - 'Python-2.0'
   - 'Unlicense'


### PR DESCRIPTION
Add MIT-0 as a license we allow to be used in our dependencies