### PR TITLE
refactor(ci): add `--noEmit` to lint build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: ./github-actions/npm/checkout-and-setup-node
       - run: yarn install --immutable
       - name: Confirm code builds with typescript as expected
-        run: yarn tsc -p tsconfig.json
+        run: yarn tsc -p tsconfig.json --noEmit
 
   test:
     timeout-minutes: 15


### PR DESCRIPTION
Without this, the lint job actually generates a bunch of in-tree `*.js` files. This creates a bunch of noise for developers who blindly copy-past the command to debug an issue and also risks future commands in this job running against those `*.js` files, which likely wouldn't be intended.