### PR TITLE
refactor(ng-dev): use the same symbols for failure, success and pending for terminal outputs

### DIFF
--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -63600,7 +63600,7 @@ async function formatFiles(files) {
     Log.error(`Formatting failed, see errors above for more information.`);
     return 1;
   }
-  Log.info(green(`\u221A  Formatting complete.`));
+  Log.info(green(`\u2714  Formatting complete.`));
   return 0;
 }
 

--- a/ng-dev/caretaker/check/ci.spec.ts
+++ b/ng-dev/caretaker/check/ci.spec.ts
@@ -9,7 +9,7 @@ import semver from 'semver';
 
 import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client.js';
 import {ActiveReleaseTrains, ReleaseTrain} from '../../release/versioning/index.js';
-import {Log} from '../../utils/logging.js';
+import {green, Log} from '../../utils/logging.js';
 import {installVirtualGitClientSpies, mockNgDevConfig} from '../../utils/testing/index.js';
 
 import {CiModule} from './ci.js';
@@ -125,7 +125,7 @@ describe('CiModule', () => {
     await module.printToTerminal();
 
     expect(debugSpy).toHaveBeenCalledWith('No active release train for name1');
-    expect(infoSpy).toHaveBeenCalledWith('label0 ✅');
+    expect(infoSpy).toHaveBeenCalledWith(`label0 ${green('✔')}`);
   });
 });
 

--- a/ng-dev/caretaker/check/ci.ts
+++ b/ng-dev/caretaker/check/ci.ts
@@ -14,7 +14,7 @@ import {
 } from '../../release/versioning/index.js';
 import githubMacros from '../../utils/git/github-macros.js';
 
-import {bold, Log} from '../../utils/logging.js';
+import {bold, green, Log, red, yellow} from '../../utils/logging.js';
 import {BaseModule} from './base.js';
 
 /** The result of checking a branch on CI. */
@@ -81,11 +81,11 @@ export class CiModule extends BaseModule<CiData> {
       if (result.status === null) {
         Log.info(`${result.name} branch was not found on CI`);
       } else if (result.status === 'passing') {
-        Log.info(`${label} ✅`);
+        Log.info(`${label} ${green('✔')}`);
       } else if (result.status === 'pending') {
-        Log.info(`${label} 🟡`);
+        Log.info(`${label} ${yellow('⏺')}`);
       } else {
-        Log.info(`${label} ❌`);
+        Log.info(`${label} ${red('✘')}`);
       }
     });
     Log.info.groupEnd();

--- a/ng-dev/caretaker/check/g3.spec.ts
+++ b/ng-dev/caretaker/check/g3.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client.js';
-import {Log} from '../../utils/logging.js';
+import {green, Log} from '../../utils/logging.js';
 import {installVirtualGitClientSpies, mockNgDevConfig} from '../../utils/testing/index.js';
 
 import {G3Module} from './g3.js';
@@ -75,7 +75,7 @@ describe('G3Module', () => {
       await module.printToTerminal();
 
       expect(infoSpy).toHaveBeenCalledWith('25 commits between g3 and master');
-      expect(infoSpy).toHaveBeenCalledWith('✅  No sync is needed at this time');
+      expect(infoSpy).toHaveBeenCalledWith(` ${green('✔')} No sync is needed at this time`);
     });
   });
 });

--- a/ng-dev/caretaker/check/g3.ts
+++ b/ng-dev/caretaker/check/g3.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {bold, Log} from '../../utils/logging.js';
+import {bold, green, Log} from '../../utils/logging.js';
 import {G3StatsData, G3Stats} from '../../utils/g3.js';
 
 import {BaseModule} from './base.js';
