### PR TITLE
feat(bazel): check all known index html file names for the index file

### DIFF
--- a/bazel/http-server/server.ts
+++ b/bazel/http-server/server.ts
@@ -136,7 +136,11 @@ export class HttpServer {
   /** Gets the raw content of the index.html. */
   private _getIndexHtmlContent(): string {
     if (!this._index) {
-      const indexPath = this._resolveUrlFromRunfiles('/index.html');
+      // Check all of the known index file names.
+      const indexPath =
+        this._resolveUrlFromRunfiles('/index.html') ||
+        this._resolveUrlFromRunfiles('/index.csr.html') ||
+        this._resolveUrlFromRunfiles('/index.server.html');
 
       if (!indexPath) {
         throw Error('Could not resolve http server index.html');


### PR DESCRIPTION
Check for `index.csr.html`, `index.html` or `index.server.html` to serve the default index html file.