### PR TITLE
build: remove windows testing and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,20 +45,6 @@ jobs:
       - run: yarn install --immutable
       - run: yarn bazel test -- //...
 
-  test-win:
-    timeout-minutes: 30
-    runs-on: windows-latest
-    steps:
-      # Because the checkout and setup node action is contained in the dev-infra repo, we must
-      # checkout the repo to be able to run the action we have created.  Other repos will skip
-      # this step.
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./github-actions/npm/checkout-and-setup-node
-      - uses: ./github-actions/bazel/setup
-      - uses: ./github-actions/bazel/configure-remote
-      - run: yarn install --immutable
-      - run: yarn bazel test --test_tag_filters=windows --build_tests_only -- ... -bazel/remote-execution/...
-
   test-macos:
     timeout-minutes: 30
     runs-on: macos-latest


### PR DESCRIPTION
Follow-up to #2576 

NOTE: This does not mean we are no longer supporting contributing to Angular on a Windows machine. Instead, we are working towards having a more stable and guaranteed developer experience on Windows! We will still ensure and verify that the Angular CLI (`ng`) works on Windows!

---

Many contributors and team members are using Linux or MacOS for development of Angular. Our tooling regularly faces challenges with infrastructure needing extra work and tricks just to function to some extent on Windows. E.g. shell scripts or Bazel actions that need extra layers for batch files that spawn a Bash shell etc, or inconsistent escaping across shells. This is putting extra stress on our infrastructure team, results in in unnecessary complexity and slows down overall development that way.

There is a simple and well-proven solution for supporting Windows development. Using WSL2, developes have access to a Bash shell that is equivalent to Linux; which we use on a day to day basis and can guarantee that development works smoothly! This means, we'd be able to offer far better stability and guarantees to our Windows contributors.

Historically, we also haven't seen a lot of Angular contributors use Windows; and if they did; they already used WSL for development. At this point we don't have any non-WSL contributors anymore (in the team or known), so we don't know anything about how well development works via e.g. Git Bash on Windows.

Testing on CI via Windows WSL is not necessary as the WSL shell is expected to be the same as the Linux bash environment. We'll be able to revisit this if we have new learnings. There are ways to execute builds etc. via WSL on CI.