### PR TITLE
Revert "ci: clean untracked files before running `postUpgradeTasks`"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,10 @@
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
 
   "postUpgradeTasks": {
-    "commands": ["git clean -f", "yarn install --immutable", "yarn update-generated-files"],
+    "commands": [
+      "yarn install --immutable",
+      "yarn update-generated-files"
+    ],
     "executionMode": "branch"
   },
 


### PR DESCRIPTION
This reverts commit 392eb3948a25a7d82a10b9af12b563fe21107587 as the issue was addressed upstream.