### PR TITLE
fix(ng-dev): use an environment variable to determine local builds

### DIFF
--- a/ng-dev/utils/version-check.ts
+++ b/ng-dev/utils/version-check.ts
@@ -40,7 +40,7 @@ export async function ngDevVersionMiddleware() {
 export async function verifyNgDevToolIsUpToDate(workspacePath: string): Promise<boolean> {
   // The placeholder will be replaced by the `pkg_npm` substitutions.
   const localVersion = `0.0.0-{SCM_HEAD_SHA}`;
-  if (localVersion === ('0.0.0-{{BUILD_SCM_COMMIT_SHA}}' as string)) {
+  if (!!process.env['LOCAL_NG_DEV_BUILD']) {
     Log.debug('Skipping ng-dev version check as this is a locally generated version.');
     return true;
   }

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -19,4 +19,4 @@ bazelCommand=${BAZEL:-"pnpm bazel"}
 
 # Execute the built ng-dev command in the current working directory
 # and pass-through arguments unmodified.
-${ngDevBinFile} ${@}
+LOCAL_NG_DEV_BUILD=1 ${ngDevBinFile} ${@}


### PR DESCRIPTION
Instead of trying to determine whether the version of ng-dev mismatches two strings that will be stamped, we now use a local environment variable to set the local build status.