### PR TITLE
fix(github-actions): delete obsolete branches and close superseded PRs

### DIFF
--- a/github-actions/create-pr-for-changes/lib/main.ts
+++ b/github-actions/create-pr-for-changes/lib/main.ts
@@ -129,6 +129,7 @@ async function main(): Promise<void> {
     const {
       data: {items: supersededPrs},
     } = await git.github.search.issuesAndPullRequests({
+      advanced_search: 'true',
       q: toGithubSearchQuery({
         repo: `${repo.owner}/${repo.name}`,
         type: 'pull-request',
@@ -276,6 +277,7 @@ async function cleanUpObsoleteBranches(
   const {
     data: {items: obsoletePrs},
   } = await git.github.search.issuesAndPullRequests({
+    advanced_search: 'true',
     q: toGithubSearchQuery({
       repo: `${repo.owner}/${repo.name}`,
       type: 'pull-request',

--- a/github-actions/create-pr-for-changes/main.js
+++ b/github-actions/create-pr-for-changes/main.js
@@ -47995,6 +47995,7 @@ async function main() {
       core.info(`No pre-existing PR found for branch '${branchName}'.`);
     }
     const { data: { items: supersededPrs } } = await git.github.search.issuesAndPullRequests({
+      advanced_search: "true",
       q: toGithubSearchQuery({
         repo: `${repo.owner}/${repo.name}`,
         type: "pull-request",
@@ -48073,6 +48074,7 @@ ${prBody}`;
 }
 async function cleanUpObsoleteBranches(git, repo, forkRepo, branchPrefix) {
   const { data: { items: obsoletePrs } } = await git.github.search.issuesAndPullRequests({
+    advanced_search: "true",
     q: toGithubSearchQuery({
       repo: `${repo.owner}/${repo.name}`,
       type: "pull-request",


### PR DESCRIPTION
When using the `create-pr-for-changes` workflow, old branches are not being deleted, and the content of superseded PRs remains open. This change ensures that:
- Obsolete branches are deleted after PR creation.
- Previously created PRs with outdated content are automatically closed.

Example: https://github.com/angular/angular/pull/61203