### PR TITLE
ci: reduce schedule for `google-closure-compiler`

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -101,7 +101,7 @@
 
     // Limit how many times these packages get updated (They deploy each merged PR)
     {
-      matchDepNames: ['renovate', 'quicktype-core'],
+      matchDepNames: ['renovate', 'quicktype-core', 'google-closure-compiler'],
       schedule: ['on sunday and wednesday'],
     },
 


### PR DESCRIPTION


This package always get released as a major version, and sometimes it's released multiple time per day https://www.npmjs.com/package/google-closure-compiler?activeTab=versions