### PR TITLE
fix(bazel): use `RUNFILES` in http_server

### DIFF
--- a/bazel/http-server/server.mts
+++ b/bazel/http-server/server.mts
@@ -14,8 +14,8 @@ import send from 'send';
 import assert from 'node:assert';
 
 // The current working directory is the runfiles root.
-const runfilesRoot = process.env['RUNFILES_DIR']!;
-assert(runfilesRoot, 'Expected `RUNFILES_DIR` to be set.');
+const runfilesRoot = process.env['RUNFILES']!;
+assert(runfilesRoot, 'Expected `RUNFILES` to be set.');
 
 /**
  * Http Server implementation that uses browser-sync internally. This server


### PR DESCRIPTION
This is necessary because `RUNFILES_DIR` is only set in tests by Bazel, while `RUNFILES` itself is set by the `rules_js` launcher and is therefore more available.