### PR TITLE
fix(bazel): add support for defining the platform used for bundling `spec_bundle` targets

### DIFF
--- a/bazel/spec-bundling/index_rjs.bzl
+++ b/bazel/spec-bundling/index_rjs.bzl
@@ -31,7 +31,7 @@ def spec_bundle(name, deps, srcs = [], bootstrap = [], testonly = True, config =
         bundle = True,
         format = "iife",
         sourcemap = "linked",
-        platform = "node",
+        platform = kwargs.pop("platform", "node"),
         entry_point = ":%s_entrypoint" % name,
         output = "%s.spec.js" % name,
         **kwargs


### PR DESCRIPTION
Previously the platform was hardcoded to node which worked by chance, but in some cases the platform should be explicitly set to browser for web test which will run in a browser