### PR TITLE
ci: skip non-affected snapshots in the publish workflow

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -34,4 +34,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SNAPSHOT_BUILDS_GITHUB_TOKEN }}
           GIT_COMMITTER_NAME: ${{ github.actor }}
           GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
-        run: pnpm ng-dev release publish-snapshots
+        run: pnpm ng-dev release publish-snapshots --skip-non-affected-snapshots


### PR DESCRIPTION
Add usage of `--skip-non-affected-snapshots`