### PR TITLE
ci: revert to cron schedule for cross-repo angular dependencies

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -104,7 +104,7 @@
       followTag: 'next',
       minimumReleaseAge: null,
       separateMajorMinor: false,
-      schedule: ['Every minute, every 2 hours'],
+      schedule: ['* 0-22/2 * * *'], // Every minute, every 2 hours
       matchPackageNames: [
         '@angular-devkit/**',
         '@angular/**',


### PR DESCRIPTION
The human-readable schedule "Every minute, every 2 hours" is not supported by the currently used version of Renovate, causing the following error:

WARN: Invalid schedule: Failed to parse "Every minute, every 2 hours"

This is due to a recent revert of the Renovate version. This commit reverts back to the cron expression to fix the issue.