### PR TITLE
a couple fixes for dns redirecting

### DIFF
--- a/apps/functions/dns-redirecting/index.ts
+++ b/apps/functions/dns-redirecting/index.ts
@@ -30,36 +30,29 @@ export const dnsRedirecting = functions.https.onRequest(
 
     if (hostname === 'code-of-conduct.angular.io') {
       response.redirect(redirectType, 'https://code-of-conduct.angular.dev');
-    }
-    if (hostname === 'update.angular.dev') {
+    } else if (hostname === 'update.angular.dev') {
       response.redirect(redirectType, 'https://angular.dev/update-guide');
-    }
-    if (hostname === 'update.angular.io') {
+    } else if (hostname === 'update.angular.io') {
       response.redirect(redirectType, 'https://angular.dev/update-guide');
-    }
-    if (hostname === 'cli.angular.io') {
+    } else if (hostname === 'cli.angular.io') {
       response.redirect(redirectType, 'https://angular.dev/tools/cli');
-    }
-    if (hostname === 'cli.angular.dev') {
+    } else if (hostname === 'cli.angular.dev') {
       response.redirect(redirectType, 'https://angular.dev/tools/cli');
-    }
-    if (hostname === 'blog.angular.io') {
+    } else if (hostname === 'blog.angular.io') {
       response.redirect(redirectType, `https://blog.angular.dev${request.originalUrl}`);
-    }
-    if (hostname === 'material.angular.io') {
+    } else if (hostname === 'material.angular.io') {
       response.redirect(redirectType, `https://material.angular.dev${request.originalUrl}`);
-    }
-    if (hostname.endsWith('.material.angular.io')) {
+    } else if (hostname.endsWith('.material.angular.io')) {
       response.redirect(
         redirectType,
         `https://${request.subdomains[0]}.material.angular.dev${request.originalUrl}`,
       );
+    } else {
+      // If no redirect is matched, we return a failure message
+      response.status(404);
+      response.send(
+        `No redirect defined for ${request.protocol}://${request.hostname}${request.originalUrl}`,
+      );
     }
-
-    // If no redirect is matched, we return a failure message
-    response.status(404);
-    response.send(
-      `No redirect defined for ${request.protocol}://${request.hostname}${request.originalUrl}`,
-    );
   },
 );

--- a/apps/functions/dns-redirecting/index.ts
+++ b/apps/functions/dns-redirecting/index.ts
@@ -8,6 +8,7 @@ export const dnsRedirecting = functions.https.onRequest(
     maxInstances: 2,
   },
   async (request, response) => {
+    console.log(`Request made at: ${request.protocol}://${request.hostname}${request.originalUrl}`);
     /** The type of redirect to use, defaulting to a 301 permanent redirect. */
     let redirectType = 301;
     /** The hostname that was used for the request. */
@@ -45,7 +46,7 @@ export const dnsRedirecting = functions.https.onRequest(
     } else if (hostname.endsWith('.material.angular.io')) {
       response.redirect(
         redirectType,
-        `https://${request.subdomains[0]}.material.angular.dev${request.originalUrl}`,
+        `https://${request.subdomains.reverse().join('.')}.angular.dev${request.originalUrl}`,
       );
     } else {
       // If no redirect is matched, we return a failure message


### PR DESCRIPTION
Previously the response redirect would complete the http response, but then we would attempt to still provide a status response and message, which caused errors throughout our logging.  The correct action is to no longer perform response actions after a redirect.