### PR TITLE
ci: disable updating of `@google-cloud/spanner`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
-
   "postUpgradeTasks": {
     "commands": [
       "pnpm install --frozen-lockfile",
@@ -10,7 +9,7 @@
     ],
     "executionMode": "branch"
   },
-
+  "ignoreDeps": ["@google-cloud/spanner"],
   "ignorePaths": ["bazel/integration/tests/**"],
   "packageRules": [
     {


### PR DESCRIPTION
This dependency had a missing dependency for sometime, which now has been addressed however  it's transtive dependency `@opentelemetry/api` now has missing depedencies.