### PR TITLE
fix(github-actions): add module type to github actions package.json

### DIFF
--- a/github-actions/bazel/configure-remote/package.json
+++ b/github-actions/bazel/configure-remote/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@types/node": "24.2.0"

--- a/github-actions/branch-manager/package.json
+++ b/github-actions/branch-manager/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.1",

--- a/github-actions/browserstack/package.json
+++ b/github-actions/browserstack/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@types/node": "24.2.0"

--- a/github-actions/feature-request/package.json
+++ b/github-actions/feature-request/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.1",

--- a/github-actions/google-internal-tests/package.json
+++ b/github-actions/google-internal-tests/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.1",

--- a/github-actions/org-file-sync/package.json
+++ b/github-actions/org-file-sync/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.1",

--- a/github-actions/post-approval-changes/package.json
+++ b/github-actions/post-approval-changes/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.1",

--- a/github-actions/pull-request-labeling/package.json
+++ b/github-actions/pull-request-labeling/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.1",

--- a/github-actions/saucelabs/package.json
+++ b/github-actions/saucelabs/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@types/node": "24.2.0"

--- a/github-actions/unified-status-check/package.json
+++ b/github-actions/unified-status-check/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.1",


### PR DESCRIPTION
This address the below warnings
```
node:9480) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///C:/a/_actions/angular/dev-infra/7f2c99469dcf64fd466abf6cb53bede791d7599d/github-actions/bazel/configure-remote/configure-remote.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to C:\a\_actions\angular\dev-infra\7f2c99469dcf64fd466abf6cb53bede791d7599d\github-actions\bazel\configure-remote\package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
```