### PR TITLE
fix(ng-dev): forcefully remove node_modules before publishing

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -366,7 +366,10 @@ export abstract class ReleaseAction {
   protected async checkoutUpstreamBranch(branchName: string) {
     this.git.run(['fetch', '-q', this.git.getRepoGitUrl(), branchName]);
     this.git.run(['checkout', '-q', 'FETCH_HEAD', '--detach']);
-    this.git.run(['clean', '-dfq']);
+    try {
+      // Remove node_modules even if they are ignored. (We do not want to run -dxf to avoid deleting other files suchs as .ng-dev-lock)
+      this.git.run(['clean', 'git clean -dfX **/node_modules']);
+    } catch {}
   }
 
   /** Installs all Yarn dependencies in the current branch. */


### PR DESCRIPTION
Currently, when preparing a release, we execute 'git clean -dfq' to ensure a clean working directory. This is problematic when a '.gitignore' file is present that excludes 'node_modules', as 'git clean' will not remove them.

This change updates the release preparation to explicitly remove all 'node_modules' directories, ensuring that we always publish from a clean state.