### PR TITLE
fix(bazel): handle `*.mts` / `*.cts` extensions in strict deps test

### DIFF
--- a/bazel/ts_project/strict_deps/index.mts
+++ b/bazel/ts_project/strict_deps/index.mts
@@ -14,7 +14,7 @@ const manifest: StrictDepsManifest = JSON.parse(await fs.readFile(manifestExecPa
  * Regex matcher to extract a npm package name, potentially with scope from a subpackage import path.
  */
 const moduleSpeciferMatcher = /^(@[\w\d-_]+\/)?([\w\d-_]+)/;
-const extensionRemoveRegex = /\.[mc]?(js|(d\.)?ts)$/;
+const extensionRemoveRegex = /\.[mc]?(js|(d\.)?[mc]?ts)$/;
 const allowedModuleNames = new Set<string>(manifest.allowedModuleNames);
 const allowedSources = new Set<string>(
   manifest.allowedSources.map((s) => s.replace(extensionRemoveRegex, '')),

--- a/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/BUILD.bazel
+++ b/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("//bazel/ts_project/strict_deps:index.bzl", "strict_deps_test")
+
+strict_deps_test(
+    name = "import_from_mts_cts_extensions",
+    srcs = ["index.ts"],
+    deps = [":mts_cts_extensions"],
+)
+
+ts_project(
+    name = "mts_cts_extensions",
+    srcs = [
+        "common_extension.cts",
+        "module_extension.mts",
+    ],
+    declaration = True,
+    deps = ["//bazel:node_modules/@types/node"],
+)

--- a/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/common_extension.cts
+++ b/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/common_extension.cts
@@ -1,0 +1,1 @@
+export const commonValue = 42;

--- a/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/index.ts
+++ b/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/index.ts
@@ -1,0 +1,5 @@
+export {commonValue} from './common_extension.cjs';
+
+// This file compiles to CommonJS, so it needs a dynamic import for TS
+// to allow a dependency on an ESM file.
+export const mod = import('./module_extension.mjs');

--- a/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/module_extension.mts
+++ b/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/module_extension.mts
@@ -1,0 +1,1 @@
+export const moduleValue = 42;

--- a/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/tsconfig.json
+++ b/bazel/ts_project/strict_deps/test/import_from_mts_cts_extensions/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "lib": ["esnext", "DOM"],
+    "declaration": true
+  }
+}


### PR DESCRIPTION
Encountered a strict deps error in https://github.com/angular/angular-cli/pull/30036 and noticed that my usage of `*.mts` files wasn't working properly.