### PR TITLE
fix(github-actions): do not auto convert to CRLF when checking out

### DIFF
--- a/github-actions/npm/checkout-and-setup-node/action.yml
+++ b/github-actions/npm/checkout-and-setup-node/action.yml
@@ -32,6 +32,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # Git checkout converts to CRLF by default. This can cause e.g. the Aspect lock
+    # files to differ. See: https://github.com/actions/checkout/issues/135.
+    # It's generally a good idea to prevent such automatic transforms.
+    - run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+      shell: bash
+
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: blob:none


### PR DESCRIPTION
This is a useful addition to the shared checkout action that will help integrating with Windows support.