### PR TITLE
feat(bazel): allow for configuration to relax CORS requirements for http-server

### DIFF
--- a/bazel/http-server/index.bzl
+++ b/bazel/http-server/index.bzl
@@ -48,6 +48,9 @@ def _http_server_rule_impl(ctx):
     if ctx.attr.enable_dev_ui:
         args += "--enable-dev-ui=true "
 
+    if ctx.attr.relax_cors:
+        args += "--relax-cors=true "
+
     for variable_name in ctx.attr.environment_variables:
         args += "--environment-variables '%s' " % variable_name
 
@@ -100,6 +103,10 @@ http_server_rule = rule(
               The development UI can be helpful for throttling network and more. This
               is a feature from the underlying browsersync implementation.
             """,
+        ),
+        "relax_cors": attr.bool(
+            default = False,
+            doc = """Whether to relax the CORS settings on requests.""",
         ),
         "history_api_fallback": attr.bool(
             default = True,

--- a/bazel/http-server/main.ts
+++ b/bazel/http-server/main.ts
@@ -11,7 +11,7 @@ import yargs from 'yargs';
 import {HttpServer} from './server';
 import {setupBazelWatcherSupport} from './ibazel';
 
-const {rootPaths, historyApiFallback, enableDevUi, environmentVariables, port} = yargs(
+const {rootPaths, historyApiFallback, enableDevUi, environmentVariables, port, relaxCors} = yargs(
   process.argv.slice(2),
 )
   .strict()
@@ -20,11 +20,19 @@ const {rootPaths, historyApiFallback, enableDevUi, environmentVariables, port} =
   .option('rootPaths', {type: 'array', string: true, default: ['']})
   .option('environmentVariables', {type: 'array', string: true, default: []})
   .option('enableDevUi', {type: 'boolean', default: false})
+  .option('relaxCors', {type: 'boolean', default: false})
   .parseSync();
 
 // In non-test executions, we will never allow for the browser-sync dev UI.
 const enableUi = process.env.TEST_TARGET === undefined && enableDevUi;
-const server = new HttpServer(port, rootPaths, enableUi, historyApiFallback, environmentVariables);
+const server = new HttpServer(
+  port,
+  rootPaths,
+  enableUi,
+  historyApiFallback,
+  environmentVariables,
+  relaxCors,
+);
 
 // Setup ibazel support.
 setupBazelWatcherSupport(server);

--- a/bazel/http-server/server.ts
+++ b/bazel/http-server/server.ts
@@ -49,6 +49,7 @@ export class HttpServer {
     enableUi: boolean,
     private _historyApiFallback: boolean = false,
     private _environmentVariables: string[] = [],
+    private _relaxCors: boolean = false,
   ) {
     if (enableUi === false) {
       this.options.ui = false;
@@ -174,9 +175,11 @@ export class HttpServer {
   }
 
   private _corsMiddleware(req: http.IncomingMessage, res: http.ServerResponse) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
-    res.setHeader('cross-origin-opener-policy', 'same-origin');
+    if (this._relaxCors) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+      res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    }
   }
 }
 


### PR DESCRIPTION
Allow the configuration to instruct to relax the CORS requirements