### PR TITLE
ci: publish bazel rules snapshots

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           bazelrc: .bazelrc
       - run: pnpm install --frozen-lockfile
-      - run: pnpm bazel build //ng-dev:npm_package --config=release
+      - run: bash ./tools/build-all.sh
       - name: Publish Snapshots
         env:
           GITHUB_TOKEN: ${{ secrets.SNAPSHOT_BUILDS_GITHUB_TOKEN }}

--- a/.ng-dev/release.mjs
+++ b/.ng-dev/release.mjs
@@ -5,6 +5,18 @@ export const release = {
       name: '@angular/ng-dev',
       snapshotRepo: 'dev-infra-private-ng-dev-builds',
     },
+    {
+      name: 'rules_angular',
+      snapshotRepo: 'rules_angular',
+    },
+    {
+      name: 'rules_browsers',
+      snapshotRepo: 'rules_browsers',
+    },
+    {
+      name: 'rules_sass',
+      snapshotRepo: 'rules_sass',
+    },
   ],
   buildPackages: async () => {
     // TODO: Create a standard build script instead of expecting the build to already be complete
@@ -12,6 +24,18 @@ export const release = {
       {
         name: '@angular/ng-dev',
         outputPath: './dist/bin/ng-dev/npm_package',
+      },
+      {
+        name: 'rules_angular',
+        outputPath: './dist/rules/rules_angular',
+      },
+      {
+        name: 'rules_browsers',
+        outputPath: './dist/rules/rules_browsers',
+      },
+      {
+        name: 'rules_sass',
+        outputPath: './dist/rules/rules_sass',
       },
     ];
   },

--- a/bazel/rules/rules_angular/README.md
+++ b/bazel/rules/rules_angular/README.md
@@ -1,0 +1,19 @@
+# rules_angular
+
+> [!IMPORTANT]
+> The source code for this library is maintained in the [angular/dev-infra](https://github.com/angular/dev-infra/tree/main/bazel/rules/rules_angular) repository.
+> Please open any issues or pull requests in that repository.
+
+## Usage
+
+Add the dependency for `rules_angular` to your `MODULE.bazel` file.
+
+```starlark
+bazel_dep(name = "rules_angular")
+
+git_override(
+    module_name = "rules_angular",
+    remote = "https://github.com/angular/rules_angular.git",
+    commit = "{SHA}",
+)
+```

--- a/bazel/rules/rules_browsers/README.md
+++ b/bazel/rules/rules_browsers/README.md
@@ -1,5 +1,9 @@
 # rules_browsers
 
+> [!IMPORTANT]
+> The source code for this library is maintained in the [angular/dev-infra](https://github.com/angular/dev-infra/tree/main/bazel/rules/rules_browsers) repository.
+> Please open any issues or pull requests in that repository.
+
 Use browsers in Bazel and run tests with them.
 
 ## Usage
@@ -7,7 +11,13 @@ Use browsers in Bazel and run tests with them.
 Add the dependency for `rules_browsers` to your `MODULE.bazel` file.
 
 ```starlark
-bazel_dep(name = "rules_browsers", version = "0.4.0")
+bazel_dep(name = "rules_browsers")
+
+git_override(
+    module_name = "rules_browsers",
+    remote = "https://github.com/angular/rules_browsers.git",
+    commit = "{SHA}",
+)
 ```
 
 This allows you to use provided testing macros. You can also use the

--- a/bazel/rules/rules_sass/README.md
+++ b/bazel/rules/rules_sass/README.md
@@ -1,0 +1,19 @@
+# rules_sass
+
+> [!IMPORTANT]
+> The source code for this library is maintained in the [angular/dev-infra](https://github.com/angular/dev-infra/tree/main/bazel/rules/rules_sass) repository.
+> Please open any issues or pull requests in that repository.
+
+## Usage
+
+Add the dependency for `rules_sass` to your `MODULE.bazel` file.
+
+```starlark
+bazel_dep(name = "rules_sass")
+
+git_override(
+    module_name = "rules_sass",
+    remote = "https://github.com/angular/rules_sass.git",
+    commit = "{SHA}",
+)
+```

--- a/tools/build-all.sh
+++ b/tools/build-all.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Bash script to build all packages and modules in the dev-infra repository.
+set -e
+
+# Ensure the script runs from the repository root.
+cd "$(dirname "$0")/.."
+
+# Build the ng-dev npm package using Bazel in release mode.
+echo "Building //ng-dev:npm_package..."
+pnpm bazel build //ng-dev:npm_package --config=release
+
+# Package each rule module by creating a git archive and extracting it.
+# This ensures that only tracked files are included in the output.
+mkdir -p dist
+
+# Create a temporary tree-ish that includes uncommitted changes.
+# If no changes exist, git stash create returns empty, so we fall back to HEAD.
+tree_ish=$(git stash create)
+if [ -z "$tree_ish" ]; then
+  tree_ish="HEAD"
+fi
+
+for rule_path in bazel/rules/rules_*; do
+  if [ -d "$rule_path" ]; then
+    rule_name=$(basename "$rule_path")
+    target_dir="dist/rules/$rule_name"
+
+    echo "Packaging $rule_name into $target_dir..."
+
+    # Ensure target directory exists and is empty
+    rm -rf "$target_dir"
+    mkdir -p "$target_dir"
+
+    # Archive the content of the rule directory and extract it into dist.
+    git archive "$tree_ish":"$rule_path" | tar -x -C "$target_dir"
+  fi
+done
+
+echo "Build all completed successfully."


### PR DESCRIPTION
This commit integrates rules_angular, rules_browsers, and rules_sass into the repository's build and snapshot publishing workflow.