### PR TITLE
ci: remove `yarn bazel sync --only=repo || true`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,7 @@
 
   "postUpgradeTasks": {
     "commands": [
-      "git restore bazel/pnpm-lock.yaml .npmrc",
       "yarn install --immutable",
-      "yarn bazel sync --only=repo || true",
       "yarn update-generated-files"
     ],
     "executionMode": "branch"


### PR DESCRIPTION
From taking to Paul it appears that this is no longer needed.