### PR TITLE
fix(bazel/rules_angular): fix 'NgtscCompilerHost' type incompatibility

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -547,7 +547,7 @@
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
         "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "7iXpy97hRtKmmBzd+nMFAwTGsF2in10kXImaLMA/Muk=",
+        "usagesDigest": "wMUO8eqom13wkxWLavnqCGJ4zFZmKs0oe11W4sSbEBw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -563,7 +563,7 @@
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
               "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript-local"
+              "typescript": "@@rules_angular+//:node_modules/typescript"
             }
           }
         },

--- a/bazel/rules/rules_angular/BUILD.bazel
+++ b/bazel/rules/rules_angular/BUILD.bazel
@@ -1,11 +1,3 @@
 load("@rules_angular_npm//:defs.bzl", "npm_link_all_packages")
-load("//src/private:symlink_package.bzl", "symlink_package")
-
-package(default_visibility = ["//visibility:public"])
 
 npm_link_all_packages()
-
-symlink_package(
-    name = "node_modules/typescript",
-    src = "@rules_angular_configurable_deps//:typescript",
-)

--- a/bazel/rules/rules_angular/MODULE.bazel
+++ b/bazel/rules/rules_angular/MODULE.bazel
@@ -75,6 +75,6 @@ use_repo(npm, "rules_angular_npm")
 rules_angular = use_extension("//setup:extensions.bzl", "rules_angular")
 rules_angular.setup(
     angular_compiler_cli = "//:node_modules/@angular/compiler-cli",
-    typescript = "//:node_modules/typescript-local",
+    typescript = "//:node_modules/typescript",
 )
 use_repo(rules_angular, "rules_angular_configurable_deps")

