### PR TITLE
ci: remove workaround for Renovate's `--ignore-pnpmfile` flag

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -3,7 +3,8 @@ module.exports = {
   gitAuthor: 'Angular Robot <angular-robot@google.com>',
   platform: 'github',
   branchNameStrict: true,
-  // Temporary workaround for https://github.com/renovatebot/renovate/discussions/30812
+  // This is needed as otherwise Renovate will add `--ignore-pnpmfile`.
+  // See: https://github.com/renovatebot/renovate/blob/93fa41b26fdef8584be4d0c2582fa12397ae4360/lib/modules/manager/npm/post-update/pnpm.ts#L111-L118
   allowScripts: true,
   // Renovate fork PRs should never be editable as Renovate would otherwise
   // not be able to delete the branches and future updates would be missed.

--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -5,9 +5,6 @@
   rangeStrategy: 'replace',
   automerge: false,
 
-  // Temporary workaround for https://github.com/renovatebot/renovate/discussions/30812
-  ignoreScripts: false,
-
   // Schedule Renovate to run during off-peak hours
   schedule: ['after 10:00pm every weekday', 'before 5:00am every weekday', 'every weekend'],
   prConcurrentLimit: 8,


### PR DESCRIPTION
This removes the `ignoreScripts: false` setting, which was a workaround for the issue described in https://github.com/renovatebot/renovate/discussions/30812.

The underlying issue was resolved in Renovate version `41.90.1`.