@@ -24,7 +24,7 @@ export class G3Module extends BaseModule<G3StatsData | void> {
     Log.info.group(bold('g3 branch check'));
     if (stats.files === 0 && stats.separateFiles === 0) {
       Log.info(`${stats.commits} commits between g3 and ${this.git.mainBranchName}`);
-      Log.info('✅  No sync is needed at this time');
+      Log.info(` ${green('✔')} No sync is needed at this time`);
     } else if (stats.separateFiles > 0) {
       Log.info(
         `${stats.separateFiles} primitives files changed, ${stats.files} Angular files changed, ` +

--- a/ng-dev/caretaker/check/services.spec.ts
+++ b/ng-dev/caretaker/check/services.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client.js';
-import {Log} from '../../utils/logging.js';
+import {green, Log, red} from '../../utils/logging.js';
 import {installVirtualGitClientSpies, mockNgDevConfig} from '../../utils/testing/index.js';
 
 import {services, ServicesModule} from './services.js';
@@ -68,9 +68,9 @@ describe('ServicesModule', () => {
       await module.printToTerminal();
 
       expect(infoGroupSpy).toHaveBeenCalledWith('Service Statuses');
-      expect(infoSpy).toHaveBeenCalledWith('Service 1 ✅');
+      expect(infoSpy).toHaveBeenCalledWith(`Service 1 ${green('✔')}`);
       expect(infoGroupSpy).toHaveBeenCalledWith(
-        `Service 2 ❌ (Updated: ${new Date(0).toLocaleString()})`,
+        `Service 2 ${red('✘')} (Updated: ${new Date(0).toLocaleString()})`,
       );
       expect(infoSpy).toHaveBeenCalledWith('  Details: Literally everything is broken');
       expect(infoSpy).toHaveBeenCalledWith('  Status URL: http://notgoogle.com');

--- a/ng-dev/caretaker/check/services.ts
+++ b/ng-dev/caretaker/check/services.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {bold, Log} from '../../utils/logging.js';
+import {bold, green, Log, red} from '../../utils/logging.js';
 import {BaseModule} from './base.js';
 
 interface ServiceConfig {
@@ -69,9 +69,9 @@ export class ServicesModule extends BaseModule<StatusCheckResult[]> {
     for (const status of statuses) {
       const name = status.name.padEnd(serviceNameMinLength);
       if (status.status === 'passing') {
-        Log.info(`${name} ✅`);
+        Log.info(`${name} ${green('✔')}`);
       } else {
-        Log.info.group(`${name} ❌ (Updated: ${status.lastUpdated.toLocaleString()})`);
+        Log.info.group(`${name} ${red('✘')} (Updated: ${status.lastUpdated.toLocaleString()})`);
         Log.info(`  Details: ${status.description}`);
         Log.info(`  Status URL: ${status.statusUrl}`);
         Log.info.groupEnd();

--- a/ng-dev/caretaker/handoff/update-github-team.ts
+++ b/ng-dev/caretaker/handoff/update-github-team.ts
@@ -54,7 +54,7 @@ export async function updateCaretakerTeamViaPrompt() {
   }
 
   if (JSON.stringify(selected) === JSON.stringify(current)) {
-    Log.info(green('  √  Caretaker group already up to date.'));
+    Log.info(green('  ✔  Caretaker group already up to date.'));
     return;
   }
 
@@ -64,7 +64,7 @@ export async function updateCaretakerTeamViaPrompt() {
     Log.error('  ✘  Failed to update caretaker group.');
     return;
   }
-  Log.info(green('  √  Successfully updated caretaker group'));
+  Log.info(green('  ✔  Successfully updated caretaker group'));
 }
 
 /** Retrieve the current list of members for the provided group. */

--- a/ng-dev/commit-message/validate-file/validate-file.ts
+++ b/ng-dev/commit-message/validate-file/validate-file.ts
@@ -23,7 +23,7 @@ export async function validateFile(filePath: string, isErrorMode: boolean) {
   const commitMessage = readFileSync(resolve(git.baseDir, filePath), 'utf8');
   const {valid, errors} = await validateCommitMessage(commitMessage);
   if (valid) {
-    Log.info(`${green('√')}  Valid commit message`);
+    Log.info(`${green('✔')}  Valid commit message`);
     deleteCommitMessageDraft(filePath);
     process.exitCode = 0;
     return;

--- a/ng-dev/commit-message/validate-range/validate-range.ts
+++ b/ng-dev/commit-message/validate-range/validate-range.ts
@@ -56,7 +56,7 @@ export async function validateCommitRange(from: string, to: string): Promise<voi
   }
 
   if (allCommitsInRangeValid) {
-    Log.info(green('√  All commit messages in range valid.'));
+    Log.info(green('✔  All commit messages in range valid.'));
   } else {
     Log.error('✘  Invalid commit message');
     errors.forEach(([header, validationErrors]) => {

--- a/ng-dev/format/format.ts
+++ b/ng-dev/format/format.ts
@@ -34,7 +34,7 @@ export async function formatFiles(files: string[]): Promise<1 | 0> {
     Log.error(`Formatting failed, see errors above for more information.`);
     return 1;
   }
-  Log.info(green(`√  Formatting complete.`));
+  Log.info(green(`✔  Formatting complete.`));
   return 0;
 }
 
@@ -78,7 +78,7 @@ export async function checkFiles(files: string[]) {
       return 1;
     }
   } else {
-    Log.info(green('√  All files correctly formatted.'));
+    Log.info(green('✔  All files correctly formatted.'));
     return 0;
   }
 }

--- a/ng-dev/ngbot/verify.ts
+++ b/ng-dev/ngbot/verify.ts
@@ -23,7 +23,7 @@ export async function verify() {
   try {
     // Try parsing the config file to verify that the syntax is correct.
     parseYaml(ngBotYaml);
-    Log.info(green('√  Valid NgBot YAML config'));
+    Log.info(green('✔  Valid NgBot YAML config'));
   } catch (e) {
     Log.error(`! Invalid NgBot YAML config`);
     Log.error(e);

--- a/ng-dev/ts-circular-dependencies/index.ts
+++ b/ng-dev/ts-circular-dependencies/index.ts
@@ -90,10 +90,10 @@ export function main(
 
   if (approve) {
     writeFileSync(goldenFile, JSON.stringify(actual, null, 2));
-    Log.info(green('✅  Updated golden file.'));
+    Log.info(green('✔  Updated golden file.'));
     return 0;
   } else if (!existsSync(goldenFile)) {
-    Log.error(`❌  Could not find golden file: ${goldenFile}`);
+    Log.error(`x  Could not find golden file: ${goldenFile}`);
     return 1;
   }
 
@@ -121,11 +121,11 @@ export function main(
   const isMatching = fixedCircularDeps.length === 0 && newCircularDeps.length === 0;
 
   if (isMatching) {
-    Log.info(green('✅  Golden matches current circular dependencies.'));
+    Log.info(green('✔  Golden matches current circular dependencies.'));
     return 0;
   }
 
-  Log.error('❌  Golden does not match current circular dependencies.');
+  Log.error('✘  Golden does not match current circular dependencies.');
   if (newCircularDeps.length !== 0) {
     Log.error(`   New circular dependencies which are not allowed:`);
     newCircularDeps.forEach((c) => Log.error(`     • ${convertReferenceChainToString(c)}`));


### PR DESCRIPTION
Use the same symbols for all terminal outputs to expressing success , pending and failure.