### PR TITLE
fix(apps): preserve path when performing redirects for blog.angular.io

### DIFF
--- a/apps/functions/dns-redirecting/index.ts
+++ b/apps/functions/dns-redirecting/index.ts
@@ -41,7 +41,7 @@ export const dnsRedirecting = functions
       response.redirect(redirectType, 'https://angular.dev/cli');
     }
     if (hostname === 'blog.angular.io') {
-      response.redirect(redirectType, 'https://blog.angular.dev');
+      response.redirect(redirectType, `https://blog.angular.dev${request.originalUrl}`);
     }
 
     // If no redirect is matched, we return a failure message

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,17 +2281,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/expand@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "@inquirer/expand@npm:2.3.0"
-  dependencies:
-    "@inquirer/core": "npm:^9.1.0"
-    "@inquirer/type": "npm:^1.5.3"
-    yoctocolors-cjs: "npm:^2.1.2"
-  checksum: 10c0/f2030cb482a715e4d5153c19b3f0fd8bf47c16cdc16e1c669e90985386edf4f7b0f3b0e97e2990bb228878b93716228eb067d94fc557c25d3c5ee58747c0a995
-  languageName: node
-  linkType: hard
-
 "@inquirer/figures@npm:^1.0.5":
   version: 1.0.5
   resolution: "@inquirer/figures@npm:1.0.5"


### PR DESCRIPTION
Ensure that the path for the url is preserved when redirecting from blog.angular.io to blog.angular.dev