### PR TITLE
build: refine module synchronization

### DIFF
--- a/ng-dev/misc/sync-module-bazel/cli.ts
+++ b/ng-dev/misc/sync-module-bazel/cli.ts
@@ -13,6 +13,7 @@ import {determineRepoBaseDirFromCwd} from '../../utils/repo-directory';
 import {PackageJson, syncNodeJs, syncPnpm, syncTypeScript} from './sync-module-bazel';
 import {ChildProcess} from '../../utils/child-process';
 import {formatFiles} from '../../format/format';
+import {getBazelBin} from '../../utils/bazel-bin';
 
 async function builder(argv: Argv) {
   return argv;
@@ -67,7 +68,7 @@ async function handler() {
 
     await formatFiles([moduleBazelPath]);
 
-    ChildProcess.spawnSync('pnpm', ['bazel', 'mod', 'deps', '--lockfile_mode=update'], {
+    ChildProcess.spawnSync(getBazelBin(), ['mod', 'deps', '--lockfile_mode=update'], {
       suppressErrorOnFailingExitCode: true,
     });
   }

--- a/tools/sync-all-modules.sh
+++ b/tools/sync-all-modules.sh
@@ -16,12 +16,15 @@ done < <(find . -name "MODULE.bazel" -not -path "*/node_modules/*" -not -path "*
 echo "Synchronizing MODULE.bazel content..."
 for dir in "${module_dirs[@]}"; do
   echo "Processing (Sync): $dir"
-  (
-    cd "$dir"
-    if [[ -f "package.json" ]] && grep -q '"ng-dev":' package.json; then
+  if [[ -f "$dir/package.json" ]] && grep -q '"ng-dev":' "$dir/package.json"; then
+    (
+      cd "$dir"
       pnpm ng-dev misc sync-module-bazel
-    fi
-  )
+    )
+
+    # Update the root lockfile. This is needed for the sync-module-bazel command to work due to circular dependencies.
+    bazel mod deps --lockfile_mode=update
+  fi
 done
 
 # Update Bazel lockfiles for each module due to circular dependencies.


### PR DESCRIPTION


Also refines the sync-all-modules.sh script to update the root lockfile during the synchronization pass. This ensures the root lockfile is accurate between module synchronization steps, which is necessary for pnpm ng-dev misc sync-module-bazel to function correctly when dealing with circular dependencies.