### PR TITLE
fix(github-actions): move `angular/**` to `matchPackageNames`

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -3,6 +3,7 @@
   extends: ['group:monorepos'],
   dependencyDashboard: true,
   rangeStrategy: 'replace',
+  automerge: false,
 
   // Schedule Renovate to run during off-peak hours
   schedule: ['after 10:00pm every weekday', 'before 5:00am every weekday', 'every weekend'],
@@ -19,6 +20,11 @@
 
   lockFileMaintenance: {
     enabled: true,
+  },
+
+  // Feature disabled: permission to enable vulnerability alerts is not granted
+  'vulnerabilityAlerts': {
+    'enabled': false,
   },
 
   // Ignored dependencies in all repositories

--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -60,13 +60,8 @@
       followTag: 'next',
       separateMajorMinor: false,
       schedule: ['at any time'],
-      matchDepNames: [
-        '@angular-devkit/**',
-        '@angular/**',
-        '@schematics/**',
-        'angular/**',
-        'ng-packagr',
-      ],
+      matchDepNames: ['@angular-devkit/**', '@angular/**', '@schematics/**', 'ng-packagr'],
+      matchPackageNames: ['angular/**'],
     },
 
     // Disable 'next' tag tracking on non-main branches


### PR DESCRIPTION
This change ensures that `angular/dev-infra` update in WORKSPACE files is grouped with `cross-repo angular dependencies` instead of `bazel` to reduce the amount of PRs opened.