### PR TITLE
ci: cnforce lockfile for dart pub get in the sass compiler updates workflow

### DIFF
--- a/.github/workflows/rules_sass-compiler-updates.yml
+++ b/.github/workflows/rules_sass-compiler-updates.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
-      - run: dart pub get
+      - run: dart pub get --enforce-lockfile
       - run: mkdir -p src/compiler/built/
       - run: dart compile exe src/compiler/bin/x_sass.dart -o src/compiler/built/${{ matrix.bin_name }}
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION


Updated the workflow to mandate --enforce-lockfile. This ensures we pull the specific package versions listed in the lockfile rather than allowing the resolver to fetch newer, unvetted updates.