### PR TITLE
build: allow for `@devinfra//` to be used in downstream repos

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,10 +1,10 @@
 load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@npm//@bazel/typescript:index.bzl", "ts_config")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 
 # BEGIN-INTERNAL
 load("//:package.bzl", "NPM_PACKAGE_SUBSTITUTIONS")
-load("//tools:defaults.bzl", "pkg_npm")
 
 rules_js_tsconfig(
     name = "rjs-tsconfig",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -75,24 +75,8 @@ def ts_library(name, testonly = False, deps = [], srcs = [], devmode_module = No
         **kwargs
     )
 
-def pkg_npm(build_package_json_from_template = False, deps = [], **kwargs):
+def pkg_npm(deps = [], **kwargs):
     _assert_defaults_allowed_for_caller()
-
-    if build_package_json_from_template:
-        native.genrule(
-            name = "package-json",
-            srcs = [
-                "package.json.tmpl",
-                "//:package.json",
-            ],
-            outs = ["package.json"],
-            cmd = """
-                $(execpath //tools:inline-package-json-deps) $(execpath package.json.tmpl) \
-                    $(execpath //:package.json) $@
-            """,
-            tools = ["//tools:inline-package-json-deps"],
-        )
-        deps.append("package-json")
 
     _pkg_npm(
         deps = deps,


### PR DESCRIPTION
Currently when trying to import `@devinfra//` in a workspace that doesn't use `rules_nodejs` anymore, we will surface errors.

This is because the top-level BUILD target/package is loaded for the shared tsconfig defaults, while this Bzl package imports from `defaults.bzl` which inherently triggers various load statements for `rules_nodejs`.

This shouldn't be the case, and this commit fixes this.