### PR TITLE
build: correctly remove prepare script from build package

### DIFF
--- a/package.bzl
+++ b/package.bzl
@@ -8,7 +8,7 @@ noStampSubstitutions = dict(stampSubstitutions, **{})
 
 basePackageSubstitutions = {
     "(#|//)\\s+BEGIN-DEV-ONLY[\\w\\W]+?(#|//)\\s+END-DEV-ONLY": "",
-    "    \"prepare\": \"husky install\",\n": "",
+    "    \"prepare\": \"husky\",\n": "",
     "@dev-infra//bazel/": "@npm//@angular/build-tooling/bazel/",
     "rlocation \"dev-infra/": "rlocation \"npm/@angular/build-tooling/",
     "//bazel/": "@npm//@angular/build-tooling/bazel/",


### PR DESCRIPTION
This was changed in https://github.com/angular/dev-infra/commit/082dd8ee781c920bfe5fa75065af6ab5a1b2fba9#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6