### PR TITLE
fix(ng-dev): always output the list of discovered targets as a label

### DIFF
--- a/ng-dev/misc/generated-files/update-generated-files.ts
+++ b/ng-dev/misc/generated-files/update-generated-files.ts
@@ -17,7 +17,12 @@ export async function updateGeneratedFileTargets(): Promise<void> {
   // Query for all of the generated file targets
   const result = await ChildProcess.spawn(
     getBazelBin(),
-    ['query', `"kind(nodejs_binary, //...) intersect attr(name, '.update$', //...)"`],
+    [
+      'query',
+      `"kind(nodejs_binary, //...) intersect attr(name, '.update$', //...)"`,
+      '--output',
+      'label',
+    ],
     {mode: 'silent'},
   );
 
@@ -27,6 +32,11 @@ export async function updateGeneratedFileTargets(): Promise<void> {
   }
 
   const targets = result.stdout.trim().split(/\r?\n/);
+
+  Log.debug.group('Discovered Targets');
+  targets.forEach((target) => Log.debug(target));
+  Log.debug.groupEnd();
+
   spinner.update(`Found ${targets.length} generated file targets to update`);
 
   // Build all of the generated file targets in parallel.


### PR DESCRIPTION
Always output the list of discovered targets for updating generated files as a list of labels instead of including the default types and such