### PR TITLE
ci: update renovate schedule

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -104,7 +104,7 @@
       followTag: 'next',
       minimumReleaseAge: null,
       separateMajorMinor: false,
-      schedule: ['0 */2 * * *'], // Every two hours.
+      schedule: ['Every minute, every 2 hours'],
       matchPackageNames: [
         '@angular-devkit/**',
         '@angular/**',


### PR DESCRIPTION
This commit updates the Renovate schedule in to 'Every minute, every 2 hours'. This change is intended to adjust the frequency of Renovate's operations, using a cleaner and more human-readable format.