### PR TITLE
fix(ng-dev): update pullapprove to handle array inclusion checks

### DIFF
--- a/ng-dev/pullapprove/condition_evaluator.ts
+++ b/ng-dev/pullapprove/condition_evaluator.ts
@@ -33,7 +33,9 @@ const conditionEvaluationContext: object = (() => {
   // We cannot process references to `author` in conditions.
   Object.defineProperty(context, 'author', {
     get: () => {
-      throw new PullApproveAuthorStateDependencyError();
+      const x: any = new String();
+      x.matchesAny = true;
+      return x;
     },
   });
 
@@ -79,6 +81,8 @@ export function convertConditionToFunction(
  */
 function transformExpressionToJs(expression: string): string {
   return expression
+    .replace(/^(.+)\s+not in\s+(\[.+\])$/, '!$2.some(x => $1.matchesAny || $1 == x)')
+    .replace(/^(.+)\s+in\s+(.+)$/, '$2.some(x => $1.matchesAny || $1 == x)')
     .replace(/^(.+)\s+not in\s+(.+)$/, '!$2.includes($1)')
     .replace(/^(.+)\s+in\s+(.+)$/, '$2.includes($1)')
     .replace(/not\s+/g, '!');

--- a/ng-dev/pullapprove/verify.spec.ts
+++ b/ng-dev/pullapprove/verify.spec.ts
@@ -79,7 +79,7 @@ describe('group parsing', () => {
     expect(() => fwCore.testFile('any')).not.toThrow();
   });
 
-  it('should never match groups with conditions that rely on author state', () => {
+  describe('automaticall matches for author and', () => {
     const groups = getGroupsFromYaml(`
       groups:
         renovate-notify-group:
@@ -89,8 +89,13 @@ describe('group parsing', () => {
       `);
     const renovateGroup = getGroupByName(groups, 'renovate-notify-group')!;
 
-    expect(renovateGroup.testFile('packages/core/index.ts')).toBe(false);
-    expect(renovateGroup.conditions[0].unverifiable).toBe(true);
+    it('can pass with a file match', () => {
+      expect(renovateGroup.testFile('packages/core/index.ts')).toBe(true);
+    });
+
+    it('can fail without a file match', () => {
+      expect(renovateGroup.testFile('packages/not-core/index.ts')).toBe(false);
+    });
   });
 
   describe('in operator', () => {


### PR DESCRIPTION
Allow the inclusion checks with arrays to be included and still pass verification checks