### PR TITLE
build: allow scripts during renovate update

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -3,6 +3,8 @@ module.exports = {
   gitAuthor: 'Angular Robot <angular-robot@google.com>',
   platform: 'github',
   branchNameStrict: true,
+  // Temporary workaround for https://github.com/renovatebot/renovate/discussions/30812
+  allowScripts: true,
   // Renovate fork PRs should never be editable as Renovate would otherwise
   // not be able to delete the branches and future updates would be missed.
   forkModeDisallowMaintainerEdits: true,

--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -5,6 +5,9 @@
   rangeStrategy: 'replace',
   automerge: false,
 
+  // Temporary workaround for https://github.com/renovatebot/renovate/discussions/30812
+  ignoreScripts: false,
+
   // Schedule Renovate to run during off-peak hours
   schedule: ['after 10:00pm every weekday', 'before 5:00am every weekday', 'every weekend'],
   prConcurrentLimit: 8,


### PR DESCRIPTION
This is needed as a workaround for PNPM due which causes the lock file to be broken due to Renovate passing `--ignore-pnpmfile`

Example: https://github.com/angular/angular/pull/62935/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13

See: https://github.com/renovatebot/renovate/discussions/30812