### PR TITLE
ci: update renovate pnpm to `9.15.6`

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - run: npm install --global pnpm@9.15.4
+      - run: npm install --global pnpm@9.15.6
         shell: bash
 
       # TODO: Use pnpm/action-setup for pnpm install once pnpm is the packageManager for this repo


### PR DESCRIPTION
This is the minimum required version in the Angular CLI repo.

```
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/tmp/renovate/repos/github/angular/angular-cli".

Expected version: ^9.15.6
Got: 9.15.4

This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.

To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".
```