### PR TITLE
feat(ng-dev/ts-circular-dependencies): make golden file optional

### DIFF
--- a/ng-dev/ts-circular-dependencies/config.ts
+++ b/ng-dev/ts-circular-dependencies/config.ts
@@ -23,7 +23,7 @@ export interface CircularDependenciesTestConfig extends CircularDependenciesPars
   /** Base directory used for shortening paths in the golden file. */
   baseDir: string;
   /** Path to the golden file that is used for checking and approving. */
-  goldenFile: string;
+  goldenFile?: string;
   /** Glob that resolves source files which should be checked. */
   glob: string;
   /**
@@ -81,7 +81,7 @@ export async function loadTestConfig(configPath: string): Promise<CircularDepend
     if (!isAbsolute(config.baseDir)) {
       config.baseDir = resolveRelativePath(config.baseDir);
     }
-    if (!isAbsolute(config.goldenFile)) {
+    if (config.goldenFile && !isAbsolute(config.goldenFile)) {
       config.goldenFile = resolveRelativePath(config.goldenFile);
     }
     if (!isAbsolute(config.glob)) {


### PR DESCRIPTION
The framework repo currently has no circular dependencies and does not allow new ones. This change makes the golden file optional so that framework can remove its empty golden file & associated pullapprove config