### PR TITLE
fix(ng-dev): ensure sync-module-bazel uses correct paths when executed in nested directories

### DIFF
--- a/ng-dev/misc/sync-module-bazel/cli.ts
+++ b/ng-dev/misc/sync-module-bazel/cli.ts
@@ -65,10 +65,11 @@ async function handler() {
   if (originalBazelContent !== moduleBazelContent) {
     writeFileSync(moduleBazelPath, moduleBazelContent);
 
-    await formatFiles(['MODULE.bazel']);
+    await formatFiles([moduleBazelPath]);
 
     ChildProcess.spawnSync('pnpm', ['bazel', 'mod', 'deps', '--lockfile_mode=update'], {
       suppressErrorOnFailingExitCode: true,
+      cwd: rootDir,
     });
   }
 }


### PR DESCRIPTION

The cwd was not specified which resulted in incorrect execution path.