### PR TITLE
refactor(ng-dev): Add managed labels for proper remapping

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -60744,6 +60744,16 @@ var managedLabels = createTypedObject()({
     name: "area: docs",
     commitCheck: (c) => c.type === "docs"
   },
+  DETECTED_COMPILER_CHANGE: {
+    description: "Issues related to `ngc`, Angular's template compiler",
+    name: "area: compiler",
+    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli"
+  },
+  DETECTED_PLATFORM_BROWSER_CHANGE: {
+    description: "Issues related to the framework runtime",
+    name: "area: core",
+    commitCheck: (c) => c.type === "platform-browser" || c.type === "core"
+  },
   DETECTED_INFRA_CHANGE: {
     description: "Related the build and CI infrastructure of the project",
     name: "area: build & ci",

--- a/.github/local-actions/labels-sync/main.js
+++ b/.github/local-actions/labels-sync/main.js
@@ -42942,6 +42942,16 @@ var managedLabels = createTypedObject()({
     name: "area: docs",
     commitCheck: (c) => c.type === "docs"
   },
+  DETECTED_COMPILER_CHANGE: {
+    description: "Issues related to `ngc`, Angular's template compiler",
+    name: "area: compiler",
+    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli"
+  },
+  DETECTED_PLATFORM_BROWSER_CHANGE: {
+    description: "Issues related to the framework runtime",
+    name: "area: core",
+    commitCheck: (c) => c.type === "platform-browser" || c.type === "core"
+  },
   DETECTED_INFRA_CHANGE: {
     description: "Related the build and CI infrastructure of the project",
     name: "area: build & ci",

--- a/github-actions/branch-manager/main.js
+++ b/github-actions/branch-manager/main.js
@@ -42942,6 +42942,16 @@ var managedLabels = createTypedObject()({
     name: "area: docs",
     commitCheck: (c) => c.type === "docs"
   },
+  DETECTED_COMPILER_CHANGE: {
+    description: "Issues related to `ngc`, Angular's template compiler",
+    name: "area: compiler",
+    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli"
+  },
+  DETECTED_PLATFORM_BROWSER_CHANGE: {
+    description: "Issues related to the framework runtime",
+    name: "area: core",
+    commitCheck: (c) => c.type === "platform-browser" || c.type === "core"
+  },
   DETECTED_INFRA_CHANGE: {
     description: "Related the build and CI infrastructure of the project",
     name: "area: build & ci",

--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -43407,6 +43407,16 @@ var managedLabels = createTypedObject()({
     name: "area: docs",
     commitCheck: (c) => c.type === "docs"
   },
+  DETECTED_COMPILER_CHANGE: {
+    description: "Issues related to `ngc`, Angular's template compiler",
+    name: "area: compiler",
+    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli"
+  },
+  DETECTED_PLATFORM_BROWSER_CHANGE: {
+    description: "Issues related to the framework runtime",
+    name: "area: core",
+    commitCheck: (c) => c.type === "platform-browser" || c.type === "core"
+  },
   DETECTED_INFRA_CHANGE: {
     description: "Related the build and CI infrastructure of the project",
     name: "area: build & ci",

--- a/github-actions/unified-status-check/main.js
+++ b/github-actions/unified-status-check/main.js
@@ -45726,6 +45726,16 @@ var managedLabels = createTypedObject()({
     name: "area: docs",
     commitCheck: (c) => c.type === "docs"
   },
+  DETECTED_COMPILER_CHANGE: {
+    description: "Issues related to `ngc`, Angular's template compiler",
+    name: "area: compiler",
+    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli"
+  },
+  DETECTED_PLATFORM_BROWSER_CHANGE: {
+    description: "Issues related to the framework runtime",
+    name: "area: core",
+    commitCheck: (c) => c.type === "platform-browser" || c.type === "core"
+  },
   DETECTED_INFRA_CHANGE: {
     description: "Related the build and CI infrastructure of the project",
     name: "area: build & ci",

--- a/ng-dev/pr/common/labels/managed.ts
+++ b/ng-dev/pr/common/labels/managed.ts
@@ -27,6 +27,16 @@ export const managedLabels = createTypedObject<ManagedLabel>()({
     name: 'area: docs',
     commitCheck: (c: Commit) => c.type === 'docs',
   },
+  DETECTED_COMPILER_CHANGE: {
+    description: "Issues related to `ngc`, Angular's template compiler",
+    name: 'area: compiler',
+    commitCheck: (c: Commit) => c.type === 'compiler' || c.type === 'compiler-cli',
+  },
+  DETECTED_PLATFORM_BROWSER_CHANGE: {
+    description: 'Issues related to the framework runtime',
+    name: 'area: core',
+    commitCheck: (c: Commit) => c.type === 'platform-browser' || c.type === 'core',
+  },
   DETECTED_INFRA_CHANGE: {
     description: 'Related the build and CI infrastructure of the project',
     name: 'area: build & ci',


### PR DESCRIPTION
This adds core and compiler to the managed labels list. We have scopes for both that need to be remapped to the singular area label. So this fixes the auto labeling for those.