### PR TITLE
ci: clean untracked files before running `postUpgradeTasks`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,7 @@
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
 
   "postUpgradeTasks": {
-    "commands": [
-      "yarn install --immutable",
-      "yarn update-generated-files"
-    ],
+    "commands": ["git clean -f", "yarn install --immutable", "yarn update-generated-files"],
     "executionMode": "branch"
   },
 


### PR DESCRIPTION
Not sure what changed overnight, but Renovate is now committing .npmrc files that we didn't generate.

Example: https://github.com/angular/angular/pull/61492/files

We should revisit this once we transition away from Yarn.