### PR TITLE
ci: change when `postUpgradeTasks` are invoked

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -36,26 +36,25 @@
     'yarn', // Yarn is copied locally in all repositories where needed.
   ],
 
-  // Renovate does not update Bazel lockfile for the time being.
-  // Workaround for https://github.com/renovatebot/renovate/issues/25557
-  postUpgradeTasks: {
-    commands: [
-      'git restore .npmrc || true', // In case `.npmrc` avoid a hard error.
-      'pnpm install --frozen-lockfile',
-      'pnpm bazel mod deps --lockfile_mode=update',
-    ],
-    executionMode: 'branch',
-  },
-
   packageRules: [
     // ============================================================================
     // GENERAL GROUPING & UPDATE BEHAVIOR
     // ============================================================================
 
-    // Disable 'postUpdateTasks' for changes that do not effect the BAZEL lockfile or generated files.
+    // Enable 'postUpdateTasks' for changes that effect the BAZEL lockfile or generated files.
+    // Renovate does not update Bazel lockfile for the time being.
+    // Workaround for https://github.com/renovatebot/renovate/issues/25557
     {
-      postUpgradeTasks: {commands: []},
-      matchManagers: ['!npm', '!bazel', '!bazel-module', '!bazelisk'],
+      postUpgradeTasks: {
+        commands: [
+          'var',
+          'git restore .npmrc || true', // In case `.npmrc` avoid a hard error.
+          'pnpm install --frozen-lockfile',
+          'pnpm bazel mod deps --lockfile_mode=update',
+        ],
+        executionMode: 'branch',
+      },
+      matchManagers: ['bazel', 'bazel-module', 'bazelisk'],
     },
 
     // Rule to disable NPM updates on branches other than 'main'.

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
-  "postUpgradeTasks": {
-    "commands": [
-      "pnpm install --frozen-lockfile",
-      "pnpm bazel mod deps --lockfile_mode=update",
-      "pnpm update-generated-files"
-    ],
-    "executionMode": "branch"
-  },
   "ignoreDeps": ["@google-cloud/spanner"],
   "ignorePaths": ["bazel/integration/tests/**"],
   "packageRules": [
@@ -16,6 +8,17 @@
       "enabled": true,
       "matchPackageNames": ["typescript"],
       "matchUpdateTypes": ["minor"]
+    },
+    {
+      "postUpgradeTasks": {
+        "commands": [
+          "pnpm install --frozen-lockfile",
+          "pnpm bazel mod deps --lockfile_mode=update",
+          "pnpm update-generated-files"
+        ],
+        "executionMode": "branch"
+      },
+      "matchManagers": ["bazel", "bazel-module", "bazelisk", "npm"]
     }
   ]
 }


### PR DESCRIPTION
Since the `package.json` file is no longer included in the Bazel lock file, the `postUpgradeTasks` are only necessary when the `matchManagers` are 'bazel', 'bazel-module', or 'bazelisk' for the majority of our repos.

For the dev-infra and Angular framework repositories, the `Angular framework repositories, the postUpgradeTasks` should be executed when the managers are 'bazel', 'bazel-module', 'bazelisk', or 'npm' due to them having generated checked-in files.