### PR TITLE
fix(bazel): clear index file on reload with http_server rule

### DIFF
--- a/bazel/http-server/server.ts
+++ b/bazel/http-server/server.ts
@@ -71,6 +71,8 @@ export class HttpServer {
 
   /** Reloads all browsers that currently visit a page from the server. */
   reload() {
+    // Clear the index file cache as the generated script names may change between builds.
+    this._index = null;
     this.server.reload();
   }
 


### PR DESCRIPTION
Clear the index html file so that when the chunks are renamed it continues to load as expected.

Addresses https://github.com/angular/angular/issues/57778