### PR TITLE
ci: remove temporary `rules_angular` update disablement

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -189,14 +189,5 @@
       matchBaseBranches: ['!main'],
       matchUpdateTypes: ['major'],
     },
-
-    // TODO(alanagius): delete the below rule once RC branch is `21.0.x`
-    // Temporary disable updates of `rules_angular` on non main branches due to the APF breaking change
-    // See: https://github.com/devversion/rules_angular/pull/63
-    {
-      enabled: false,
-      matchBaseBranches: ['!main'],
-      matchDepNames: ['rules_angular'],
-    },
   ],
 }


### PR DESCRIPTION
The temporary rule to disable `rules_angular` updates on non-main branches is no longer needed as the release candidate branch is now on version 21, which includes the necessary APF breaking change.