### PR TITLE
build: update actions/upload-artifact digest to 6f51ac0

### DIFF
--- a/github-actions/previews/pack-and-upload-artifact/action.yml
+++ b/github-actions/previews/pack-and-upload-artifact/action.yml
@@ -61,7 +61,7 @@ runs:
         tar -czvf "$pkg" -C '${{steps.copy.outputs.deploy-dir}}' .
         echo "artifact-path=$pkg" >> $GITHUB_OUTPUT
 
-    - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+    - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
       with:
         name: '${{inputs.workflow-artifact-name}}'
         path: '${{steps.pack.outputs.artifact-path}}'

--- a/github-actions/previews/pack-and-upload-artifact/action.yml
+++ b/github-actions/previews/pack-and-upload-artifact/action.yml
@@ -61,7 +61,7 @@ runs:
         tar -czvf "$pkg" -C '${{steps.copy.outputs.deploy-dir}}' .
         echo "artifact-path=$pkg" >> $GITHUB_OUTPUT
 
-    - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+    - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
       with:
         name: '${{inputs.workflow-artifact-name}}'
         path: '${{steps.pack.outputs.artifact-path}}'


### PR DESCRIPTION
Updates to a specific patch version of upload-artifact instead of just the major version.