### PR TITLE
fix(ng-dev/release): allow empty commits when publishing snapshots

### DIFF
--- a/ng-dev/release/snapshot-publish/snapshots.ts
+++ b/ng-dev/release/snapshot-publish/snapshots.ts
@@ -161,9 +161,11 @@ export class SnapshotPublisher {
             ['diff-index', '--quiet', '-I', '0\\.0\\.0-[a-f0-9]+', 'HEAD', '--'],
             {cwd: tmpRepoDir},
           ).status === 1;
+
         this.git.run(
           [
             'commit',
+            '--allow-empty',
             '--author',
             this.commitAuthor,
             '-m',


### PR DESCRIPTION

When publishing snapshots, it's possible that a package is built but 
contains no functional changes (e.g. only version placeholder updates 
which are ignored by the diff). 
Previously, the git commit step would fail in these cases because the 
working tree was clean. This change adding the --allow-empty flag to 
ensure the commit succeeds regardless of changes.