### PR TITLE
fix(ng-dev): add `which` to direct dependencies

### DIFF
--- a/ng-dev/package.json
+++ b/ng-dev/package.json
@@ -25,6 +25,7 @@
     "supports-color": "10.0.0",
     "typed-graphqlify": "^3.1.1",
     "typescript": "~4.9.0",
+    "which": "^5.0.0",
     "yaml": "2.7.0"
   }
 }


### PR DESCRIPTION
The package depends on `which` but did not explicitly list it as a direct dependency, leading to build failures.

The following error was encountered during the build:
```
ERROR: <path-to-file>/BUILD.bazel:7:19: Bundling Javascript <path-to-file>/lib/main.ts [esbuild] failed: (Exit 1): _main_generated_esbuild_launcher.sh failed: error executing command
Error: Could not resolve "which"

    node_modules/@angular/ng-dev/utils/resolve-yarn-bin.js:10:18:
        import which from 'which';
                        ~~~~~~~
```

Example: https://github.com/angular/angular/actions/runs/12997612455/job/36248972584?pr=59669