### PR TITLE
build: enforce frozen lockfile mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,9 @@ test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test
 build --sandbox_default_allow_network=false
 test --sandbox_default_allow_network=false
 
+# Frozen lockfile
+common --lockfile_mode=error
+
 # Required by `rules_ts`.
 common --@aspect_rules_ts//ts:skipLibCheck=always
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler


### PR DESCRIPTION
This commit adds `lockfile_mode=error` to the `.bazelrc` file. This change ensures that any future builds will fail if the lock file is not up-to-date with the `BUILD.bazel` file, preventing inconsistencies and encouraging developers to commit updated lock files.