### PR TITLE
fix(bazel): ensure spec-bundling supports npm dependencies

### DIFF
--- a/bazel/spec-bundling/spec-entrypoint.bzl
+++ b/bazel/spec-bundling/spec-entrypoint.bzl
@@ -45,6 +45,7 @@ def _spec_entrypoint_impl(ctx):
     for dep in ctx.attr.deps:
         if JsInfo in dep:
             spec_all_deps.append(dep[JsInfo].transitive_sources)
+            spec_all_deps.append(dep[JsInfo].npm_sources)
         elif JSModuleInfo in dep:
             spec_all_deps.append(dep[JSModuleInfo].sources)
         else:
@@ -53,6 +54,7 @@ def _spec_entrypoint_impl(ctx):
     for dep in ctx.attr.bootstrap:
         if JsInfo in dep:
             bootstrap_all_deps.append(dep[JsInfo].transitive_sources)
+            bootstrap_all_deps.append(dep[JsInfo].npm_sources)
             bootstrap_direct_deps.append(dep[JsInfo].sources)
         elif JSModuleInfo in dep:
             bootstrap_all_deps.append(dep[JSModuleInfo].sources)


### PR DESCRIPTION
We didn't bring in transitive npm sources. This commit fixes this, so that we can now e.g. import zone.js in bootstrap spec-bundling files.