### PR TITLE
test(bazel): ensure shared chunks work properly in API golden testing

### DIFF
--- a/bazel/api-golden/test/fixtures/test_package/shared_chunk.d.ts
+++ b/bazel/api-golden/test/fixtures/test_package/shared_chunk.d.ts
@@ -1,0 +1,1 @@
+export const sharedChunk = true;

--- a/bazel/api-golden/test/fixtures/test_package/testing/index.d.ts
+++ b/bazel/api-golden/test/fixtures/test_package/testing/index.d.ts
@@ -1,5 +1,7 @@
 import {fromTopLevel} from 'test-package';
 
+export {sharedChunk} from '.././shared_chunk.js';
+
 export declare const anotherVariable = fromTopLevel;
 
 export declare function rawStringFn(input: string): string;

--- a/bazel/api-golden/test/fixtures/test_package/testing/nested.d.ts
+++ b/bazel/api-golden/test/fixtures/test_package/testing/nested.d.ts
@@ -1,4 +1,6 @@
 import * as babel from '@babel/core';
 
+export {sharedChunk} from '.././shared_chunk.js';
+
 export declare function acceptVersion(v: babel.types.ExistsTypeAnnotation): void;
 export declare const nestedFile = true;

--- a/bazel/api-golden/test/goldens/test_package/testing/index.api.md
+++ b/bazel/api-golden/test/goldens/test_package/testing/index.api.md
@@ -10,6 +10,9 @@ export const anotherVariable = fromTopLevel;
 // @public (undocumented)
 export function rawStringFn(input: string): string;
 
+// @public (undocumented)
+export const sharedChunk = true;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/bazel/api-golden/test/goldens/test_package/testing/nested/index.api.md
+++ b/bazel/api-golden/test/goldens/test_package/testing/nested/index.api.md
@@ -12,6 +12,9 @@ export function acceptVersion(v: babel_2.types.ExistsTypeAnnotation): void;
 // @public (undocumented)
 export const nestedFile = true;
 
+// @public (undocumented)
+export const sharedChunk = true;
+
 // (No @packageDocumentation comment for this package)
 
 ```


### PR DESCRIPTION
This verifies that shared `.d.ts` chunks work properly in API golden testing. It's fine (and keeps the code simple) to just expect the shared definition to be repeated in the package entry-point goldens (it's still a single command to update)