### PR TITLE
ci: manually install pnpm via npm for renovate

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -25,9 +25,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 9.15.4
+      - run: npm install --global pnpm@9.15.4
+        shell: bash
+
+      # TODO: Use pnpm/action-setup for pnpm install once pnpm is the packageManager for this repo
       - run: yarn --cwd .github/ng-renovate install --immutable
         shell: bash
 


### PR DESCRIPTION
Manually install pnpm via npm for the renovate environment as the pnpm install action does not allow the install when anothe package is defined as the packageManager in the root package.json