### PR TITLE
ci: add pnpm to ng-renovate runner environment

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: 9.15.4
       - run: yarn --cwd .github/ng-renovate install --immutable
         shell: bash
 


### PR DESCRIPTION
Add pnpm to the runner environment to allow for pnpm lock file updates