### PR TITLE
ci: update ng-renovate to use `ubuntu-latest`

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -22,7 +22,7 @@ jobs:
           - angular/angular-cli
           - angular/vscode-ng-language-service
           - angular/.github
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: npm install --global pnpm@9.15.6


### PR DESCRIPTION
This job is currently broken due to an older Node.js version being installed.

See: https://github.com/angular/dev-infra/actions/runs/14835918390/job/41647050107