### PR TITLE
fix(bazel): ensure source maps for spec-bundle is linked

### DIFF
--- a/bazel/spec-bundling/index_rjs.bzl
+++ b/bazel/spec-bundling/index_rjs.bzl
@@ -31,7 +31,7 @@ def spec_bundle(name, deps, srcs = [], bootstrap = [], testonly = True, config =
         bundle = True,
         format = "iife",
         minify = True,
-        sourcemap = "external",
+        sourcemap = "linked",
         platform = "node",
         entry_point = ":%s_entrypoint" % name,
         output = "%s.spec.js" % name,

--- a/bazel/spec-bundling/index_rjs.bzl
+++ b/bazel/spec-bundling/index_rjs.bzl
@@ -30,7 +30,6 @@ def spec_bundle(name, deps, srcs = [], bootstrap = [], testonly = True, config =
         testonly = testonly,
         bundle = True,
         format = "iife",
-        minify = True,
         sourcemap = "linked",
         platform = "node",
         entry_point = ":%s_entrypoint" % name,


### PR DESCRIPTION
Currently we don't have any real TS-based errors because source-maps aren't linked.