### PR TITLE
fix(ng-dev): fix commitCheck functions for managed labels

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -62440,19 +62440,31 @@ var managedLabels = createTypedObject(ManagedLabel)({
   DETECTED_HTTP_CHANGE: {
     description: "Issues related to HTTP and HTTP Client",
     name: "area: common/http",
-    commitCheck: (c) => c.type === "common/http" || c.type === "http",
+    commitCheck: (c) => c.scope === "common/http" || c.scope === "http",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_COMPILER_CHANGE: {
     description: "Issues related to `ngc`, Angular's template compiler",
     name: "area: compiler",
-    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli",
+    commitCheck: (c) => c.scope === "compiler" || c.scope === "compiler-cli",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_PLATFORM_BROWSER_CHANGE: {
     description: "Issues related to the framework runtime",
     name: "area: core",
-    commitCheck: (c) => c.type === "platform-browser" || c.type === "core",
+    commitCheck: (c) => c.scope === "platform-browser" || c.scope === "core" || c.scope === "platform-browser-dynamic",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_PLATFORM_SERVER_CHANGE: {
+    description: "Issues related to server-side rendering",
+    name: "area: server",
+    commitCheck: (c) => c.scope === "platform-server",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_ZONES_CHANGE: {
+    description: "Issues related to zone.js",
+    name: "area: zones",
+    commitCheck: (c) => c.scope === "zone.js",
     repositories: [ManagedRepositories.ANGULAR]
   }
 });

--- a/.github/local-actions/labels-sync/main.js
+++ b/.github/local-actions/labels-sync/main.js
@@ -45864,19 +45864,31 @@ var managedLabels = createTypedObject(ManagedLabel)({
   DETECTED_HTTP_CHANGE: {
     description: "Issues related to HTTP and HTTP Client",
     name: "area: common/http",
-    commitCheck: (c) => c.type === "common/http" || c.type === "http",
+    commitCheck: (c) => c.scope === "common/http" || c.scope === "http",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_COMPILER_CHANGE: {
     description: "Issues related to `ngc`, Angular's template compiler",
     name: "area: compiler",
-    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli",
+    commitCheck: (c) => c.scope === "compiler" || c.scope === "compiler-cli",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_PLATFORM_BROWSER_CHANGE: {
     description: "Issues related to the framework runtime",
     name: "area: core",
-    commitCheck: (c) => c.type === "platform-browser" || c.type === "core",
+    commitCheck: (c) => c.scope === "platform-browser" || c.scope === "core" || c.scope === "platform-browser-dynamic",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_PLATFORM_SERVER_CHANGE: {
+    description: "Issues related to server-side rendering",
+    name: "area: server",
+    commitCheck: (c) => c.scope === "platform-server",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_ZONES_CHANGE: {
+    description: "Issues related to zone.js",
+    name: "area: zones",
+    commitCheck: (c) => c.scope === "zone.js",
     repositories: [ManagedRepositories.ANGULAR]
   }
 });

--- a/github-actions/branch-manager/main.js
+++ b/github-actions/branch-manager/main.js
@@ -45864,19 +45864,31 @@ var managedLabels = createTypedObject(ManagedLabel)({
   DETECTED_HTTP_CHANGE: {
     description: "Issues related to HTTP and HTTP Client",
     name: "area: common/http",
-    commitCheck: (c) => c.type === "common/http" || c.type === "http",
+    commitCheck: (c) => c.scope === "common/http" || c.scope === "http",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_COMPILER_CHANGE: {
     description: "Issues related to `ngc`, Angular's template compiler",
     name: "area: compiler",
-    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli",
+    commitCheck: (c) => c.scope === "compiler" || c.scope === "compiler-cli",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_PLATFORM_BROWSER_CHANGE: {
     description: "Issues related to the framework runtime",
     name: "area: core",
-    commitCheck: (c) => c.type === "platform-browser" || c.type === "core",
+    commitCheck: (c) => c.scope === "platform-browser" || c.scope === "core" || c.scope === "platform-browser-dynamic",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_PLATFORM_SERVER_CHANGE: {
+    description: "Issues related to server-side rendering",
+    name: "area: server",
+    commitCheck: (c) => c.scope === "platform-server",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_ZONES_CHANGE: {
+    description: "Issues related to zone.js",
+    name: "area: zones",
+    commitCheck: (c) => c.scope === "zone.js",
     repositories: [ManagedRepositories.ANGULAR]
   }
 });

--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -46329,19 +46329,31 @@ var managedLabels = createTypedObject(ManagedLabel)({
   DETECTED_HTTP_CHANGE: {
     description: "Issues related to HTTP and HTTP Client",
     name: "area: common/http",
-    commitCheck: (c) => c.type === "common/http" || c.type === "http",
+    commitCheck: (c) => c.scope === "common/http" || c.scope === "http",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_COMPILER_CHANGE: {
     description: "Issues related to `ngc`, Angular's template compiler",
     name: "area: compiler",
-    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli",
+    commitCheck: (c) => c.scope === "compiler" || c.scope === "compiler-cli",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_PLATFORM_BROWSER_CHANGE: {
     description: "Issues related to the framework runtime",
     name: "area: core",
-    commitCheck: (c) => c.type === "platform-browser" || c.type === "core",
+    commitCheck: (c) => c.scope === "platform-browser" || c.scope === "core" || c.scope === "platform-browser-dynamic",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_PLATFORM_SERVER_CHANGE: {
+    description: "Issues related to server-side rendering",
+    name: "area: server",
+    commitCheck: (c) => c.scope === "platform-server",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_ZONES_CHANGE: {
+    description: "Issues related to zone.js",
+    name: "area: zones",
+    commitCheck: (c) => c.scope === "zone.js",
     repositories: [ManagedRepositories.ANGULAR]
   }
 });

--- a/github-actions/unified-status-check/main.js
+++ b/github-actions/unified-status-check/main.js
@@ -47684,19 +47684,31 @@ var managedLabels = createTypedObject(ManagedLabel)({
   DETECTED_HTTP_CHANGE: {
     description: "Issues related to HTTP and HTTP Client",
     name: "area: common/http",
-    commitCheck: (c) => c.type === "common/http" || c.type === "http",
+    commitCheck: (c) => c.scope === "common/http" || c.scope === "http",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_COMPILER_CHANGE: {
     description: "Issues related to `ngc`, Angular's template compiler",
     name: "area: compiler",
-    commitCheck: (c) => c.type === "compiler" || c.type === "compiler-cli",
+    commitCheck: (c) => c.scope === "compiler" || c.scope === "compiler-cli",
     repositories: [ManagedRepositories.ANGULAR]
   },
   DETECTED_PLATFORM_BROWSER_CHANGE: {
     description: "Issues related to the framework runtime",
     name: "area: core",
-    commitCheck: (c) => c.type === "platform-browser" || c.type === "core",
+    commitCheck: (c) => c.scope === "platform-browser" || c.scope === "core" || c.scope === "platform-browser-dynamic",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_PLATFORM_SERVER_CHANGE: {
+    description: "Issues related to server-side rendering",
+    name: "area: server",
+    commitCheck: (c) => c.scope === "platform-server",
+    repositories: [ManagedRepositories.ANGULAR]
+  },
+  DETECTED_ZONES_CHANGE: {
+    description: "Issues related to zone.js",
+    name: "area: zones",
+    commitCheck: (c) => c.scope === "zone.js",
     repositories: [ManagedRepositories.ANGULAR]
   }
 });

--- a/ng-dev/pr/common/labels/managed.ts
+++ b/ng-dev/pr/common/labels/managed.ts
@@ -47,19 +47,34 @@ export const managedLabels = createTypedObject(ManagedLabel)({
   DETECTED_HTTP_CHANGE: {
     description: 'Issues related to HTTP and HTTP Client',
     name: 'area: common/http',
-    commitCheck: (c: Commit) => c.type === 'common/http' || c.type === 'http',
+    commitCheck: (c: Commit) => c.scope === 'common/http' || c.scope === 'http',
     repositories: [ManagedRepositories.ANGULAR],
   },
   DETECTED_COMPILER_CHANGE: {
     description: "Issues related to `ngc`, Angular's template compiler",
     name: 'area: compiler',
-    commitCheck: (c: Commit) => c.type === 'compiler' || c.type === 'compiler-cli',
+    commitCheck: (c: Commit) => c.scope === 'compiler' || c.scope === 'compiler-cli',
     repositories: [ManagedRepositories.ANGULAR],
   },
   DETECTED_PLATFORM_BROWSER_CHANGE: {
     description: 'Issues related to the framework runtime',
     name: 'area: core',
-    commitCheck: (c: Commit) => c.type === 'platform-browser' || c.type === 'core',
+    commitCheck: (c: Commit) =>
+      c.scope === 'platform-browser' ||
+      c.scope === 'core' ||
+      c.scope === 'platform-browser-dynamic',
+    repositories: [ManagedRepositories.ANGULAR],
+  },
+  DETECTED_PLATFORM_SERVER_CHANGE: {
+    description: 'Issues related to server-side rendering',
+    name: 'area: server',
+    commitCheck: (c: Commit) => c.scope === 'platform-server',
+    repositories: [ManagedRepositories.ANGULAR],
+  },
+  DETECTED_ZONES_CHANGE: {
+    description: 'Issues related to zone.js',
+    name: 'area: zones',
+    commitCheck: (c: Commit) => c.scope === 'zone.js',
     repositories: [ManagedRepositories.ANGULAR],
   },
 });


### PR DESCRIPTION
Some of the managed labels were incorrectly looking at type rather than scope for their commitCheck function, which resulted in always failing to match.