--- a/bazel/rules/rules_angular/MODULE.bazel.lock
+++ b/bazel/rules/rules_angular/MODULE.bazel.lock
@@ -210,7 +210,7 @@
     "//setup:extensions.bzl%rules_angular": {
       "general": {
         "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "jkYG7pVwv9AUzkvnnZz9u6hli0yfOwImvAzrkQK2DTY=",
+        "usagesDigest": "HEQ4Gmf3EPxCgnf3Tqa2HODnSVNDmEWlFWcP/XnMRbU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -219,7 +219,7 @@
             "repoRuleId": "@@//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
               "angular_compiler_cli": "@@//:node_modules/@angular/compiler-cli",
-              "typescript": "@@//:node_modules/typescript-local"
+              "typescript": "@@//:node_modules/typescript"
             }
           },
           "dev_infra_rules_angular_configurable_deps": {

--- a/bazel/rules/rules_angular/package.json
+++ b/bazel/rules/rules_angular/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@angular/compiler-cli": "22.0.0-next.3",
-    "typescript-local": "npm:typescript@5.9.3"
+    "typescript": "5.9.3"
   },
   "devDependencies": {
     "@angular/build": "22.0.0-next.1",

--- a/bazel/rules/rules_angular/pnpm-lock.yaml
+++ b/bazel/rules/rules_angular/pnpm-lock.yaml
@@ -13,9 +13,9 @@ importers:
       '@angular/compiler-cli':
         specifier: 22.0.0-next.3
         version: 22.0.0-next.3(@angular/compiler@22.0.0-next.3)(typescript@5.9.3)
-      typescript-local:
-        specifier: npm:typescript@5.9.3
-        version: typescript@5.9.3
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
     devDependencies:
       '@angular/build':
         specifier: 22.0.0-next.1

--- a/bazel/rules/rules_angular/src/worker/BUILD.bazel
+++ b/bazel/rules/rules_angular/src/worker/BUILD.bazel
@@ -5,9 +5,15 @@ load("//src/private:symlink_package.bzl", "symlink_package")
 
 package(default_visibility = ["//visibility:public"])
 
+# User configured dependencies
 symlink_package(
     name = "node_modules/@angular/compiler-cli",
     src = "@rules_angular_configurable_deps//:angular_compiler_cli",
+)
+
+symlink_package(
+    name = "node_modules/typescript",
+    src = "@rules_angular_configurable_deps//:typescript",
 )
 
 # ---
@@ -40,13 +46,13 @@ ts_project(
     declaration = True,
     tsconfig = "tsconfig",
     deps = [
-        "//:node_modules/typescript",
         "//:node_modules/json-stable-stringify",
         "//:node_modules/lru-cache",
         "//:node_modules/memfs",
         # NOTE: The Angular compiler in this target is not affecting any compilation
         # output, but it's still necessary for some foundational utils like virtual FS.
         "//:node_modules/@angular/compiler-cli",  # compiler from npm.
+        "//:node_modules/typescript",  # typescript from npm.
     ],
 )
 
@@ -62,10 +68,10 @@ ts_project(
     tsconfig = "tsconfig",
     deps = [
         ":node_modules/@angular/compiler-cli",  # user-configured compiler
+        ":node_modules/typescript",  # user-configured typescript
         "//:node_modules/json-stable-stringify",
         "//:node_modules/lru-cache",
         "//:node_modules/memfs",
-        "//:node_modules/typescript",
     ],
 )
 

--- a/bazel/rules/rules_browsers/MODULE.bazel.lock
+++ b/bazel/rules/rules_browsers/MODULE.bazel.lock
@@ -759,7 +759,7 @@
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
         "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "817oO2TO7X12eqL/1sLolLEMte0KVWIlmCGYKTKpY7A=",
+        "usagesDigest": "bW3NjO5IwkrQn0yIQPRNd4Lb077vl5Gu8AOzyN+zmCw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -768,7 +768,7 @@
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
               "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript-local"
+              "typescript": "@@rules_angular+//:node_modules/typescript"
             }
           },
           "dev_infra_rules_angular_configurable_deps": {

--- a/bazel/rules/rules_browsers/test/MODULE.bazel.lock
+++ b/bazel/rules/rules_browsers/test/MODULE.bazel.lock
@@ -547,7 +547,7 @@
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
         "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "817oO2TO7X12eqL/1sLolLEMte0KVWIlmCGYKTKpY7A=",
+        "usagesDigest": "bW3NjO5IwkrQn0yIQPRNd4Lb077vl5Gu8AOzyN+zmCw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -556,7 +556,7 @@
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
               "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript-local"
+              "typescript": "@@rules_angular+//:node_modules/typescript"
             }
           },
           "dev_infra_rules_angular_configurable_deps": {

--- a/bazel/rules/rules_sass/MODULE.bazel.lock
+++ b/bazel/rules/rules_sass/MODULE.bazel.lock
@@ -603,7 +603,7 @@
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
         "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "817oO2TO7X12eqL/1sLolLEMte0KVWIlmCGYKTKpY7A=",
+        "usagesDigest": "bW3NjO5IwkrQn0yIQPRNd4Lb077vl5Gu8AOzyN+zmCw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -612,7 +612,7 @@
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
               "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript-local"
+              "typescript": "@@rules_angular+//:node_modules/typescript"
             }
           },
           "dev_infra_rules_angular_configurable_deps": {

--- a/ng-dev/misc/sync-module-bazel/cli.ts
+++ b/ng-dev/misc/sync-module-bazel/cli.ts
@@ -34,10 +34,7 @@ async function handler() {
   // Read package.json
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageJson;
   const pnpmVersion = packageJson.engines?.pnpm;
-  const tsVersion =
-    packageJson.dependencies?.typescript ||
-    packageJson.devDependencies?.typescript ||
-    packageJson.dependencies?.['typescript-local']?.replace('npm:typescript@', '');
+  const tsVersion = packageJson.dependencies?.typescript || packageJson.devDependencies?.typescript;
 
   // Read .nvmrc
   let nvmrcVersion: string | undefined;

--- a/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
+++ b/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
@@ -15,7 +15,6 @@ export interface PackageJson {
   };
   dependencies?: {
     typescript?: string;
-    'typescript-local'?: string;
   };
   devDependencies?: {
     typescript?: string;


### PR DESCRIPTION


This change fixes an issue where the 'NgtscCompilerHost' was not assignable to 'CompilerHost'
due to incompatible 'SourceFile' types from different TypeScript versions.

The fix involves ensuring that the Angular compiler worker uses the user-configured
TypeScript dependency instead of a potentially different version from the root.
As part of this, the 'typescript-local' dependency alias is renamed to 'typescript'
and the symlinking logic is moved to the worker package.