### PR TITLE
fix(bazel): ensure `PORT` variable is prioritized over CLI flag

### DIFF
--- a/bazel/http-server/main.ts
+++ b/bazel/http-server/main.ts
@@ -7,18 +7,23 @@
  */
 
 import yargs from 'yargs';
+import assert from 'node:assert';
 
 import {HttpServer} from './server';
 import {setupBazelWatcherSupport} from './ibazel';
 
-const {rootPaths, historyApiFallback, enableDevUi, environmentVariables, port, relaxCors} = yargs(
-  process.argv.slice(2),
-)
+const {
+  rootPaths,
+  historyApiFallback,
+  enableDevUi,
+  environmentVariables,
+  port: cliPort,
+  relaxCors,
+} = yargs(process.argv.slice(2))
   .strict()
   .option('port', {
     type: 'number',
-    default: process.env['PORT'] !== undefined ? Number(process.env['PORT']) : 4200,
-    defaultDescription: '${PORT}, or 4200 if unset',
+    default: 4200,
   })
   .option('historyApiFallback', {type: 'boolean', default: false})
   .option('rootPaths', {type: 'array', string: true, default: ['']})
@@ -26,6 +31,13 @@ const {rootPaths, historyApiFallback, enableDevUi, environmentVariables, port, r
   .option('enableDevUi', {type: 'boolean', default: false})
   .option('relaxCors', {type: 'boolean', default: false})
   .parseSync();
+
+let port = cliPort;
+// Process environment port always overrides the CLI, or rule attribute-specified port.
+if (process.env.PORT !== undefined) {
+  port = Number(process.env.PORT);
+  assert(!isNaN(port), 'Expected `PORT` environment variable to be a valid number.');
+}
 
 // In non-test executions, we will never allow for the browser-sync dev UI.
 const enableUi = process.env.TEST_TARGET === undefined && enableDevUi;


### PR DESCRIPTION
This is necessary for `server_test` to override the port that may be specified via Starlark, or the CLI flag.