### PR TITLE
build: remove fix commit message label as it breaks with autosquash strategy

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -62617,7 +62617,8 @@ var mergeLabels = createTypedObject(MergeLabel)({
   },
   MERGE_FIX_COMMIT_MESSAGE: {
     description: "When the PR is merged, rewrites/fixups of the commit messages are needed",
-    name: "merge: fix commit message"
+    name: "merge: fix commit message",
+    repositories: [ManagedRepositories.COMPONENTS, ManagedRepositories.ANGULAR_CLI]
   },
   MERGE_CARETAKER_NOTE: {
     description: "Alert the caretaker performing the merge to check the PR for an out of normal action needed or note",

--- a/.github/local-actions/labels-sync/main.js
+++ b/.github/local-actions/labels-sync/main.js
@@ -46025,7 +46025,8 @@ var mergeLabels = createTypedObject(MergeLabel)({
   },
   MERGE_FIX_COMMIT_MESSAGE: {
     description: "When the PR is merged, rewrites/fixups of the commit messages are needed",
-    name: "merge: fix commit message"
+    name: "merge: fix commit message",
+    repositories: [ManagedRepositories.COMPONENTS, ManagedRepositories.ANGULAR_CLI]
   },
   MERGE_CARETAKER_NOTE: {
     description: "Alert the caretaker performing the merge to check the PR for an out of normal action needed or note",

--- a/github-actions/branch-manager/main.js
+++ b/github-actions/branch-manager/main.js
@@ -46025,7 +46025,8 @@ var mergeLabels = createTypedObject(MergeLabel)({
   },
   MERGE_FIX_COMMIT_MESSAGE: {
     description: "When the PR is merged, rewrites/fixups of the commit messages are needed",
-    name: "merge: fix commit message"
+    name: "merge: fix commit message",
+    repositories: [ManagedRepositories.COMPONENTS, ManagedRepositories.ANGULAR_CLI]
   },
   MERGE_CARETAKER_NOTE: {
     description: "Alert the caretaker performing the merge to check the PR for an out of normal action needed or note",

--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -46490,7 +46490,8 @@ var mergeLabels = createTypedObject(MergeLabel)({
   },
   MERGE_FIX_COMMIT_MESSAGE: {
     description: "When the PR is merged, rewrites/fixups of the commit messages are needed",
-    name: "merge: fix commit message"
+    name: "merge: fix commit message",
+    repositories: [ManagedRepositories.COMPONENTS, ManagedRepositories.ANGULAR_CLI]
   },
   MERGE_CARETAKER_NOTE: {
     description: "Alert the caretaker performing the merge to check the PR for an out of normal action needed or note",

--- a/github-actions/unified-status-check/main.js
+++ b/github-actions/unified-status-check/main.js
@@ -47845,7 +47845,8 @@ var mergeLabels = createTypedObject(MergeLabel)({
   },
   MERGE_FIX_COMMIT_MESSAGE: {
     description: "When the PR is merged, rewrites/fixups of the commit messages are needed",
-    name: "merge: fix commit message"
+    name: "merge: fix commit message",
+    repositories: [ManagedRepositories.COMPONENTS, ManagedRepositories.ANGULAR_CLI]
   },
   MERGE_CARETAKER_NOTE: {
     description: "Alert the caretaker performing the merge to check the PR for an out of normal action needed or note",

--- a/ng-dev/pr/common/labels/merge.ts
+++ b/ng-dev/pr/common/labels/merge.ts
@@ -1,4 +1,4 @@
-import {createTypedObject, Label} from './base.js';
+import {createTypedObject, Label, ManagedRepositories} from './base.js';
 
 class MergeLabel extends Label {}
 
@@ -14,6 +14,7 @@ export const mergeLabels = createTypedObject(MergeLabel)({
   MERGE_FIX_COMMIT_MESSAGE: {
     description: 'When the PR is merged, rewrites/fixups of the commit messages are needed',
     name: 'merge: fix commit message',
+    repositories: [ManagedRepositories.COMPONENTS, ManagedRepositories.ANGULAR_CLI],
   },
   MERGE_CARETAKER_NOTE: {
     description:


### PR DESCRIPTION

This label and its merge script mode don't work properly with auto-squash. The label was initially built in the components repository; which doesn't use autosquashing.

We should not re-add the label automatically.