### PR TITLE
fix(github-actions): handle when no target label is provided for mergeability check

### DIFF
--- a/.github/local-actions/branch-manager/main.js
+++ b/.github/local-actions/branch-manager/main.js
@@ -69642,19 +69642,19 @@ async function main() {
     })();
     await setMergeabilityStatusOnPullRequest(statusInfo);
   } catch (e) {
+    let state = "error";
     let description;
     const { runId, repo: repo2, serverUrl } = import_github5.context;
     const targetUrl = `${serverUrl}/${repo2.owner}/${repo2.repo}/actions/runs/${runId}`;
-    if (e instanceof Error) {
+    if (e instanceof InvalidTargetLabelError) {
+      state = "pending";
+      description = e.failureMessage;
+    } else if (e instanceof Error) {
       description = e.message;
     } else {
       description = "Internal Error, see link for action log";
     }
-    await setMergeabilityStatusOnPullRequest({
-      state: "error",
-      description,
-      targetUrl
-    });
+    await setMergeabilityStatusOnPullRequest({ state, description, targetUrl });
     throw e;
   }
 }

--- a/github-actions/branch-manager/lib/main.ts
+++ b/github-actions/branch-manager/lib/main.ts
@@ -111,7 +111,7 @@ async function createWorkflowForPullRequest(inputs: WorkflowInputs) {
       repo: inputs.repo,
       owner: inputs.owner,
       state: 'pending',
-      description: 'Running mergibility check',
+      description: 'Mergibility check requested',
       sha: inputs.sha,
       context: 'mergeability',
     });

--- a/github-actions/branch-manager/main.js
+++ b/github-actions/branch-manager/main.js
@@ -48159,7 +48159,7 @@ async function createWorkflowForPullRequest(inputs) {
       repo: inputs.repo,
       owner: inputs.owner,
       state: "pending",
-      description: "Running mergibility check",
+      description: "Mergibility check requested",
       sha: inputs.sha,
       context: "mergeability"
     });


### PR DESCRIPTION
Properly return an error meessage when no target label is present.