### PR TITLE
ci: enable pnpm updates

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -134,7 +134,6 @@
         'node',
         'bazel', // bazelisk bazel verison
         'npm',
-        'pnpm',
         'rxjs',
         'tslib',
         'yarn',


### PR DESCRIPTION
With pnpm version 10, pnpm will download the appropriate version and thus no longer require to pin the version of pnpm in all repositories to that of the renovate GitHub action.