### PR TITLE
refactor(ng-dev): Add managed http label

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -60763,6 +60763,11 @@ var managedLabels = createTypedObject()({
     description: "Issues related to performance",
     name: "area: performance",
     commitCheck: (c) => c.type === "perf"
+  },
+  DETECTED_HTTP_CHANGE: {
+    description: "",
+    name: "area: common/http",
+    commitCheck: (c) => c.type === "common/http" || c.type === "http"
   }
 });
 

--- a/.github/local-actions/labels-sync/main.js
+++ b/.github/local-actions/labels-sync/main.js
@@ -42961,6 +42961,11 @@ var managedLabels = createTypedObject()({
     description: "Issues related to performance",
     name: "area: performance",
     commitCheck: (c) => c.type === "perf"
+  },
+  DETECTED_HTTP_CHANGE: {
+    description: "",
+    name: "area: common/http",
+    commitCheck: (c) => c.type === "common/http" || c.type === "http"
   }
 });
 

--- a/github-actions/branch-manager/main.js
+++ b/github-actions/branch-manager/main.js
@@ -42961,6 +42961,11 @@ var managedLabels = createTypedObject()({
     description: "Issues related to performance",
     name: "area: performance",
     commitCheck: (c) => c.type === "perf"
+  },
+  DETECTED_HTTP_CHANGE: {
+    description: "",
+    name: "area: common/http",
+    commitCheck: (c) => c.type === "common/http" || c.type === "http"
   }
 });
 

--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -43426,6 +43426,11 @@ var managedLabels = createTypedObject()({
     description: "Issues related to performance",
     name: "area: performance",
     commitCheck: (c) => c.type === "perf"
+  },
+  DETECTED_HTTP_CHANGE: {
+    description: "",
+    name: "area: common/http",
+    commitCheck: (c) => c.type === "common/http" || c.type === "http"
   }
 });
 

--- a/github-actions/unified-status-check/main.js
+++ b/github-actions/unified-status-check/main.js
@@ -45745,6 +45745,11 @@ var managedLabels = createTypedObject()({
     description: "Issues related to performance",
     name: "area: performance",
     commitCheck: (c) => c.type === "perf"
+  },
+  DETECTED_HTTP_CHANGE: {
+    description: "",
+    name: "area: common/http",
+    commitCheck: (c) => c.type === "common/http" || c.type === "http"
   }
 });
 

--- a/ng-dev/pr/common/labels/managed.ts
+++ b/ng-dev/pr/common/labels/managed.ts
@@ -47,4 +47,9 @@ export const managedLabels = createTypedObject<ManagedLabel>()({
     name: 'area: performance',
     commitCheck: (c: Commit) => c.type === 'perf',
   },
+  DETECTED_HTTP_CHANGE: {
+    description: '',
+    name: 'area: common/http',
+    commitCheck: (c: Commit) => c.type === 'common/http' || c.type === 'http',
+  },
 });


### PR DESCRIPTION
This adds another label that has two variants for auto labeling.