### PR TITLE
fix(ng-dev): fix prerelease check in `cherryPickChangelogIntoNextBranch`

### DIFF
--- a/ng-dev/release/publish/test/common.spec.ts
+++ b/ng-dev/release/publish/test/common.spec.ts
@@ -582,6 +582,87 @@ describe('common release action logic', () => {
         }),
       );
     });
+
+    it('should update the renovate config labels in the cherry-pick commit', async () => {
+      const baseReleaseTrains = new ActiveReleaseTrains({
+        exceptionalMinor: null,
+        releaseCandidate: new ReleaseTrain('10.1.x', parse('10.1.0-rc.0')),
+        next: new ReleaseTrain('master', parse('10.2.0-next.0')),
+        latest: new ReleaseTrain('10.0.x', parse('10.0.0')),
+      });
+      const {version, branchName} = baseReleaseTrains.latest;
+      const forkBranchName = `changelog-cherry-pick-${version}`;
+
+      const {repo, fork, instance, gitClient, projectDir} = setupReleaseActionForTesting(
+        DelegateTestAction,
+        baseReleaseTrains,
+      );
+
+      // Expect the changelog to be fetched and return a fake changelog to test that
+      // it is properly appended. Also expect a pull request to be created in the fork.
+      repo
+        .expectFindForkRequest(fork)
+        .expectPullRequestToBeCreated('master', fork, forkBranchName, 200)
+        .expectPullRequestMergeCheck(200, false)
+        .expectPullRequestMerge(200);
+
+      // Simulate that the fork branch name is available.
+      fork.expectBranchRequest(forkBranchName);
+
+      const renovateConfigPath = join(projectDir, 'renovate.json');
+      writeFileSync(
+        renovateConfigPath,
+        JSON.stringify({
+          'baseBranches': ['main', '20.1.x'],
+          'packageRules': [
+            {
+              'matchBaseBranches': ['main'],
+              'addLabels': ['target: minor'],
+            },
+            {
+              'matchBaseBranches': ['!main'],
+              'addLabels': ['target: rc'],
+            },
+          ],
+        }),
+        'utf8',
+      );
+
+      await instance.testCherryPickWithPullRequest(version, branchName);
+
+      expect(gitClient.pushed.length).toBe(1);
+      expect(gitClient.pushed[0]).toEqual(
+        getBranchPushMatcher({
+          targetBranch: forkBranchName,
+          targetRepo: fork,
+          baseBranch: 'master',
+          baseRepo: repo,
+          expectedCommits: [
+            {
+              message: `docs: release notes for the v${version} release`,
+              files: ['CHANGELOG.md', renovateConfigPath],
+            },
+          ],
+        }),
+      );
+
+      // Verify renovate config contents
+      const {packageRules} = JSON.parse(readFileSync(renovateConfigPath, 'utf-8')) as Record<
+        string,
+        unknown
+      >;
+
+      expect(packageRules).toEqual([
+        {
+          'matchBaseBranches': ['main'],
+          'addLabels': ['target: minor'],
+        },
+        {
+          'matchBaseBranches': ['!main'],
+          'addLabels': ['target: patch'],
+        },
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
Prerelease is not a boolean but rather an array.