### PR TITLE
Revert "ci: use `ubuntu-latest-4core` for Angular renovate"

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -15,18 +15,13 @@ jobs:
   renovate:
     strategy:
       matrix:
-        repositories:
-          - name: angular/angular
-            run_os: ubuntu-latest-4core
-          - name: angular/dev-infra
-            run_os: ubuntu-latest
-          - name: angular/components
-            run_os: ubuntu-latest
-          - name: angular/angular-cli
-            run_os: ubuntu-latest
-          - name: angular/vscode-ng-language-service
-            run_os: ubuntu-latest
-    runs-on: ${{ matrix.repositories.run_os }}
+        REPOSITORY:
+          - angular/angular
+          - angular/dev-infra
+          - angular/components
+          - angular/angular-cli
+          - angular/vscode-ng-language-service
+    runs-on: ubuntu-latest
     steps:
       # Because the checkout and setup node action is contained in the dev-infra repo, we must
       # checkout the repo to be able to run the action we have created.  Other repos will skip
@@ -50,4 +45,4 @@ jobs:
           RENOVATE_FORK_TOKEN: ${{ secrets.NG_RENOVATE_USER_ACCESS_TOKEN }}
           GITHUB_COM_TOKEN: ${{ secrets.NG_RENOVATE_USER_ACCESS_TOKEN }}
           RENOVATE_CONFIG_FILE: .github/ng-renovate/runner-config.js
-          RENOVATE_REPOSITORIES: ${{ matrix.repositories.name }}
+          RENOVATE_REPOSITORIES: ${{ matrix.REPOSITORY }}


### PR DESCRIPTION
This reverts commit 2ccf1247420ab72d27e99ee5e585156934596f5a.

For the logs it appears that this did not improve much.