### PR TITLE
refactor(github-actions): Updated metadata labeler to remove merge label when PR is in draft

### DIFF
--- a/github-actions/pull-request-labeling/main.js
+++ b/github-actions/pull-request-labeling/main.js
@@ -43470,6 +43470,21 @@ var PullRequestLabeling = class {
         await this.addLabel(targetLabels.TARGET_FEATURE.name);
       }
     }
+    if (this.pullRequestMetadata.draft && this.labels.has(actionLabels.ACTION_MERGE.name)) {
+      core.info(`This pull request is still in draft mode, removing "action: merge" label`);
+      await this.removeLabel(actionLabels.ACTION_MERGE.name);
+    }
+  }
+  async removeLabel(label) {
+    const { number: issue_number, owner, repo } = import_github2.context.issue;
+    try {
+      await this.git.issues.removeLabel({ repo, owner, issue_number, name: label });
+      core.info(`Removed ${label} label from PR #${issue_number}`);
+      this.labels.delete(label);
+    } catch (err) {
+      core.error(`Failed to remove ${label} label from PR #${issue_number}`);
+      core.debug(err);
+    }
   }
   async addLabel(label) {
     const { number: issue_number, owner, repo } = import_github2.context.issue;


### PR DESCRIPTION
This prevents items being added to the merge queue accidentally still in draft mode.