### PR TITLE
fix(bazel): improve spec bundling to preserve original names

### DIFF
--- a/bazel/spec-bundling/index_rjs.bzl
+++ b/bazel/spec-bundling/index_rjs.bzl
@@ -1,7 +1,7 @@
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@devinfra//bazel/spec-bundling:spec-entrypoint.bzl", "spec_entrypoint")
 
-def spec_bundle(name, deps, bootstrap = [], testonly = True, **kwargs):
+def spec_bundle(name, deps, bootstrap = [], testonly = True, config = {}, **kwargs):
     spec_entrypoint(
         name = "%s_entrypoint" % name,
         deps = deps,
@@ -16,6 +16,17 @@ def spec_bundle(name, deps, bootstrap = [], testonly = True, **kwargs):
         srcs = deps + [
             ":%s_entrypoint" % name,
         ],
+        config = dict({
+            # Bundling specs may result in classes being aliased to avoid collisions. e.g. when
+            # everything is bundled into a single AMD bundle. To avoid test failures for assertions
+            # on symbol names, we instruct ESBuild to keep original names. See:
+            # https://esbuild.github.io/api/#keep-names.
+            "keepNames": True,
+            # Needed for ZoneJS async await
+            "supported": {
+                "async-await": False,
+            },
+        }, **config),
         testonly = testonly,
         bundle = True,
         format = "iife",


### PR DESCRIPTION
This will be useful when tests assert on e.g. class `constructor.name` fields.