### PR TITLE
fix(bazel/api-golden): ensure golden directory exists

### DIFF
--- a/bazel/api-golden/index_npm_packages.ts
+++ b/bazel/api-golden/index_npm_packages.ts
@@ -70,6 +70,7 @@ async function main(
     // Keep track of outdated goldens.
     if (actual !== expected) {
       if (approveGolden) {
+        fs.mkdirSync(path.dirname(goldenFilePath), {recursive: true});
         fs.writeFileSync(goldenFilePath, actual, 'utf8');
       } else {
         outdatedGoldens.push(goldenName);


### PR DESCRIPTION
This makes it much easier to generate the initial golden directory, as we don't have to manually create all of them, for every entry-point.