### PR TITLE
fix(github-actions): use stable TMPDIR for rules_sass compiler compilation

### DIFF
--- a/.github/workflows/rules_sass-compiler-updates.yml
+++ b/.github/workflows/rules_sass-compiler-updates.yml
@@ -29,7 +29,14 @@ jobs:
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
       - run: dart pub get --enforce-lockfile
       - run: mkdir -p src/compiler/built/
-      - run: dart compile exe src/compiler/bin/x_sass.dart -o src/compiler/built/${{ matrix.bin_name }}
+
+      # To fix the non-deterministic build problem on macOS, force the Dart compiler to use a stable,
+      # non-random temporary directory during compilation. By default, macOS uses a random subfolder in /var/folders/...,
+      # but we can override this by setting the TMPDIR environment variable to a fixed path within the workspace.
+      - run: |
+          mkdir -p .dart_tmp
+          export TMPDIR="$(pwd)/.dart_tmp"
+          dart compile exe src/compiler/bin/x_sass.dart -o src/compiler/built/${{ matrix.bin_name }}
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ matrix.bin_name }}


### PR DESCRIPTION

Forcing a stable temporary directory prevents the Dart compiler on macOS from embedding random absolute paths into the compiled binaries.
    
Previously, the random temp paths (e.g., /var/folders/.../random_hash/snapshot.aot) caused the binaries to differ on every build run even when the source code was identical. Using a workspace-relative TMPDIR ensures deterministic binary output.