### PR TITLE
fix(ng-dev): ensure node version check uses project directory after nvm install

### DIFF
--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -209,7 +209,10 @@ export abstract class ExternalCommands {
       });
 
       if (!quiet) {
-        const {stdout: nodeVersion} = await ChildProcess.spawn('node', ['--version']);
+        const {stdout: nodeVersion} = await ChildProcess.spawn('node', ['--version'], {
+          mode: 'silent',
+          cwd: projectDir,
+        });
         Log.info(green(`  ✓   Set node version to ${nodeVersion}.`));
       }
     } catch (e) {


### PR DESCRIPTION

Sets the working directory to the project directory and enables silent mode when retrieving the Node.js version. This ensures that the logged version correctly reflects project-specific configurations like those in an `.nvmrc` file.