### PR TITLE
ci: remove `angular/.github` for auto update

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -21,7 +21,6 @@ jobs:
           - angular/components
           - angular/angular-cli
           - angular/vscode-ng-language-service
-          - angular/.github
     runs-on: ubuntu-latest
     steps:
       # Because the checkout and setup node action is contained in the dev-infra repo, we must


### PR DESCRIPTION
This repo only has a single dependency and the update PR never gets merged https://github.com/angular/.github/pull/32