### PR TITLE
refactor(ng-dev/commit-message): add more deprecation format

### DIFF
--- a/ng-dev/commit-message/validate.ts
+++ b/ng-dev/commit-message/validate.ts
@@ -220,5 +220,9 @@ export function printValidationErrors(errors: string[], print = Log.error) {
   print();
   print(`<breaking change description>`);
   print();
+  print(`DEPRECATED: <deprecation summary>`);
+  print();
+  print(`<deprecation description>`);
+  print();
   print();
 }


### PR DESCRIPTION
This will give more info on the correct deprecation notice expected in the commit body