### PR TITLE
ci: disable renovate for `angular/vscode-ng-language-service`

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -23,7 +23,6 @@ jobs:
           - angular/dev-infra
           - angular/components
           - angular/angular-cli
-          - angular/vscode-ng-language-service
           - angular/ai-tutor
           - angular/web-codegen-scorer
     runs-on: ubuntu-latest


### PR DESCRIPTION
The contents of this repo has been migrated to `angular/angular`.