### PR TITLE
fix(github-actions): add `CC-BY-3.0` as a permissible license

### DIFF
--- a/github-actions/linting/licenses/dependency-review-config.yml
+++ b/github-actions/linting/licenses/dependency-review-config.yml
@@ -6,6 +6,7 @@ allow_licenses:
   - 'BlueOak-1.0.0'
   - 'BSD-2-Clause'
   - 'BSD-3-Clause'
+  - 'CC-BY-3.0'
   - 'CC-BY-4.0'
   - 'CC0-1.0'
   - 'ISC'


### PR DESCRIPTION
Add `CC-BY-3.0` as a license we allow to be used in our dependencies