### PR TITLE
fix(github-actions): more `cross-repo angular dependencies` fixes

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -66,8 +66,19 @@
       followTag: 'next',
       separateMajorMinor: false,
       schedule: ['at any time'],
-      matchDepNames: ['@angular-devkit/**', '@angular/**', '@schematics/**', 'ng-packagr'],
-      matchPackageNames: ['angular/**'],
+      matchPackageNames: [
+        '@angular-devkit/**',
+        '@angular/**',
+        '@schematics/**',
+        'angular/**',
+        'ng-packagr',
+      ],
+    },
+
+    // @angular/benchpress is not released as 'next'
+    {
+      followTag: null,
+      matchDepNames: ['@angular/benchpress'],
     },
 
     // Disable 'next' tag tracking on non-main branches


### PR DESCRIPTION
- `matchDepNames` conflicts with `matchDepNames`
- `@angular/benchpress` is not released as `next` this is causing a dependency lookup warning