### PR TITLE
feat(ng-dev): create a check that ng-dev is up to date

### DIFF
--- a/ng-dev/cli.ts
+++ b/ng-dev/cli.ts
@@ -19,6 +19,7 @@ import {buildPullapproveParser} from './pullapprove/cli.js';
 import {buildReleaseParser} from './release/cli.js';
 import {tsCircularDependenciesBuilder} from './ts-circular-dependencies/index.js';
 import {captureLogOutputForCommand} from './utils/logging.js';
+import {ngDevVersionMiddleware} from './utils/version-check.js';
 import {buildAuthParser} from './auth/cli.js';
 import {buildPerfParser} from './perf/cli.js';
 import {buildAiParser} from './ai/cli.js';
@@ -28,7 +29,7 @@ runParserWithCompletedFunctions((yargs: Argv) => {
   process.exitCode = 0;
   return yargs
     .scriptName('ng-dev')
-    .middleware(captureLogOutputForCommand, true)
+    .middleware([captureLogOutputForCommand, ngDevVersionMiddleware], true)
     .demandCommand()
     .recommendCommands()
     .command('auth <command>', false, buildAuthParser)

--- a/ng-dev/utils/version-check.ts
+++ b/ng-dev/utils/version-check.ts
@@ -13,6 +13,20 @@ import {parse as parseYaml} from 'yaml';
 import {ngDevNpmPackageName, workspaceRelativePackageJsonPath} from './constants.js';
 import {Log} from './logging.js';
 import {tryGetPackageId} from '@pnpm/dependency-path';
+import {determineRepoBaseDirFromCwd} from './repo-directory.js';
+
+/** Whether ngDevVersionMiddleware verification has already occured. */
+let verified = false;
+export async function ngDevVersionMiddleware() {
+  // TODO(josephperrott): remove this guard against running multiple times after
+  //   https://github.com/yargs/yargs/issues/2223 is fixed
+  if (verified) {
+    return;
+  }
+  // TODO(josephperrott): Create an enforcement configuration option.
+  await verifyNgDevToolIsUpToDate(determineRepoBaseDirFromCwd());
+  verified = true;
+}
 
 /**
  * Verifies that the `ng-dev` tool is up-to-date in the workspace. The check will compare
@@ -26,6 +40,10 @@ import {tryGetPackageId} from '@pnpm/dependency-path';
 export async function verifyNgDevToolIsUpToDate(workspacePath: string): Promise<boolean> {
   // The placeholder will be replaced by the `pkg_npm` substitutions.
   const localVersion = `0.0.0-{SCM_HEAD_SHA}`;
+  if (localVersion === ('0.0.0-{{BUILD_SCM_COMMIT_SHA}}' as string)) {
+    Log.debug('Skipping ng-dev version check as this is a locally generated version.');
+    return true;
+  }
   const workspacePackageJsonFile = path.join(workspacePath, workspaceRelativePackageJsonPath);
   const pnpmLockFile = path.join(workspacePath, 'pnpm-lock.yaml');
   const yarnLockFile = path.join(workspacePath, 'yarn.lock');
@@ -36,12 +54,14 @@ export async function verifyNgDevToolIsUpToDate(workspacePath: string): Promise<
     ? getExpectedVersionFromPnpmLock(workspacePackageJsonFile, pnpmLockFile)
     : getExpectedVersionFromYarnLock(workspacePackageJsonFile, yarnLockFile);
 
-  Log.debug(`Expecting the following ng-dev version: ${expectedVersion}`);
+  Log.debug('Checking ng-dev version in lockfile and in the running script:');
+  Log.debug(`  Local: ${localVersion}`);
+  Log.debug(`  Expected: ${expectedVersion}`);
 
   if (localVersion !== expectedVersion) {
-    Log.error('  ✘   Your locally installed version of the `ng-dev` tool is outdated and not');
-    Log.error('      matching with the version in the `package.json` file.');
-    Log.error('      Re-install the dependencies to ensure you are using the correct version.');
+    Log.warn('  ⚠   Your locally installed version of the `ng-dev` tool is outdated and not');
+    Log.warn('      matching with the version in the `package.json` file.');
+    Log.warn('      Re-install the dependencies to ensure you are using the correct version.');
     return false;
   }
 


### PR DESCRIPTION
Whenever ng-dev is run we now check to ensure that the ng-dev script that is running matches the version found in the pnpm lockfile. Upon failing this check, a non-blocking warning message is logged to the console.