### PR TITLE
feat(ng-dev): handle updating the `MODULE.bazel.lock` file during a release

### DIFF
--- a/ng-dev/release/publish/actions/configure-next-as-major.ts
+++ b/ng-dev/release/publish/actions/configure-next-as-major.ts
@@ -39,10 +39,18 @@ export class ConfigureNextAsMajorAction extends ReleaseAction {
     await this.checkoutUpstreamBranch(branchName);
     await this.updateProjectVersion(newVersion);
 
-    await this.createCommit(getCommitMessageForNextBranchMajorSwitch(newVersion), [
+    const filesToCommit: string[] = [
       workspaceRelativePackageJsonPath,
       ...this.getAspectLockFiles(),
-    ]);
+    ];
+
+    const bazelModuleLockFile = this.getModuleBazelLockFile();
+    if (bazelModuleLockFile) {
+      filesToCommit.push(bazelModuleLockFile);
+    }
+
+    await this.createCommit(getCommitMessageForNextBranchMajorSwitch(newVersion), filesToCommit);
+
     const pullRequest = await this.pushChangesToForkAndCreatePullRequest(
       branchName,
       `switch-next-to-major-${newVersion}`,

--- a/ng-dev/release/publish/actions/exceptional-minor/prepare-exceptional-minor.ts
+++ b/ng-dev/release/publish/actions/exceptional-minor/prepare-exceptional-minor.ts
@@ -49,10 +49,20 @@ export class PrepareExceptionalMinorAction extends ReleaseAction {
       pkgJson[exceptionalMinorPackageIndicator] = true;
     });
 
-    await this.createCommit(`build: prepare exceptional minor branch: ${this._newBranch}`, [
+    const filesToCommit: string[] = [
       workspaceRelativePackageJsonPath,
       ...this.getAspectLockFiles(),
-    ]);
+    ];
+
+    const bazelModuleLockFile = this.getModuleBazelLockFile();
+    if (bazelModuleLockFile) {
+      filesToCommit.push(bazelModuleLockFile);
+    }
+
+    await this.createCommit(
+      `build: prepare exceptional minor branch: ${this._newBranch}`,
+      filesToCommit,
+    );
 
     await this.pushHeadToRemoteBranch(this._newBranch);
 

--- a/ng-dev/release/publish/actions/shared/branch-off-next-branch.ts
+++ b/ng-dev/release/publish/actions/shared/branch-off-next-branch.ts
@@ -145,6 +145,11 @@ export abstract class BranchOffNextBranchBaseAction extends CutNpmNextPrerelease
       ...this.getAspectLockFiles(),
     ];
 
+    const bazelModuleLockFile = this.getModuleBazelLockFile();
+    if (bazelModuleLockFile) {
+      filesToCommit.push(bazelModuleLockFile);
+    }
+
     const renovateConfigPath = await updateRenovateConfig(
       this.projectDir,
       `${version.major}.${version.minor}.x`,

--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -7,7 +7,6 @@
  */
 
 import semver from 'semver';
-
 import {ChildProcess, SpawnResult, SpawnOptions} from '../../utils/child-process.js';
 import {Spinner} from '../../utils/spinner.js';
 import {NpmDistTag} from '../versioning/index.js';
@@ -261,6 +260,25 @@ export abstract class ExternalCommands {
       Log.error('  ✘   An error occurred while installing dependencies.');
       throw new FatalReleaseActionError();
     }
+  }
+
+  /**
+   * Invokes the `bazel mod deps --lockfile_mode=update` command in order
+   * to refresh `MODULE.bazel.lock` file.
+   */
+  static async invokeBazelModDepsUpdate(projectDir: string): Promise<void> {
+    const spinner = new Spinner('Updating "MODULE.bazel.lock"');
+    try {
+      await ChildProcess.spawn(getBazelBin(), ['mod', 'deps', '--lockfile_mode=update'], {
+        cwd: projectDir,
+        mode: 'silent',
+      });
+    } catch (e) {
+      Log.error(e);
+      Log.error('  ✘   An error occurred while updating "MODULE.bazel.lock".');
+      throw new FatalReleaseActionError();
+    }
+    spinner.success(green(' Updated "MODULE.bazel.lock" file.'));
   }
 
   /**

--- a/ng-dev/utils/constants.ts
+++ b/ng-dev/utils/constants.ts
@@ -11,3 +11,6 @@ export const ngDevNpmPackageName = '@angular/ng-dev';
 
 /** Workspace-relative path for the "package.json" file. */
 export const workspaceRelativePackageJsonPath = 'package.json';
+
+/** Workspace-relative path for the "MODULE.bazel.lock" file. */
+export const workspaceRelativeBazelModuleLock = 'MODULE.bazel.lock';


### PR DESCRIPTION


This lock has contains hashes of the package.json file. Thus it needs to be updated once the version is updating during the release.