### PR TITLE
fix(ng-dev): ensure pnpm is silent when invoked as external command

### DIFF
--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -284,7 +284,7 @@ export abstract class ExternalCommands {
   ): Promise<SpawnResult> {
     if (await pnpmVersioning.isUsingPnpm(projectDir)) {
       const pnpmSpec = await pnpmVersioning.getPackageSpec(projectDir);
-      return ChildProcess.spawn('npx', ['--yes', pnpmSpec, 'run', ...args], {
+      return ChildProcess.spawn('npx', ['--yes', pnpmSpec, '-s', 'run', ...args], {
         ...spawnOptions,
         cwd: projectDir,
       });


### PR DESCRIPTION
pnpm invoked via `npx` currently can bloat stdout and break the release tool. This commit fixes this.