### PR TITLE
fix(github-actions): replace `package-manager-cache` with `cache` option in checkout-and-setup-node

### DIFF
--- a/github-actions/npm/checkout-and-setup-node/action.yml
+++ b/github-actions/npm/checkout-and-setup-node/action.yml
@@ -49,15 +49,18 @@ runs:
       run: |
         PM=$(jq -r '.packageManager | match("^(npm|pnpm|yarn)@").captures[0].string' package.json || echo "")
         echo "PACKAGE_MANAGER=$PM" >> "$GITHUB_OUTPUT"
+        if [ "$PM" == "pnpm" ]; then
+          echo "CACHE_MANAGER_VALUE=pnpm" >> "$GITHUB_OUTPUT"
+        fi
 
     - if: steps.packageManager.outputs.PACKAGE_MANAGER == 'pnpm'
       uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       with:
         run_install: false
 
-    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:
         node-version-file: ${{ inputs.node-version-file-path }}
         node-version: ${{ inputs.node-version }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
-        package-manager-cache: ${{ inputs.disable-package-manager-cache != 'true' }}
+        cache: ${{ inputs.disable-package-manager-cache != 'true' && steps.packageManager.outputs.CACHE_MANAGER_VALUE || '' }}


### PR DESCRIPTION

In `actions/setup-node` version 6 `package-manager-cache` is only supported for npm.

See: https://github.com/actions/setup-node/pull/1374