### PR TITLE
feat(ng-dev): support releasing when operating in a hybrid pnpm rules_js repo

### DIFF
--- a/ng-dev/release/config/index.ts
+++ b/ng-dev/release/config/index.ts
@@ -61,6 +61,12 @@ export interface ReleaseConfig {
     newVersion: string,
     builtPackagesWithInfo: BuiltPackageWithInfo[],
   ) => Promise<void>;
+
+  /**
+   * Whether the repository is in rules_js interop mode, relying on
+   * integrity files to be automatically updated.
+   */
+  rulesJsInteropMode?: boolean;
 }
 
 /**

--- a/ng-dev/release/publish/BUILD.bazel
+++ b/ng-dev/release/publish/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
         "@npm//@types/semver",
         "@npm//@types/yargs",
         "@npm//ejs",
+        "@npm//fast-glob",
         "@npm//folder-hash",
         "@npm//semver",
         "@npm//typed-graphqlify",


### PR DESCRIPTION
Updating the `package.json` for a release also requires updating some Aspect lock files that
capture the hash of the `package.json` file.

The release tool currently doesn't do this, and some tricky manual workaround steps are
needed. This commit automatically runs the sync command.