### PR TITLE
refactor(ng-dev): extract common pattern for processing async commands in child-process

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -56702,49 +56702,6 @@ var ChildProcess = class {
       childProcess.on("close", (status) => status === 0 ? resolve() : reject(status));
     });
   }
-  static spawn(command, args, options = {}) {
-    return new Promise((resolve, reject) => {
-      const commandText = `${command} ${args.join(" ")}`;
-      const outputMode = options.mode;
-      const env3 = getEnvironmentForNonInteractiveCommand(options.env);
-      Log.debug(`Executing command: ${commandText}`);
-      const childProcess = _spawn(command, args, { ...options, env: env3, shell: true, stdio: "pipe" });
-      let logOutput = "";
-      let stdout = "";
-      let stderr = "";
-      if (options.input !== void 0) {
-        childProcess.stdin.write(options.input);
-        childProcess.stdin.end();
-      }
-      childProcess.stderr.on("data", (message) => {
-        stderr += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      childProcess.stdout.on("data", (message) => {
-        stdout += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      childProcess.on("close", (exitCode, signal) => {
-        const exitDescription = exitCode !== null ? `exit code "${exitCode}"` : `signal "${signal}"`;
-        const printFn = outputMode === "on-error" ? Log.error : Log.debug;
-        const status = statusFromExitCodeAndSignal(exitCode, signal);
-        printFn(`Command "${commandText}" completed with ${exitDescription}.`);
-        printFn(`Process output: 
-${logOutput}`);
-        if (status === 0 || options.suppressErrorOnFailingExitCode) {
-          resolve({ stdout, stderr, status });
-        } else {
-          reject(outputMode === "silent" ? logOutput : void 0);
-        }
-      });
-    });
-  }
   static spawnSync(command, args, options = {}) {
     const commandText = `${command} ${args.join(" ")}`;
     const env3 = getEnvironmentForNonInteractiveCommand(options.env);
@@ -56756,44 +56713,14 @@ ${logOutput}`);
     }
     throw new Error(stderr);
   }
+  static spawn(command, args, options = {}) {
+    const commandText = `${command} ${args.join(" ")}`;
+    const env3 = getEnvironmentForNonInteractiveCommand(options.env);
+    return processAsyncCmd(commandText, options, _spawn(command, args, { ...options, env: env3, shell: true, stdio: "pipe" }));
+  }
   static exec(command, options = {}) {
-    return new Promise((resolve, reject) => {
-      var _a2, _b;
-      const outputMode = options.mode;
-      const env3 = getEnvironmentForNonInteractiveCommand(options.env);
-      Log.debug(`Executing command: ${command}`);
-      const childProcess = _exec(command, { ...options, env: env3 });
-      let logOutput = "";
-      let stdout = "";
-      let stderr = "";
-      (_a2 = childProcess.stderr) == null ? void 0 : _a2.on("data", (message) => {
-        stderr += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      (_b = childProcess.stdout) == null ? void 0 : _b.on("data", (message) => {
-        stdout += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      childProcess.on("close", (exitCode, signal) => {
-        const exitDescription = exitCode !== null ? `exit code "${exitCode}"` : `signal "${signal}"`;
-        const printFn = outputMode === "on-error" ? Log.error : Log.debug;
-        const status = statusFromExitCodeAndSignal(exitCode, signal);
-        printFn(`Command "${command}" completed with ${exitDescription}.`);
-        printFn(`Process output: 
-${logOutput}`);
-        if (status === 0 || options.suppressErrorOnFailingExitCode) {
-          resolve({ stdout, stderr, status });
-        } else {
-          reject(outputMode === "silent" ? logOutput : void 0);
-        }
-      });
-    });
+    const env3 = getEnvironmentForNonInteractiveCommand(options.env);
+    return processAsyncCmd(command, options, _exec(command, { ...options, env: env3 }));
   }
 };
 function statusFromExitCodeAndSignal(exitCode, signal) {
@@ -56802,6 +56729,42 @@ function statusFromExitCodeAndSignal(exitCode, signal) {
 function getEnvironmentForNonInteractiveCommand(userProvidedEnv) {
   const forceColorValue = supports_color_default2.stdout !== false ? supports_color_default2.stdout.level.toString() : void 0;
   return { FORCE_COLOR: forceColorValue, ...userProvidedEnv ?? process.env };
+}
+function processAsyncCmd(command, options, childProcess) {
+  return new Promise((resolve, reject) => {
+    var _a2, _b;
+    let logOutput = "";
+    let stdout = "";
+    let stderr = "";
+    Log.debug(`Executing command: ${command}`);
+    (_a2 = childProcess.stderr) == null ? void 0 : _a2.on("data", (message) => {
+      stderr += message;
+      logOutput += message;
+      if (options.mode === void 0 || options.mode === "enabled") {
+        process.stderr.write(message);
+      }
+    });
+    (_b = childProcess.stdout) == null ? void 0 : _b.on("data", (message) => {
+      stdout += message;
+      logOutput += message;
+      if (options.mode === void 0 || options.mode === "enabled") {
+        process.stderr.write(message);
+      }
+    });
+    childProcess.on("close", (exitCode, signal) => {
+      const exitDescription = exitCode !== null ? `exit code "${exitCode}"` : `signal "${signal}"`;
+      const printFn = options.mode === "on-error" ? Log.error : Log.debug;
+      const status = statusFromExitCodeAndSignal(exitCode, signal);
+      printFn(`Command "${command}" completed with ${exitDescription}.`);
+      printFn(`Process output: 
+${logOutput}`);
+      if (status === 0 || options.suppressErrorOnFailingExitCode) {
+        resolve({ stdout, stderr, status });
+      } else {
+        reject(options.mode === "silent" ? logOutput : void 0);
+      }
+    });
+  });
 }
 
 // 

--- a/github-actions/create-pr-for-changes/main.js
+++ b/github-actions/create-pr-for-changes/main.js
@@ -41511,49 +41511,6 @@ var ChildProcess = class {
       childProcess.on("close", (status) => status === 0 ? resolve() : reject(status));
     });
   }
-  static spawn(command, args, options = {}) {
-    return new Promise((resolve, reject) => {
-      const commandText = `${command} ${args.join(" ")}`;
-      const outputMode = options.mode;
-      const env3 = getEnvironmentForNonInteractiveCommand(options.env);
-      Log.debug(`Executing command: ${commandText}`);
-      const childProcess = _spawn(command, args, { ...options, env: env3, shell: true, stdio: "pipe" });
-      let logOutput = "";
-      let stdout = "";
-      let stderr = "";
-      if (options.input !== void 0) {
-        childProcess.stdin.write(options.input);
-        childProcess.stdin.end();
-      }
-      childProcess.stderr.on("data", (message) => {
-        stderr += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      childProcess.stdout.on("data", (message) => {
-        stdout += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      childProcess.on("close", (exitCode, signal) => {
-        const exitDescription = exitCode !== null ? `exit code "${exitCode}"` : `signal "${signal}"`;
-        const printFn = outputMode === "on-error" ? Log.error : Log.debug;
-        const status = statusFromExitCodeAndSignal(exitCode, signal);
-        printFn(`Command "${commandText}" completed with ${exitDescription}.`);
-        printFn(`Process output: 
-${logOutput}`);
-        if (status === 0 || options.suppressErrorOnFailingExitCode) {
-          resolve({ stdout, stderr, status });
-        } else {
-          reject(outputMode === "silent" ? logOutput : void 0);
-        }
-      });
-    });
-  }
   static spawnSync(command, args, options = {}) {
     const commandText = `${command} ${args.join(" ")}`;
     const env3 = getEnvironmentForNonInteractiveCommand(options.env);
@@ -41565,44 +41522,14 @@ ${logOutput}`);
     }
     throw new Error(stderr);
   }
+  static spawn(command, args, options = {}) {
+    const commandText = `${command} ${args.join(" ")}`;
+    const env3 = getEnvironmentForNonInteractiveCommand(options.env);
+    return processAsyncCmd(commandText, options, _spawn(command, args, { ...options, env: env3, shell: true, stdio: "pipe" }));
+  }
   static exec(command, options = {}) {
-    return new Promise((resolve, reject) => {
-      var _a, _b;
-      const outputMode = options.mode;
-      const env3 = getEnvironmentForNonInteractiveCommand(options.env);
-      Log.debug(`Executing command: ${command}`);
-      const childProcess = _exec(command, { ...options, env: env3 });
-      let logOutput = "";
-      let stdout = "";
-      let stderr = "";
-      (_a = childProcess.stderr) == null ? void 0 : _a.on("data", (message) => {
-        stderr += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      (_b = childProcess.stdout) == null ? void 0 : _b.on("data", (message) => {
-        stdout += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      childProcess.on("close", (exitCode, signal) => {
-        const exitDescription = exitCode !== null ? `exit code "${exitCode}"` : `signal "${signal}"`;
-        const printFn = outputMode === "on-error" ? Log.error : Log.debug;
-        const status = statusFromExitCodeAndSignal(exitCode, signal);
-        printFn(`Command "${command}" completed with ${exitDescription}.`);
-        printFn(`Process output: 
-${logOutput}`);
-        if (status === 0 || options.suppressErrorOnFailingExitCode) {
-          resolve({ stdout, stderr, status });
-        } else {
-          reject(outputMode === "silent" ? logOutput : void 0);
-        }
-      });
-    });
+    const env3 = getEnvironmentForNonInteractiveCommand(options.env);
+    return processAsyncCmd(command, options, _exec(command, { ...options, env: env3 }));
   }
 };
 function statusFromExitCodeAndSignal(exitCode, signal) {
@@ -41611,6 +41538,42 @@ function statusFromExitCodeAndSignal(exitCode, signal) {
 function getEnvironmentForNonInteractiveCommand(userProvidedEnv) {
   const forceColorValue = supports_color_default2.stdout !== false ? supports_color_default2.stdout.level.toString() : void 0;
   return { FORCE_COLOR: forceColorValue, ...userProvidedEnv ?? process.env };
+}
+function processAsyncCmd(command, options, childProcess) {
+  return new Promise((resolve, reject) => {
+    var _a, _b;
+    let logOutput = "";
+    let stdout = "";
+    let stderr = "";
+    Log.debug(`Executing command: ${command}`);
+    (_a = childProcess.stderr) == null ? void 0 : _a.on("data", (message) => {
+      stderr += message;
+      logOutput += message;
+      if (options.mode === void 0 || options.mode === "enabled") {
+        process.stderr.write(message);
+      }
+    });
+    (_b = childProcess.stdout) == null ? void 0 : _b.on("data", (message) => {
+      stdout += message;
+      logOutput += message;
+      if (options.mode === void 0 || options.mode === "enabled") {
+        process.stderr.write(message);
+      }
+    });
+    childProcess.on("close", (exitCode, signal) => {
+      const exitDescription = exitCode !== null ? `exit code "${exitCode}"` : `signal "${signal}"`;
+      const printFn = options.mode === "on-error" ? Log.error : Log.debug;
+      const status = statusFromExitCodeAndSignal(exitCode, signal);
+      printFn(`Command "${command}" completed with ${exitDescription}.`);
+      printFn(`Process output: 
+${logOutput}`);
+      if (status === 0 || options.suppressErrorOnFailingExitCode) {
+        resolve({ stdout, stderr, status });
+      } else {
+        reject(options.mode === "silent" ? logOutput : void 0);
+      }
+    });
+  });
 }
 
 // 

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -53435,49 +53435,6 @@ var ChildProcess = class {
       childProcess.on("close", (status) => status === 0 ? resolve() : reject(status));
     });
   }
-  static spawn(command, args, options = {}) {
-    return new Promise((resolve, reject) => {
-      const commandText = `${command} ${args.join(" ")}`;
-      const outputMode = options.mode;
-      const env3 = getEnvironmentForNonInteractiveCommand(options.env);
-      Log.debug(`Executing command: ${commandText}`);
-      const childProcess = _spawn(command, args, { ...options, env: env3, shell: true, stdio: "pipe" });
-      let logOutput = "";
-      let stdout = "";
-      let stderr = "";
-      if (options.input !== void 0) {
-        childProcess.stdin.write(options.input);
-        childProcess.stdin.end();
-      }
-      childProcess.stderr.on("data", (message) => {
-        stderr += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      childProcess.stdout.on("data", (message) => {
-        stdout += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      childProcess.on("close", (exitCode, signal) => {
-        const exitDescription = exitCode !== null ? `exit code "${exitCode}"` : `signal "${signal}"`;
-        const printFn = outputMode === "on-error" ? Log.error : Log.debug;
-        const status = statusFromExitCodeAndSignal(exitCode, signal);
-        printFn(`Command "${commandText}" completed with ${exitDescription}.`);
-        printFn(`Process output: 
-${logOutput}`);
-        if (status === 0 || options.suppressErrorOnFailingExitCode) {
-          resolve({ stdout, stderr, status });
-        } else {
-          reject(outputMode === "silent" ? logOutput : void 0);
-        }
-      });
-    });
-  }
   static spawnSync(command, args, options = {}) {
     const commandText = `${command} ${args.join(" ")}`;
     const env3 = getEnvironmentForNonInteractiveCommand(options.env);
@@ -53489,44 +53446,14 @@ ${logOutput}`);
     }
     throw new Error(stderr);
   }
+  static spawn(command, args, options = {}) {
+    const commandText = `${command} ${args.join(" ")}`;
+    const env3 = getEnvironmentForNonInteractiveCommand(options.env);
+    return processAsyncCmd(commandText, options, _spawn(command, args, { ...options, env: env3, shell: true, stdio: "pipe" }));
+  }
   static exec(command, options = {}) {
-    return new Promise((resolve, reject) => {
-      var _a2, _b;
-      const outputMode = options.mode;
-      const env3 = getEnvironmentForNonInteractiveCommand(options.env);
-      Log.debug(`Executing command: ${command}`);
-      const childProcess = _exec(command, { ...options, env: env3 });
-      let logOutput = "";
-      let stdout = "";
-      let stderr = "";
-      (_a2 = childProcess.stderr) == null ? void 0 : _a2.on("data", (message) => {
-        stderr += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      (_b = childProcess.stdout) == null ? void 0 : _b.on("data", (message) => {
-        stdout += message;
-        logOutput += message;
-        if (outputMode === void 0 || outputMode === "enabled") {
-          process.stderr.write(message);
-        }
-      });
-      childProcess.on("close", (exitCode, signal) => {
-        const exitDescription = exitCode !== null ? `exit code "${exitCode}"` : `signal "${signal}"`;
-        const printFn = outputMode === "on-error" ? Log.error : Log.debug;
-        const status = statusFromExitCodeAndSignal(exitCode, signal);
-        printFn(`Command "${command}" completed with ${exitDescription}.`);
-        printFn(`Process output: 
-${logOutput}`);
-        if (status === 0 || options.suppressErrorOnFailingExitCode) {
-          resolve({ stdout, stderr, status });
-        } else {
-          reject(outputMode === "silent" ? logOutput : void 0);
-        }
-      });
-    });
+    const env3 = getEnvironmentForNonInteractiveCommand(options.env);
+    return processAsyncCmd(command, options, _exec(command, { ...options, env: env3 }));
   }
 };
 function statusFromExitCodeAndSignal(exitCode, signal) {
@@ -53535,6 +53462,42 @@ function statusFromExitCodeAndSignal(exitCode, signal) {
 function getEnvironmentForNonInteractiveCommand(userProvidedEnv) {
   const forceColorValue = supports_color_default2.stdout !== false ? supports_color_default2.stdout.level.toString() : void 0;
   return { FORCE_COLOR: forceColorValue, ...userProvidedEnv ?? process.env };
+}
+function processAsyncCmd(command, options, childProcess) {
+  return new Promise((resolve, reject) => {
+    var _a2, _b;
+    let logOutput = "";
+    let stdout = "";
+    let stderr = "";
+    Log.debug(`Executing command: ${command}`);
+    (_a2 = childProcess.stderr) == null ? void 0 : _a2.on("data", (message) => {
+      stderr += message;
+      logOutput += message;
+      if (options.mode === void 0 || options.mode === "enabled") {
+        process.stderr.write(message);
+      }
+    });
+    (_b = childProcess.stdout) == null ? void 0 : _b.on("data", (message) => {
+      stdout += message;
+      logOutput += message;
+      if (options.mode === void 0 || options.mode === "enabled") {
+        process.stderr.write(message);
+      }
+    });
+    childProcess.on("close", (exitCode, signal) => {
+      const exitDescription = exitCode !== null ? `exit code "${exitCode}"` : `signal "${signal}"`;
+      const printFn = options.mode === "on-error" ? Log.error : Log.debug;
+      const status = statusFromExitCodeAndSignal(exitCode, signal);
+      printFn(`Command "${command}" completed with ${exitDescription}.`);
+      printFn(`Process output: 
+${logOutput}`);
+      if (status === 0 || options.suppressErrorOnFailingExitCode) {
+        resolve({ stdout, stderr, status });
+      } else {
+        reject(options.mode === "silent" ? logOutput : void 0);
+      }
+    });
+  });
 }
 
 // 


### PR DESCRIPTION
Extract the common pattern for processing the ChildProcess object to be shared instead of requiring management of the same action in two places.