### PR TITLE
ci: update renovate configuration

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -11,7 +11,7 @@ module.exports = {
   forkModeDisallowMaintainerEdits: true,
   onboarding: false,
   persistRepoData: true,
-  allowedPostUpgradeCommands: ['.', '^pnpm install$', '^pnpm update-generated-files$'],
+  allowedCommands: ['.'],
   hostRules: [
     {
       matchHost: 'api.github.com',

--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -6,10 +6,11 @@
   automerge: false,
 
   // Schedule Renovate to run during off-peak hours
-  schedule: ['after 10:00pm every weekday', 'before 5:00am every weekday', 'every weekend'],
+  schedule: ['after 6am on Monday, Wednesday, Friday', 'before 10am on Monday, Wednesday, Friday'],
+
   prConcurrentLimit: 8,
   prHourlyLimit: 4,
-  timezone: 'America/Tijuana',
+  timezone: 'Europe/Rome',
 
   // Commit and PR customization
   commitBody: 'See associated pull request for more information.',
@@ -20,6 +21,7 @@
 
   lockFileMaintenance: {
     enabled: true,
+    schedule: ['after 5am on Tuesday', 'before 7am on Tuesday'],
   },
 
   // Feature disabled: permission to enable vulnerability alerts is not granted
@@ -146,7 +148,7 @@
         'quicktype-core',
         'renovate',
       ],
-      schedule: ['on sunday and wednesday'],
+      schedule: ['after 6am on Wednesday', 'before 10am on Wednesday'],
     },
 
     // ============================================================================


### PR DESCRIPTION
Updates the renovate configuration to run during European business hours. The schedule is now set to run on Monday, Wednesday, and Friday between 6am and 10pm in the Europe/Rome timezone.

Additionally, the allowedPostUpgradeCommands option is renamed to allowedCommands to align with the latest Renovate Bot configuration.