### PR TITLE
feat(ng-dev): expose utilities for resolving yarn

### DIFF
--- a/ng-dev/index.ts
+++ b/ng-dev/index.ts
@@ -38,3 +38,6 @@ export * from './utils/logging.js';
 export * from './utils/git/authenticated-git-client.js';
 export * from './utils/git/git-client.js';
 export * from './utils/git/github.js';
+
+// Exposes common utils needed for consumer scripts
+export {resolveYarnScriptForProject, YarnCommandInfo} from './utils/resolve-yarn-bin.js';


### PR DESCRIPTION
This is useful for the docs deployment script in Material, where we currently have two different Yarn versions.