### PR TITLE
feat(github-actions): support configuring networking mode for WSL action

### DIFF
--- a/github-actions/setup-wsl/action.yml
+++ b/github-actions/setup-wsl/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: Interface alias for the WSL firewall.
     default: 'vEthernet (WSL)'
     required: false
+  wsl_networking_mode:
+    description: Networking mode for the WSL config
+    default: NAT
+    required: false
 
 outputs:
   cmd_path:
@@ -44,6 +48,7 @@ runs:
             firewall=false
             localhostForwarding=false
             memory=14GB
+            networkingMode=${{inputs.wsl_networking_mode}}
         wsl-shell-command: bash --login -euo pipefail
         additional-packages: |
           curl


### PR DESCRIPTION
This will be useful if we want to try the WSL2 mirrored network mode, that merges both "hosts" into a single "localhost".