### PR TITLE
ci: adjust bazel preset execution

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -45,10 +45,11 @@
       postUpgradeTasks: {
         commands: [
           'git restore .npmrc || true', // In case `.npmrc` avoid a hard error.
-          'pnpm install --frozen-lockfile',
-          'pnpm bazel mod deps --lockfile_mode=update',
+          'bazel mod deps --lockfile_mode=update',
         ],
-        executionMode: 'branch',
+        // This is theory should be `branch` but in some cases this is causing the command not to
+        // run when in the same branch there are mixtures of update types by different managers.
+        executionMode: 'update',
       },
       matchManagers: ['bazel', 'bazel-module', 'bazelisk'],
     },
@@ -103,7 +104,7 @@
       followTag: 'next',
       minimumReleaseAge: null,
       separateMajorMinor: false,
-      schedule: ['at any time'],
+      schedule: ['0 */2 * * *'], // Every two hours.
       matchPackageNames: [
         '@angular-devkit/**',
         '@angular/**',


### PR DESCRIPTION
This commit adjusts the bazel preset for Renovate to improve its behavior.

The executionMode is changed from 'branch' to 'update' to prevent cases where multiple updates in the same branch by different managers would cause commands not to run.

Additionally, with native Bazel support now available in Renovate, the pnpm install command is no longer necessary and has been removed. The bazel mod deps command is now run directly.

To reduce the frequency of pull requests, especially new ones being opened immediately after a merge, the cross-repository updates are now scheduled to run every two hours.