### PR TITLE
Various fixes for Angular CLI migration

### DIFF
--- a/bazel/spec-bundling/index_rjs.bzl
+++ b/bazel/spec-bundling/index_rjs.bzl
@@ -11,7 +11,9 @@ def spec_bundle(name, deps, bootstrap = [], testonly = True, **kwargs):
 
     esbuild.esbuild(
         name = name,
-        srcs = [
+        # Note: `deps` are added here to automatically collect transitive NPM
+        # sources etc. and make them available for bundling.
+        srcs = deps + [
             ":%s_entrypoint" % name,
         ],
         testonly = testonly,

--- a/github-actions/setup-wsl/action.yml
+++ b/github-actions/setup-wsl/action.yml
@@ -129,6 +129,3 @@ runs:
         cd ${{steps.disk_path.outputs.repo}}
         nvm install
       shell: wsl-bash {0}
-    - name: Installing Yarn (in WSL)
-      run: npm install -g yarn@1
-      shell: wsl-bash {0}


### PR DESCRIPTION
The user, consuming the action, should be responsible for installing pnpm, or yarn.