### PR TITLE
ci: update `MODULE.bazel.lock` and refine update strategy

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -36,16 +36,43 @@
     'yarn', // Yarn is copied locally in all repositories where needed.
   ],
 
+  // Renovate does not update Bazel lockfile for the time being.
+  // Workaround for https://github.com/renovatebot/renovate/issues/25557
+  postUpgradeTasks: {
+    commands: [
+      'git restore .npmrc || true', // In case `.npmrc` avoid a hard error.
+      'pnpm install --frozen-lockfile',
+      'pnpm bazel mod deps --lockfile_mode=update',
+    ],
+    executionMode: 'branch',
+  },
+
   packageRules: [
     // ============================================================================
     // GENERAL GROUPING & UPDATE BEHAVIOR
     // ============================================================================
 
-    // Group all non-major updates (minor and patch) together
+    // Disable 'postUpdateTasks' for changes that do not effect the BAZEL lockfile or generated files.
+    {
+      postUpgradeTasks: {commands: []},
+      matchManagers: ['!npm', '!bazel', '!bazel-module', '!bazelisk'],
+    },
+
+    // Rule to disable NPM updates on branches other than 'main'.
+    // But allow updating engines and packageManagers.
+    {
+      enabled: false,
+      matchBaseBranches: ['!main'],
+      matchDepNames: ['!node', '!pnpm', '!npm', '!yarn'],
+      matchManagers: ['npm'],
+    },
+
+    // Group all non-major dependencies together for updates.
     {
       groupName: 'all non-major dependencies',
       matchDepNames: ['*', '!node', '!pnpm', '!npm', '!yarn'],
       matchUpdateTypes: ['digest', 'patch', 'minor'],
+      matchManagers: ['npm'],
     },
 
     // ============================================================================
@@ -55,7 +82,13 @@
     // Group Bazel updates
     {
       groupName: 'bazel dependencies',
-      matchManagers: ['bazel'],
+      matchManagers: ['bazel', 'bazel-module'],
+    },
+
+    // Group GitHub Actions workflow
+    {
+      groupName: 'all github actions',
+      matchManagers: ['github-actions'],
     },
 
     // ============================================================================
@@ -64,6 +97,7 @@
 
     // Group updates related to Angular ecosystem across repositories
     {
+      enabled: true, // Enable NPM updates of cross-repo dependencies on all branches.
       groupName: 'cross-repo angular dependencies',
       followTag: 'next',
       separateMajorMinor: false,
@@ -108,17 +142,6 @@
     },
 
     // ============================================================================
-    // WORKFLOW-SPECIFIC UPDATE RULES
-    // ============================================================================
-
-    // Group dependencies in the scorecard GitHub Actions workflow
-    {
-      groupName: 'scorecard action dependencies',
-      matchFileNames: ['.github/workflows/scorecard.yml'],
-      matchDepNames: ['*'],
-    },
-
-    // ============================================================================
     // EXCLUSION RULES
     // ============================================================================
 
@@ -134,7 +157,7 @@
       matchDepNames: [
         '@types/node',
         'node',
-        'bazel', // bazelisk bazel verison
+        'bazel', // bazelisk bazel version
         'npm',
         'rxjs',
         'tslib',
@@ -148,6 +171,13 @@
       enabled: false,
       matchDepNames: ['typescript'],
       matchUpdateTypes: ['major', 'minor'],
+    },
+
+    // Rule to disable major updates on branches other than 'main'.
+    {
+      enabled: false,
+      matchBaseBranches: ['!main'],
+      matchUpdateTypes: ['major'],
     },
   ],
 }


### PR DESCRIPTION
Adds a Renovate postUpdateTask to automatically update `MODULE.bazel.lock` and resolves an outstanding issue with Bazel lockfile support.

Reduces dependency updates on non-main branches to only Bazel, GitHub Actions, and cross-repository updates. This change aims to reduce friction and improve the caretaker workflow.