### PR TITLE
fix: remove version and date from GitHub release

### DIFF
--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -17,15 +17,6 @@ const typesToIncludeInReleaseNotes = Object.values(COMMIT_TYPES)
   .filter((type) => type.releaseNotesLevel === ReleaseNotesLevel.Visible)
   .map((type) => type.name);
 
-/** List of commit authors which are bots. */
-const botsAuthorNames = [
-  'dependabot[bot]',
-  'Renovate Bot',
-  'angular-robot',
-  'angular-robot[bot]',
-  'Angular Robot',
-];
-
 /** Data used for context during rendering. */
 export interface RenderContextData {
   title: string | false;

--- a/ng-dev/release/notes/templates/github-release.ts
+++ b/ng-dev/release/notes/templates/github-release.ts
@@ -7,9 +7,6 @@
  */
 
 export default `
-<a name="<%- urlFragmentForRelease %>"></a>
-# <%- version %><% if (title) { %> "<%- title %>"<% } %> (<%- dateStamp %>)
-
 <%_
 const commitsInChangelog = commits.filter(includeInReleaseNotes());
 for (const group of asCommitGroups(commitsInChangelog)) {

--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -666,7 +666,7 @@ export abstract class ReleaseAction {
 
     await this.git.github.repos.createRelease({
       ...this.git.remoteParams,
-      name: `v${releaseNotes.version}`,
+      name: releaseNotes.version.toString(),
       tag_name: tagName,
       prerelease: isPrerelease,
       make_latest: showAsLatestOnGitHub ? 'true' : 'false',

--- a/ng-dev/release/publish/test/branch-off-next-branch-testing.ts
+++ b/ng-dev/release/publish/test/branch-off-next-branch-testing.ts
@@ -53,7 +53,7 @@ async function expectGithubApiRequestsForBranchOff(
     })
     .expectTagToBeCreated(expectedTagName, 'STAGING_COMMIT_SHA')
     .expectReleaseToBeCreated(
-      `v${expectedVersion}`,
+      expectedVersion,
       expectedTagName,
       // Note: Currently when we branch off, we never release a "latest" stable version.
       false,

--- a/ng-dev/release/publish/test/common.spec.ts
+++ b/ng-dev/release/publish/test/common.spec.ts
@@ -192,7 +192,7 @@ describe('common release action logic', () => {
           ahead_by: 1,
         })
         .expectTagToBeCreated(tagName, 'STAGING_SHA')
-        .expectReleaseToBeCreated(`v${version}`, tagName, true);
+        .expectReleaseToBeCreated(version.toString(), tagName, true);
 
       // Set up a custom NPM registry.
       releaseConfig.publishRegistry = customRegistryUrl;
@@ -239,11 +239,10 @@ describe('common release action logic', () => {
         })
         .expectTagToBeCreated(tagName, 'STAGING_SHA')
         .expectReleaseToBeCreated(
-          `v${version}`,
+          version.toString(),
           tagName,
           true,
           changelogPattern`
-            # 10.1.0-next.0 <..>
             ### test
             | Commit | Description |
             | -- | -- |
@@ -343,7 +342,7 @@ describe('common release action logic', () => {
         })
         .expectTagToBeCreated(tagName, 'STAGING_SHA')
         .expectReleaseToBeCreated(
-          `v${version}`,
+          version.toString(),
           tagName,
           true,
           changelogPattern`

--- a/ng-dev/release/publish/test/release-notes/generation.spec.ts
+++ b/ng-dev/release/publish/test/release-notes/generation.spec.ts
@@ -255,7 +255,6 @@ describe('release notes generation', () => {
       );
 
       expect(await releaseNotes.getChangelogEntry()).toMatch(changelogPattern`
-        # 13.0.0 <..>
         ## Breaking Changes
         ### cdk/a11y
         - Description of breaking change.
@@ -289,7 +288,6 @@ describe('release notes generation', () => {
       );
 
       expect(await releaseNotes.getChangelogEntry()).toMatch(changelogPattern`
-        # 13.0.0 <..>
         ## Breaking Changes
         ### cdk/a11y
         - Description of breaking change.
@@ -320,7 +318,6 @@ describe('release notes generation', () => {
       );
 
       expect(await releaseNotes.getChangelogEntry()).toMatch(changelogPattern`
-        # 13.0.0 <..>
         ## Deprecations
         ### cdk/a11y
         - Description of deprecation.
@@ -351,7 +348,6 @@ describe('release notes generation', () => {
       );
 
       expect(await releaseNotes.getChangelogEntry()).toMatch(changelogPattern`
-        # 13.0.0 <..>
         ## Deprecations
         ### cdk/a11y
         - Description of deprecation.
@@ -383,7 +379,6 @@ describe('release notes generation', () => {
         );
 
         expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
-          # 13.0.0 <..>
           ### @angular-devkit/core
           | Commit | Description |
           | -- | -- |
@@ -418,7 +413,6 @@ describe('release notes generation', () => {
         );
 
         expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
-          # 13.0.0 <..>
           ### cdk
           | Commit | Description |
           | -- | -- |
@@ -457,7 +451,6 @@ describe('release notes generation', () => {
         );
 
         expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
-          # 13.0.0 <..>
           ### cdk/a11y
           | Commit | Description |
           | -- | -- |
@@ -499,7 +492,6 @@ describe('release notes generation', () => {
         );
 
         expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
-          # 13.0.0 <..>
           ### cdk
           | Commit | Description |
           | -- | -- |
@@ -531,7 +523,6 @@ describe('release notes generation', () => {
       );
 
       expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
-        # 13.0.0 <..>
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
@@ -562,7 +553,6 @@ describe('release notes generation', () => {
       );
 
       expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
-        # 13.0.0 <..>
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
@@ -592,7 +582,6 @@ describe('release notes generation', () => {
       );
 
       expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
-        # 13.0.0 <..>
         ### cdk/a11y
         | Commit | Description |
         | -- | -- |
@@ -624,7 +613,6 @@ describe('release notes generation', () => {
     );
 
     expect(await releaseNotes.getGithubReleaseEntry()).toMatch(changelogPattern`
-      # 13.0.0 <..>
       ### cdk/a11y
       | Commit | Description |
       | -- | -- |

--- a/ng-dev/release/publish/test/test-utils/staging-test.ts
+++ b/ng-dev/release/publish/test/test-utils/staging-test.ts
@@ -85,11 +85,7 @@ export async function expectGithubApiRequests(
       ahead_by: 1,
     })
     .expectTagToBeCreated(expectedTagName, 'STAGING_COMMIT_SHA')
-    .expectReleaseToBeCreated(
-      `v${expectedVersion}`,
-      expectedTagName,
-      opts.willShowAsLatestOnGitHub,
-    );
+    .expectReleaseToBeCreated(expectedVersion, expectedTagName, opts.willShowAsLatestOnGitHub);
 }
 
 function expectNpmPublishToBeInvoked(packages: NpmPackage[], expectedNpmDistTag: NpmDistTag) {


### PR DESCRIPTION
The version and date are already displayed on the GitHub release page. Additionally, the `v` prefix has been removed from the title.


Before
<img width="1155" alt="Screenshot 2025-03-13 at 15 56 38" src="https://github.com/user-attachments/assets/7c1bbeb7-babe-41ea-a2e7-bfeb534918a2" />



After
<img width="1200" alt="Screenshot 2025-03-13 at 15 56 56" src="https://github.com/user-attachments/assets/62a4ceeb-50be-4cf2-9e60-566cbb87cd5b" />
