### PR TITLE
fix(ng-dev): correctly set `next` branch name in renovate config

### DIFF
--- a/ng-dev/release/publish/actions/shared/branch-off-next-branch.ts
+++ b/ng-dev/release/publish/actions/shared/branch-off-next-branch.ts
@@ -145,7 +145,11 @@ export abstract class BranchOffNextBranchBaseAction extends CutNpmNextPrerelease
       ...this.getAspectLockFiles(),
     ];
 
-    const renovateConfigPath = await updateRenovateConfig(this.projectDir, nextBranch);
+    const renovateConfigPath = await updateRenovateConfig(
+      this.projectDir,
+      `${version.major}.${version.minor}.x`,
+    );
+
     if (renovateConfigPath) {
       filesToCommit.push(renovateConfigPath);
     }


### PR DESCRIPTION
Related issue: https://github.com/angular/angular/commit/b67351aa48cccadfc36b2cb127da5b986dcdfa81