### PR TITLE
ng-renovate workflow changes

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -32,6 +32,8 @@ jobs:
       # this step.
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./github-actions/npm/checkout-and-setup-node
+        with:
+          cache-dependency-path: './.github/ng-renovate/pnpm-lock.yaml'
       - run: pnpm install --frozen-lockfile
         working-directory: ./.github/ng-renovate
       - run: pnpm exec renovate

--- a/github-actions/npm/checkout-and-setup-node/action.yml
+++ b/github-actions/npm/checkout-and-setup-node/action.yml
@@ -21,6 +21,12 @@ inputs:
     description: 'When set to true, disables the package manager cache.'
     default: false
 
+  cache-dependency-path:
+    description: |
+      Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc.
+      Supports wildcards or a list of file names for caching multiple dependencies.
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -56,4 +62,5 @@ runs:
       with:
         node-version-file: ${{ inputs.node-version-file-path }}
         node-version: ${{ inputs.node-version }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
         cache: ${{ inputs.disable-package-manager-cache != 'true' && steps.packageManager.outputs.CACHE_MANAGER_VALUE || '' }}


### PR DESCRIPTION
**feat(github-actions): add cache-dependency-path to checkout-and-setup-node**
This allows specifying a dependency file path for more accurate caching, aligning with the official `setup-node` action's capabilities. The `ng-renovate` workflow is updated to use this new input.

See: https://github.com/actions/setup-node?tab=readme-ov-file#caching-global-packages-data

---

**ci: remove `pnpm/action-setup` set from `ng-renovate` workflow**
This step is already included in `./github-actions/npm/checkout-and-setup-node` which makes this duplicate.