### PR TITLE
Revert "fix(github-actions): use stable TMPDIR for rules_sass compile…

### DIFF
--- a/.github/workflows/rules_sass-compiler-updates.yml
+++ b/.github/workflows/rules_sass-compiler-updates.yml
@@ -29,14 +29,7 @@ jobs:
       - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
       - run: dart pub get --enforce-lockfile
       - run: mkdir -p src/compiler/built/
-
-      # To fix the non-deterministic build problem on macOS, force the Dart compiler to use a stable,
-      # non-random temporary directory during compilation. By default, macOS uses a random subfolder in /var/folders/...,
-      # but we can override this by setting the TMPDIR environment variable to a fixed path within the workspace.
-      - run: |
-          mkdir -p .dart_tmp
-          export TMPDIR="$(pwd)/.dart_tmp"
-          dart compile exe src/compiler/bin/x_sass.dart -o src/compiler/built/${{ matrix.bin_name }}
+      - run: dart compile exe src/compiler/bin/x_sass.dart -o src/compiler/built/${{ matrix.bin_name }}
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ matrix.bin_name }}


### PR DESCRIPTION
…r compilation"

This reverts commit b9ac8bcfb5dd346d045511e30ff1db5231d7da2b.

**Did not solve the problem.**