### PR TITLE
fix(apps): respond to request for m.aio/assets/versions.json directly

### DIFF
--- a/apps/functions/dns-redirecting/index.ts
+++ b/apps/functions/dns-redirecting/index.ts
@@ -2,6 +2,7 @@ import * as functions from 'firebase-functions';
 
 export const dnsRedirecting = functions.https.onRequest(
   {
+    cors: true,
     invoker: 'public',
     timeoutSeconds: 5,
     minInstances: 1,
@@ -42,6 +43,13 @@ export const dnsRedirecting = functions.https.onRequest(
     } else if (hostname === 'blog.angular.io') {
       response.redirect(redirectType, `https://blog.angular.dev${request.originalUrl}`);
     } else if (hostname === 'material.angular.io') {
+      if (request.originalUrl === '/assets/versions.json') {
+        const versionsData = await fetch('https://material.angular.dev/assets/versions.json').then(
+          (r) => r.json(),
+        );
+        response.set('Content-Type', 'application/json').send(JSON.stringify(versionsData));
+        return;
+      }
       response.redirect(redirectType, `https://material.angular.dev${request.originalUrl}`);
     } else if (hostname.endsWith('.material.angular.io')) {
       response.redirect(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2589,30 +2589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor@npm:7.52.8":
-  version: 7.52.8
-  resolution: "@microsoft/api-extractor@npm:7.52.8"
-  dependencies:
-    "@microsoft/api-extractor-model": "npm:7.30.6"
-    "@microsoft/tsdoc": "npm:~0.15.1"
-    "@microsoft/tsdoc-config": "npm:~0.17.1"
-    "@rushstack/node-core-library": "npm:5.13.1"
-    "@rushstack/rig-package": "npm:0.5.3"
-    "@rushstack/terminal": "npm:0.15.3"
-    "@rushstack/ts-command-line": "npm:5.0.1"
-    lodash: "npm:~4.17.15"
-    minimatch: "npm:~3.0.3"
-    resolve: "npm:~1.22.1"
-    semver: "npm:~7.5.4"
-    source-map: "npm:~0.6.1"
-    typescript: "npm:5.8.2"
-  bin:
-    api-extractor: bin/api-extractor
-  checksum: 10c0/42f4335ebf27c7fa819a858378062d774e130dda109f001825d49fd284430c62ea9eb703a8c49a9dd8e3a607bbf19ba4457548353282673e7429e0e6d01b325b
-  languageName: node
-  linkType: hard
-
-"@microsoft/api-extractor@npm:^7.24.2":
+"@microsoft/api-extractor@npm:7.52.8, @microsoft/api-extractor@npm:^7.24.2":
   version: 7.52.8
   resolution: "@microsoft/api-extractor@npm:7.52.8"
   dependencies:


### PR DESCRIPTION
Rather than respond with a redirect for the versions information on m.aio, respond with the actual JSON string that would be responded at the destination url to prevent CORS issues.