### PR TITLE
fix(ng-dev): update buildifier to format all .bazel files

### DIFF
--- a/ng-dev/format/formatters/buildifier.ts
+++ b/ng-dev/format/formatters/buildifier.ts
@@ -20,7 +20,7 @@ export class Buildifier extends Formatter {
 
   override binaryFilePath = join(this.git.baseDir, 'node_modules/.bin/buildifier');
 
-  override defaultFileMatcher = ['**/*.bzl', '**/BUILD.bazel', '**/WORKSPACE', '**/BUILD'];
+  override defaultFileMatcher = ['**/*.bzl', '**/*.bazel', '**/WORKSPACE', '**/BUILD'];
 
   override actions = {
     check: {


### PR DESCRIPTION
This is needed to format module.bazel files.