### PR TITLE
ci: limit update frequency of github/codeql-action

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -133,7 +133,12 @@
 
     // Limit how many times these packages get updated (They deploy each merged PR)
     {
-      matchDepNames: ['renovate', 'quicktype-core', 'google-closure-compiler'],
+      matchDepNames: [
+        'github/codeql-action',
+        'google-closure-compiler',
+        'quicktype-core',
+        'renovate',
+      ],
       schedule: ['on sunday and wednesday'],
     },
 


### PR DESCRIPTION
The `github/codeql-action` is released frequently, with each merged PR triggering a new release. This creates a lot of noise in the form of Renovate PRs.

To reduce this noise, limit the update checks for this action to twice a week, aligning it with the schedule for other frequently updated packages.