### PR TITLE
fix(ng-dev): change default of confirm prompt to false

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -59159,7 +59159,13 @@ ${page}${helpTipBottom}${choiceDescription}${import_ansi_escapes4.default.cursor
 // 
 var Prompt = class {
 };
-Prompt.confirm = esm_default4;
+Prompt.confirm = (_config, _context) => {
+  const config = {
+    default: false,
+    ..._config
+  };
+  return esm_default4(config, _context);
+};
 Prompt.input = esm_default5;
 Prompt.checkbox = esm_default2;
 Prompt.select = esm_default11;

--- a/.github/local-actions/changelog/main.js
+++ b/.github/local-actions/changelog/main.js
@@ -58722,7 +58722,13 @@ ${page}${helpTipBottom}${choiceDescription}${import_ansi_escapes4.default.cursor
 // 
 var Prompt = class {
 };
-Prompt.confirm = esm_default4;
+Prompt.confirm = (_config, _context) => {
+  const config2 = {
+    default: false,
+    ..._config
+  };
+  return esm_default4(config2, _context);
+};
 Prompt.input = esm_default5;
 Prompt.checkbox = esm_default2;
 Prompt.select = esm_default11;

--- a/github-actions/slash-commands/main.js
+++ b/github-actions/slash-commands/main.js
@@ -59056,7 +59056,13 @@ ${page}${helpTipBottom}${choiceDescription}${import_ansi_escapes4.default.cursor
 // 
 var Prompt = class {
 };
-Prompt.confirm = esm_default4;
+Prompt.confirm = (_config, _context) => {
+  const config = {
+    default: false,
+    ..._config
+  };
+  return esm_default4(config, _context);
+};
 Prompt.input = esm_default5;
 Prompt.checkbox = esm_default2;
 Prompt.select = esm_default11;

--- a/ng-dev/utils/prompt.ts
+++ b/ng-dev/utils/prompt.ts
@@ -13,7 +13,18 @@ import {confirm, input, checkbox, select, editor} from '@inquirer/prompts';
  * class to allow easier mocking management in test environments.
  */
 export class Prompt {
-  static confirm: typeof confirm = confirm;
+  static confirm: typeof confirm = (
+    // These are extractions of the PromptConfig from the inquirer types.
+    _config: Parameters<typeof confirm>[0],
+    _context: Parameters<typeof confirm>[1],
+  ) => {
+    /** Config to use when creating a confirm prompt, changes the default to `false` instead of `true`. */
+    const config = {
+      default: false,
+      ..._config,
+    };
+    return confirm(config, _context);
+  };
   static input: typeof input = input;
   static checkbox: typeof checkbox = checkbox;
   static select: typeof select = select;


### PR DESCRIPTION
Change the default of the confirm prompt to be false instead of true