### PR TITLE
fix(ng-dev/release): delete node_modules before pnpm install

### DIFF
--- a/ng-dev/release/publish/actions.ts
+++ b/ng-dev/release/publish/actions.ts
@@ -369,6 +369,13 @@ export abstract class ReleaseAction {
   /** Installs all Yarn dependencies in the current branch. */
   protected async installDependenciesForCurrentBranch() {
     if (await this.pnpmVersioning.isUsingPnpm(this.projectDir)) {
+      // Note: We delate all contents of `node_modules` before installing dependencies. We do
+      // this because if a pnpm workspace package exists at one ref and not another, it can
+      // cause the pnpm install from within Bazel to errantly attempt to install a package that
+      // does not exist.
+      try {
+        this.git.run(['clean', '-qdfX', '**/node_modules']);
+      } catch {}
       await ExternalCommands.invokePnpmInstall(this.projectDir);
       return;
     }

--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -223,7 +223,10 @@ export abstract class ExternalCommands {
           'install',
           ...(yarnCommand.legacy ? ['--frozen-lockfile', '--non-interactive'] : ['--immutable']),
         ],
-        {cwd: projectDir},
+        {
+          cwd: projectDir,
+          mode: 'on-error',
+        },
       );
       Log.info(green('  ✓   Installed project dependencies.'));
     } catch (e) {
@@ -250,6 +253,7 @@ export abstract class ExternalCommands {
         ],
         {
           cwd: projectDir,
+          mode: 'on-error',
         },
       );
 


### PR DESCRIPTION
We delete the node_modules prior to a pnpm install during the release because if a package exists on main, but does not exist on the released branch, the node_modules directory will persist and bazel will attempt to pick it up and install it but no package.json exists for it.