### PR TITLE
fix(ng-dev/release): escape double quotes in snapshot commit message

### DIFF
--- a/ng-dev/release/snapshot-publish/snapshots.ts
+++ b/ng-dev/release/snapshot-publish/snapshots.ts
@@ -161,9 +161,16 @@ export class SnapshotPublisher {
             ['diff-index', '--quiet', '-I', '0\\.0\\.0-[a-f0-9]+', 'HEAD', '--'],
             {cwd: tmpRepoDir},
           ).status === 1;
-        this.git.run(['commit', '--author', this.commitAuthor, '-m', this.snapshotCommitMessage], {
-          cwd: tmpRepoDir,
-        });
+        this.git.run(
+          [
+            'commit',
+            '--author',
+            this.commitAuthor,
+            '-m',
+            `"${this.snapshotCommitMessage.replace(/"/g, '\\"')}"`,
+          ],
+          {cwd: tmpRepoDir},
+        );
 
         return {
           url,


### PR DESCRIPTION
When creating a snapshot commit, the snapshot message might contain double quotes which need to be properly escaped when passed to the git command line. This fixes an issue where the `git commit -m` command fails or produces incorrectly formatted messages if the snapshot message contains quotes.
