### PR TITLE
refactor(github-actions/commit-message-based-labels): prevent auto removal of already applied labels

### DIFF
--- a/github-actions/commit-message-based-labels/lib/main.ts
+++ b/github-actions/commit-message-based-labels/lib/main.ts
@@ -49,9 +49,6 @@ class CommitMessageBasedLabelManager {
       if (hasCommit && !hasLabel) {
         await this.addLabel(name);
       }
-      if (!hasCommit && hasLabel) {
-        await this.removeLabel(name);
-      }
     }
 
     for (const commit of this.commits) {
@@ -74,19 +71,6 @@ class CommitMessageBasedLabelManager {
       this.labels.add(label);
     } catch (err) {
       core.error(`Failed to add ${label} label to PR #${issue_number}`);
-      core.debug(err as string);
-    }
-  }
-
-  /** Remove the provided label from the pull request. */
-  async removeLabel(name: string) {
-    const {number: issue_number, owner, repo} = context.issue;
-    try {
-      await this.git.issues.removeLabel({repo, owner, issue_number, name});
-      core.info(`Added ${name} label to PR #${issue_number}`);
-      this.labels.delete(name);
-    } catch (err) {
-      core.error(`Failed to add ${name} label to PR #${issue_number}`);
       core.debug(err as string);
     }
   }

--- a/github-actions/commit-message-based-labels/main.js
+++ b/github-actions/commit-message-based-labels/main.js
@@ -43655,9 +43655,6 @@ var CommitMessageBasedLabelManager = class {
       if (hasCommit && !hasLabel) {
         await this.addLabel(name);
       }
-      if (!hasCommit && hasLabel) {
-        await this.removeLabel(name);
-      }
     }
     for (const commit of this.commits) {
       const label = "area: " + commit.scope;
@@ -43674,17 +43671,6 @@ var CommitMessageBasedLabelManager = class {
       this.labels.add(label);
     } catch (err) {
       core.error(`Failed to add ${label} label to PR #${issue_number}`);
-      core.debug(err);
-    }
-  }
-  async removeLabel(name) {
-    const { number: issue_number, owner, repo } = import_github2.context.issue;
-    try {
-      await this.git.issues.removeLabel({ repo, owner, issue_number, name });
-      core.info(`Added ${name} label to PR #${issue_number}`);
-      this.labels.delete(name);
-    } catch (err) {
-      core.error(`Failed to add ${name} label to PR #${issue_number}`);
       core.debug(err);
     }
   }


### PR DESCRIPTION
If a commit message does not match our patterns and a label has already been applied manually, this action would remove the labels, which would add the PR back to the triage queue. Instead, this will never remove an already added label.