### PR TITLE
ci: use corepack in ng-renovate workflow

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -28,8 +28,10 @@ jobs:
       # this step.
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./github-actions/npm/checkout-and-setup-node
-      - run: npm install --global pnpm@9.15.6
-        shell: bash
+      - name: Corepack install and enable
+        run: |
+          npm install corepack -g
+          corepack enable
 
       # TODO: Use pnpm/action-setup for pnpm install once pnpm is the packageManager for this repo
       - run: yarn --cwd .github/ng-renovate install --immutable


### PR DESCRIPTION
This allow the repos to have different versions of pnpm. Potentially also in different branches