### PR TITLE
ci: remove yarn cache from checkout and setup node

### DIFF
--- a/github-actions/npm/checkout-and-setup-node/action.yml
+++ b/github-actions/npm/checkout-and-setup-node/action.yml
@@ -42,7 +42,6 @@ runs:
       with:
         node-version-file: ${{ inputs.node-version-file-path }}
         node-version: ${{ inputs.node-version }}
-        cache: 'yarn'
 
     # TODO(josephperrott): Determine if its safe to use this caching step.
     # - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2


### PR DESCRIPTION
Remove yarn cache from checkout and setup node action.