### PR TITLE
fix(ng-dev): default model to pro

### DIFF
--- a/ng-dev/ai/consts.ts
+++ b/ng-dev/ai/consts.ts
@@ -7,7 +7,7 @@
  */
 
 /** Default model to use for AI-based scripts. */
-export const DEFAULT_MODEL = 'gemini-2.5-flash';
+export const DEFAULT_MODEL = 'gemini-2.5-pro';
 
 /** Default temperature for AI-based scripts. */
 export const DEFAULT_TEMPERATURE = 0.1;


### PR DESCRIPTION
Switches from using the `flash` model to the `pro` one by default.