### PR TITLE
fix(ng-dev): fix release issues with PNPM

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -390,7 +390,7 @@ export abstract class ReleaseAction {
   /** Installs all Yarn dependencies in the current branch. */
   protected async installDependenciesForCurrentBranch() {
     if (await this.pnpmVersioning.isUsingPnpm(this.projectDir)) {
-      await ExternalCommands.invokePnpmInstall(this.projectDir, this.pnpmVersioning);
+      await ExternalCommands.invokePnpmInstall(this.projectDir);
       return;
     }
 

--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -239,15 +239,21 @@ export abstract class ExternalCommands {
    * Invokes the `pnpm install` command in order to install dependencies for
    * the configured project with the currently checked out revision.
    */
-  static async invokePnpmInstall(
-    projectDir: string,
-    pnpmVersioning: PnpmVersioning,
-  ): Promise<void> {
+  static async invokePnpmInstall(projectDir: string): Promise<void> {
     try {
-      const pnpmSpec = await pnpmVersioning.getPackageSpec(projectDir);
-      await ChildProcess.spawn('npx', ['--yes', pnpmSpec, 'install', '--frozen-lockfile'], {
-        cwd: projectDir,
-      });
+      await ChildProcess.spawn(
+        'pnpm',
+        [
+          'install',
+          '--frozen-lockfile',
+          // PNPM does not have no interactive,
+          // See: https://github.com/pnpm/pnpm/issues/6778
+          '--config.confirmModulesPurge=false',
+        ],
+        {
+          cwd: projectDir,
+        },
+      );
 
       Log.info(green('  ✓   Installed project dependencies.'));
     } catch (e) {


### PR DESCRIPTION
Currently the release process hangs due to PNPM being interactive `The modules directories will be removed and reinstalled from scratch. Proceed? (Y/n) ` if when pressing `yes` the process does not continue.

Also, there is no reason why using `npx` to invoke `pnpm` as when having pnpm version 10 locally the correct version of pnpm will be downloaded.