### PR TITLE
fix(github-actions): escaping of double backslash is breaking

### DIFF
--- a/github-actions/setup-wsl/action.yml
+++ b/github-actions/setup-wsl/action.yml
@@ -20,7 +20,7 @@ outputs:
     value: C:\wsl_root
   wsl_root_unc_path:
     description: UNC Windows path pointing to the WSL file system root.
-    value: \\wsl.localhost\Debian
+    value: \\\\wsl.localhost\Debian
 
 runs:
   using: composite


### PR DESCRIPTION
Apparently the double backslach ends up being escaped, while e.g. C:\wsl doesn't need the escaping :)