### PR TITLE
fix(ng-dev): move `disallowFixup` to commit message config

### DIFF
--- a/ng-dev/commit-message/config.ts
+++ b/ng-dev/commit-message/config.ts
@@ -14,6 +14,7 @@ export interface CommitMessageConfig {
   minBodyLength: number;
   minBodyLengthTypeExcludes?: string[];
   scopes: string[];
+  disallowFixup?: boolean;
 }
 
 /** Assert the provided config contains a `CommitMessageConfig`. */

--- a/ng-dev/commit-message/validate.spec.ts
+++ b/ng-dev/commit-message/validate.spec.ts
@@ -269,24 +269,27 @@ describe('validate-commit-message.js', () => {
 
       describe('with `disallowFixup`', () => {
         it('when true should fail', async () => {
+          setConfig({...config, commitMessage: {...config.commitMessage, disallowFixup: true}});
+
           const msg = 'fixup! foo';
 
           expectValidationResult(
             await validateCommitMessage(msg, {
-              disallowFixup: true,
               nonFixupCommitHeaders: ['foo', 'bar', 'baz'],
             }),
             INVALID,
-            ['The commit must be manually fixed-up into the target commit as fixup commits are disallowed'],
+            [
+              'The commit must be manually fixed-up into the target commit as fixup commits are disallowed',
+            ],
           );
         });
 
         it('when false should pass', async () => {
+          setConfig({...config, commitMessage: {...config.commitMessage, disallowFixup: false}});
           const msg = 'fixup! foo';
 
           expectValidationResult(
             await validateCommitMessage(msg, {
-              disallowFixup: false,
               nonFixupCommitHeaders: ['foo', 'bar', 'baz'],
             }),
             VALID,

--- a/ng-dev/commit-message/validate.ts
+++ b/ng-dev/commit-message/validate.ts
@@ -15,7 +15,6 @@ import {Commit, parseCommitMessage} from './parse.js';
 /** Options for commit message validation. */
 export interface ValidateCommitMessageOptions {
   disallowSquash?: boolean;
-  disallowFixup?: boolean;
   nonFixupCommitHeaders?: string[];
 }
 
@@ -91,7 +90,7 @@ export async function validateCommitMessage(
     // stripping the `fixup! ` prefix), otherwise we assume this verification will happen in another
     // check.
     if (commit.isFixup) {
-      if (options.disallowFixup) {
+      if (config.disallowFixup) {
         errors.push(
           'The commit must be manually fixed-up into the target commit as fixup commits are disallowed',
         );


### PR DESCRIPTION
This option needs to be configurable from the config