### PR TITLE
fix(ng-dev/ts-circular-dependencies): print errors when goldens are disabled

### DIFF
--- a/ng-dev/ts-circular-dependencies/index.ts
+++ b/ng-dev/ts-circular-dependencies/index.ts
@@ -115,7 +115,10 @@ export function main(
       return 1;
     }
     if (cycles.length > 0) {
-      Log.error(`x  No circular dependencies are allow within this repository.`);
+      Log.error(
+        `x  No circular dependencies are allow within this repository, but circular dependencies were found:`,
+      );
+      actual.forEach((c) => Log.error(`     • ${convertReferenceChainToString(c)}`));
       return 1;
     }
 


### PR DESCRIPTION


Id the circular deps golden file is disabled for the repo, print the errors directly to the console instead so they can be addressed