### PR TITLE
fix(ng-dev): add additional debug logging to caretaker check

### DIFF
--- a/ng-dev/caretaker/check/ci.ts
+++ b/ng-dev/caretaker/check/ci.ts
@@ -49,18 +49,23 @@ export class CiModule extends BaseModule<CiData> {
           };
         }
 
-        const status = (
-          await githubMacros.getCombinedChecksAndStatusesForRef(this.git.github, {
+        const {result, results} = await githubMacros.getCombinedChecksAndStatusesForRef(
+          this.git.github,
+          {
             ...this.git.remoteParams,
             ref: train.branchName,
-          })
-        ).result;
+          },
+        );
+
+        Log.debug(`Individual Status Results for branch (${train.branchName})`);
+        results.forEach((r) => Log.debug(` - ${r.name}:`.padEnd(80), r.result));
+        Log.debug();
 
         return {
           active: true,
           name: train.branchName,
           label: `${trainName} (${train.branchName})`,
-          status,
+          status: result,
         };
       },
     );


### PR DESCRIPTION
Add additional debug logging for the specific status results in the caretaker check to allow for easier debugging if an unexpected failure shows in our check that does not show in the Github UI.