### PR TITLE
feat(bazel): still support cross-compiling for Windows

### DIFF
--- a/bazel/git-toolchain/BUILD.bazel
+++ b/bazel/git-toolchain/BUILD.bazel
@@ -74,3 +74,18 @@ toolchain(
     toolchain = ":git_macos_arm64",
     toolchain_type = ":toolchain_type",
 )
+
+toolchain(
+    name = "git_windows_toolchain",
+    # TODO(devversion): Consult with Bazel team on best practices.
+    # Toolchain selection isn't able to cross-compile if we require Windows
+    # also as execution platform. This shouldn't be necessary because the toolchain
+    # is only used for target platform execution (not to be confused with Bazel execution).
+    # exec_compatible_with = [],
+    target_compatible_with = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":git_windows",
+    toolchain_type = ":toolchain_type",
+)

--- a/bazel/remote-execution/BUILD.bazel
+++ b/bazel/remote-execution/BUILD.bazel
@@ -7,7 +7,6 @@ platform(
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
-        "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
         # We use the official Puppeteer docker image that supports launching browsers. Note that we


### PR DESCRIPTION
This allows us to compile the Angular CLI tests for Windows target platform, allowing us to execute the CLI tests outside Bazel in native Windows environments.