### PR TITLE
fix(github-actions): explicitly allow renovate as a dependency through the license check

### DIFF
--- a/github-actions/linting/licenses/dependency-review-config.yml
+++ b/github-actions/linting/licenses/dependency-review-config.yml
@@ -1,5 +1,5 @@
-vulnerability_check: false
-allow_licenses:
+vulnerability-check: false
+allow-licenses:
   - '0BSD'
   - 'Apache-2.0'
   - 'Artistic-2.0'
@@ -16,3 +16,7 @@ allow_licenses:
   - 'MIT-0'
   - 'Python-2.0'
   - 'Unlicense'
+allow-dependencies-licenses:
+  # Renovate uses the AGPL-3.0 license, which we have determined is okay for our
+  # usage. We do not however, want to depend on this license in general
+  - 'pkg:npm/renovate'


### PR DESCRIPTION
Explicitly ignore renovate for license check as we have determined an exception for this package. Additionally use hyphen separators instead of underscores based on new documentation.