### PR TITLE
fix(ng-dev): fix interactive rebase env

### DIFF
--- a/ng-dev/pr/rebase/index.ts
+++ b/ng-dev/pr/rebase/index.ts
@@ -100,11 +100,13 @@ export async function rebasePr(prNumber: number, interactive: boolean = false): 
      * fixup commits should occur.
      */
 
+    // the env variable prevents the editor from showing in the case of fixup commits and not
+    // interactively rebasing
+    const env =
+      squashFixups && !interactive ? {...process.env, GIT_SEQUENCE_EDITOR: 'true'} : undefined;
     let flags: string[] = [];
-    let env = undefined;
 
     if (squashFixups || interactive) {
-      env = {...process.env, GIT_SEQUENCE_EDITOR: 'true'};
       flags.push('--interactive');
     }
     if (squashFixups) {


### PR DESCRIPTION
The env variable is only needed with autosquash. Otherwise the editor will not be presented.