### PR TITLE
refactor: enable merge confidence badge

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -1,6 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['group:monorepos'],
+  extends: ['mergeConfidence:all-badges', 'group:monorepos'],
   dependencyDashboard: true,
   rangeStrategy: 'replace',
   automerge: false,


### PR DESCRIPTION
Enables the Renovate merge confidence feature to display a badge on pull requests. This badge provides a visual indicator of the risk of merging a dependency update, based on the test results of other repositories that have already adopted the same update.

See: https://docs.renovatebot.com/merge-confidence/