### PR TITLE
fix(ng-dev): ensure release actions commit aspect lock files

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -136,6 +136,16 @@ export abstract class ReleaseAction {
     }
   }
 
+  /*
+   * Get the modified Aspect lock files if `rulesJsInteropMode` is enabled.
+   */
+  protected getAspectLockFiles(): string[] {
+    // TODO: Remove after `rules_js` migration is complete.
+    return this.config.rulesJsInteropMode
+      ? glob.sync(['.aspect/**', 'pnpm-lock.yaml'], {cwd: this.projectDir})
+      : [];
+  }
+
   /** Gets the most recent commit of a specified branch. */
   protected async getLatestCommitOfBranch(branchName: string): Promise<string> {
     const {
@@ -221,14 +231,11 @@ export abstract class ReleaseAction {
 
     // Commit message for the release point.
     const commitMessage = getCommitMessageForRelease(newVersion);
-
-    const filesToCommit = [workspaceRelativePackageJsonPath, workspaceRelativeChangelogPath];
-
-    // Ensure modified Aspect lock files are included in the release commit.
-    // TODO: Remove after `rules_js` migration is complete.
-    if (this.config.rulesJsInteropMode) {
-      filesToCommit.push(...glob.sync(['.aspect/**', 'pnpm-lock.yaml'], {cwd: this.projectDir}));
-    }
+    const filesToCommit = [
+      workspaceRelativePackageJsonPath,
+      workspaceRelativeChangelogPath,
+      ...this.getAspectLockFiles(),
+    ];
 
     // Create a release staging commit including changelog and version bump.
     await this.createCommit(commitMessage, filesToCommit);

--- a/ng-dev/release/publish/actions/configure-next-as-major.ts
+++ b/ng-dev/release/publish/actions/configure-next-as-major.ts
@@ -38,8 +38,10 @@ export class ConfigureNextAsMajorAction extends ReleaseAction {
     await this.assertPassingGithubStatus(beforeStagingSha, branchName);
     await this.checkoutUpstreamBranch(branchName);
     await this.updateProjectVersion(newVersion);
+
     await this.createCommit(getCommitMessageForNextBranchMajorSwitch(newVersion), [
       workspaceRelativePackageJsonPath,
+      ...this.getAspectLockFiles(),
     ]);
     const pullRequest = await this.pushChangesToForkAndCreatePullRequest(
       branchName,

--- a/ng-dev/release/publish/actions/exceptional-minor/prepare-exceptional-minor.ts
+++ b/ng-dev/release/publish/actions/exceptional-minor/prepare-exceptional-minor.ts
@@ -48,9 +48,12 @@ export class PrepareExceptionalMinorAction extends ReleaseAction {
     await this.updateProjectVersion(this._newVersion, (pkgJson) => {
       pkgJson[exceptionalMinorPackageIndicator] = true;
     });
+
     await this.createCommit(`build: prepare exceptional minor branch: ${this._newBranch}`, [
       workspaceRelativePackageJsonPath,
+      ...this.getAspectLockFiles(),
     ]);
+
     await this.pushHeadToRemoteBranch(this._newBranch);
 
     Log.info(green(`  ✓   Version branch "${this._newBranch}" created.`));

--- a/ng-dev/release/publish/actions/shared/branch-off-next-branch.ts
+++ b/ng-dev/release/publish/actions/shared/branch-off-next-branch.ts
@@ -139,7 +139,10 @@ export abstract class BranchOffNextBranchBaseAction extends CutNpmNextPrerelease
 
     // Create an individual commit for the next version bump. The changelog should go into
     // a separate commit that makes it clear where the changelog is cherry-picked from.
-    await this.createCommit(bumpCommitMessage, [workspaceRelativePackageJsonPath]);
+    await this.createCommit(bumpCommitMessage, [
+      workspaceRelativePackageJsonPath,
+      ...this.getAspectLockFiles(),
+    ]);
 
     await this.prependReleaseNotesToChangelog(releaseNotes);
 


### PR DESCRIPTION
Several actions within the release process were not committing the aspect lock files as expected. This fix ensures that the aspect lock files are properly committed during all relevant stages of the release workflow.