### PR TITLE
fix(ng-dev): remove formatting expectations around constant only globs

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -62167,7 +62167,7 @@ var Buildifier = class extends Formatter {
     };
   }
 };
-var BAZEL_WARNING_FLAG = `--warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,native-build,native-package,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,string-iteration,unused-variable`;
+var BAZEL_WARNING_FLAG = `--warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,native-build,native-package,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,string-iteration,unused-variable`;
 
 // 
 import { join as join3 } from "path";

--- a/ng-dev/format/formatters/buildifier.ts
+++ b/ng-dev/format/formatters/buildifier.ts
@@ -49,7 +49,7 @@ export class Buildifier extends Formatter {
 // The warning flag for buildifier copied from angular/angular's usage.
 const BAZEL_WARNING_FLAG =
   `--warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,` +
-  `attr-single-file,constant-glob,ctx-args,depset-iteration,depset-union,dict-concatenation,` +
+  `attr-single-file,ctx-args,depset-iteration,depset-union,dict-concatenation,` +
   `duplicated-name,filetype,git-repository,http-archive,integer-division,load,` +
   `native-build,native-package,output-group,package-name,package-on-top,positional-args,` +
   `redefined-variable,repository-name,string-iteration,unused-variable`;


### PR DESCRIPTION
Remove the formatting requirement for not including constant only globs. While they are technically less efficient, they are not worth flagging for us compared to the cost of the inefficiency.