### PR TITLE
fix(ng-dev): ensure `update-generate-files` completes on error

### DIFF
--- a/ng-dev/misc/generated-files/update-generated-files.ts
+++ b/ng-dev/misc/generated-files/update-generated-files.ts
@@ -14,45 +14,50 @@ import {green, Log} from '../../utils/logging.js';
 export async function updateGeneratedFileTargets(): Promise<void> {
   const spinner = new Spinner('Querying for all generated file targets');
 
-  // Query for all of the generated file targets
-  const result = await ChildProcess.spawn(
-    getBazelBin(),
-    [
-      'query',
-      `"kind(nodejs_binary, //...) intersect attr(name, '.update$', //...)"`,
-      '--output',
-      'label',
-    ],
-    {mode: 'silent'},
-  );
+  try {
+    // Query for all of the generated file targets
+    const result = await ChildProcess.spawn(
+      getBazelBin(),
+      [
+        'query',
+        `"kind(nodejs_binary, //...) intersect attr(name, '.update$', //...)"`,
+        '--output',
+        'label',
+      ],
+      {mode: 'silent'},
+    );
 
-  if (result.status !== 0) {
-    spinner.complete();
-    throw Error(`Unexpected error: ${result.stderr}`);
-  }
-
-  const targets = result.stdout.trim().split(/\r?\n/);
-
-  Log.debug.group('Discovered Targets');
-  targets.forEach((target) => Log.debug(target));
-  Log.debug.groupEnd();
-
-  spinner.update(`Found ${targets.length} generated file targets to update`);
-
-  // Build all of the generated file targets in parallel.
-  await ChildProcess.spawn(getBazelBin(), ['build', targets.join(' ')], {mode: 'silent'});
-
-  // Individually run the generated file update targets.
-  for (let idx = 0; idx < targets.length; idx++) {
-    const target = targets[idx];
-    spinner.update(`${idx + 1} of ${targets.length} updates completed`);
-    const updateResult = await ChildProcess.spawn(getBazelBin(), ['run', target], {mode: 'silent'});
-    if (updateResult.status !== 0) {
-      spinner.complete();
-      throw Error(`Unexpected error while updating: ${target}.`);
+    if (result.status !== 0) {
+      throw new Error(`Unexpected error: ${result.stderr}`);
     }
-  }
 
-  spinner.complete();
-  Log.info(` ${green('✔')}  Updated all generated files (${targets.length} targets)`);
+    const targets = result.stdout.trim().split(/\r?\n/);
+
+    Log.debug.group('Discovered Targets');
+    targets.forEach((target) => Log.debug(target));
+    Log.debug.groupEnd();
+
+    spinner.update(`Found ${targets.length} generated file targets to update`);
+
+    // Build all of the generated file targets in parallel.
+    await ChildProcess.spawn(getBazelBin(), ['build', targets.join(' ')], {mode: 'silent'});
+
+    // Individually run the generated file update targets.
+    for (let idx = 0; idx < targets.length; idx++) {
+      const target = targets[idx];
+      spinner.update(`${idx + 1} of ${targets.length} updates completed`);
+      const updateResult = await ChildProcess.spawn(getBazelBin(), ['run', target], {
+        mode: 'silent',
+      });
+      if (updateResult.status !== 0) {
+        throw new Error(`Unexpected error while updating: ${target}.`);
+      }
+    }
+
+    spinner.complete();
+    Log.info(` ${green('✔')}  Updated all generated files (${targets.length} targets)`);
+  } catch (e) {
+    spinner.failure('An error has occurred.');
+    throw e;
+  }
 }


### PR DESCRIPTION
Previously, if an error occurred, the spinner was never stopped, preventing the task from completing. As a result, Renovate would hang for several minutes before being forcefully terminated.