### PR TITLE
ci: ignore `yarn` & `bazel` updates

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -28,7 +28,8 @@
   // Ignored dependencies in all repositories
   "ignoreDeps": [
     "build_bazel_rules_nodejs",
-    "rules_pkg"
+    "rules_pkg",
+    "yarn" // Yarn is copied locally in all repositories where needed.
   ],
 
   "packageRules": [
@@ -128,6 +129,7 @@
       "enabled": false,
       "matchPackageNames": [
         "@types/node",
+        "bazel",
         "node",
         "npm",
         "pnpm",

--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -40,7 +40,7 @@
     // Group all non-major updates (minor and patch) together
     {
       "groupName": "all non-major dependencies",
-      "matchPackageNames": [
+      "matchDepNames": [
         "*",
         "!node",
         "!pnpm",
@@ -70,7 +70,7 @@
       "followTag": "next",
       "separateMajorMinor": false,
       "schedule": ["at any time"],
-      "matchPackageNames": [
+      "matchDepNames": [
         "@angular-devkit/**",
         "@angular/**",
         "@schematics/**",
@@ -87,19 +87,19 @@
 
     // Keep minor and patch updates separate for TypeScript
     {
-      "matchPackageNames": ["typescript"],
+      "matchDepNames": ["typescript"],
       "separateMinorPatch": true
     },
 
     // Group TypeScript-related packages
     {
       "groupName": "typescript dependencies",
-      "matchPackageNames": ["typescript", "tslib"]
+      "matchDepNames": ["typescript", "tslib"]
     },
 
     // Limit how many times these packages get updated (They deploy each merged PR)
     {
-      "matchPackageNames": ["renovate", "quicktype-core"],
+      "matchDepNames": ["renovate", "quicktype-core"],
       "schedule": ["on sunday and wednesday"]
     },
 
@@ -111,7 +111,7 @@
     {
       "groupName": "scorecard action dependencies",
       "matchFileNames": [".github/workflows/scorecard.yml"],
-      "matchPackageNames": ["*"]
+      "matchDepNames": ["*"]
     },
 
     // ============================================================================
@@ -127,7 +127,7 @@
     // Disable major updates for specified dependencies
     {
       "enabled": false,
-      "matchPackageNames": [
+      "matchDepNames": [
         "@types/node",
         "bazel",
         "node",
@@ -143,7 +143,7 @@
     // Disable TypeScript major and minor updates
     {
       "enabled": false,
-      "matchPackageNames": ["typescript"],
+      "matchDepNames": ["typescript"],
       "matchUpdateTypes": ["major", "minor"]
     }
   ]


### PR DESCRIPTION
`yarn` is copied locally