### PR TITLE
Corepack revert

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -11,9 +11,6 @@ on:
 permissions:
   contents: read
 
-env:
-  COREPACK_ENABLE_DOWNLOAD_PROMPT: 0 # Disable corepack prompt
-
 jobs:
   renovate:
     strategy:

--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -31,10 +31,8 @@ jobs:
       # this step.
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./github-actions/npm/checkout-and-setup-node
-      - name: Corepack install and enable
-        run: |
-          npm install corepack -g
-          corepack enable
+      - run: npm install --global pnpm@9.15.6
+        shell: bash
 
       # TODO: Use pnpm/action-setup for pnpm install once pnpm is the packageManager for this repo
       - run: yarn --cwd .github/ng-renovate install --immutable


### PR DESCRIPTION
Turns out we cannot use corepack as not all package.json have a packageManager field.
Ex: https://github.com/angular/angular/pull/61234#issuecomment-2867330185