### PR TITLE
fix(github-actions): remove oss scorecard summary from dependency checks

### DIFF
--- a/github-actions/linting/licenses/action.yml
+++ b/github-actions/linting/licenses/action.yml
@@ -19,3 +19,4 @@ runs:
       with:
         config-file: '${{ env.ACTION_REPO }}/github-actions/linting/licenses/dependency-review-config.yml@${{ env.ACTION_REF }}'
         allow-dependencies-licenses: '${{inputs.allow-dependencies-licenses}}'
+        show-openssf-scorecard: false


### PR DESCRIPTION
Remove the scorecard summary as we already check scorecard separately, additionally, this should help to avoid too much being placed in the GITHUB_STEP_SUMMARY and causing failures.