### PR TITLE
fix(github-actions): properly assess the full path for artifact metadata

### DIFF
--- a/github-actions/previews/upload-artifacts-to-firebase/extract-artifact-metadata.js
+++ b/github-actions/previews/upload-artifacts-to-firebase/extract-artifact-metadata.js
@@ -19398,11 +19398,14 @@ var artifactMetadata = {
 // 
 async function main() {
   const [artifactDirPath] = process.argv.slice(2);
+  const fullArtifactDirPath = await fs.promises.realpath(artifactDirPath);
   for (const [key, name] of Object.entries(artifactMetadata)) {
-    const expectedPath = path.join(artifactDirPath, name);
+    const expectedPath = path.normalize(path.join(fullArtifactDirPath, name));
     const realPath = await fs.promises.realpath(expectedPath);
     if (expectedPath !== realPath) {
-      throw Error(`Value for unsafe-${key} not stored directly in file as expected, instead stored in ${realPath}`);
+      throw Error(`Value for unsafe-${key} not stored directly in file as expected,
+  expected: ${expectedPath}
+  got: ${realPath}`);
     }
     const content = await fs.promises.readFile(expectedPath, "utf8");
     const outputName = `unsafe-${key}`;

--- a/github-actions/previews/upload-artifacts-to-firebase/lib/extract-artifact-metadata.ts
+++ b/github-actions/previews/upload-artifacts-to-firebase/lib/extract-artifact-metadata.ts
@@ -21,17 +21,19 @@ import {artifactMetadata} from '../../constants.js';
 
 async function main() {
   const [artifactDirPath] = process.argv.slice(2);
+  /** The full path to the artifact directory. */
+  const fullArtifactDirPath = await fs.promises.realpath(artifactDirPath);
 
   for (const [key, name] of Object.entries(artifactMetadata)) {
     /** The expected path of the artifact */
-    const expectedPath = path.join(artifactDirPath, name);
+    const expectedPath = path.normalize(path.join(fullArtifactDirPath, name));
 
     // We confirm that the provided artifact path is actually in the expected location instead of pointing somewhere
     // else to exfiltrate information.
     const realPath = await fs.promises.realpath(expectedPath);
     if (expectedPath !== realPath) {
       throw Error(
-        `Value for unsafe-${key} not stored directly in file as expected, instead stored in ${realPath}`,
+        `Value for unsafe-${key} not stored directly in file as expected,\n  expected: ${expectedPath}\n  got: ${realPath}`,
       );
     }
 


### PR DESCRIPTION
Properly find the full path for artifact metadata, previously we were comparing a full path against a relative path which would always fail