### PR TITLE
build: skip rules_sass compiler update PR if only macOS binaries changed

### DIFF
--- a/.github/workflows/rules_sass-compiler-updates.yml
+++ b/.github/workflows/rules_sass-compiler-updates.yml
@@ -53,7 +53,19 @@ jobs:
           merge-multiple: true
       - name: chmod binaries
         run: chmod +x src/compiler/built/*
+      - name: Check for meaningful changes
+        id: check
+        run: |
+          CHANGES=$(git diff --name-only | grep -v "^bazel/rules/rules_sass/src/compiler/built/sass_mac" || true)
+          if [ -z "$CHANGES" ]; then
+            echo "Only macOS binaries changed (non-deterministic). Skipping PR."
+            echo "skip_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "Meaningful changes detected."
+            echo "skip_pr=false" >> $GITHUB_OUTPUT
+          fi
       - name: Create Pull Request
+        if: steps.check.outputs.skip_pr != 'true'
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.ANGULAR_ROBOT_ACCESS_TOKEN }}


### PR DESCRIPTION
The rules_sass compiler binaries on macOS are non-deterministic, causing valid updates to be proposed even when nothing in rules_sass changed. This change skips creating a Pull Request if only the macOS binaries changed.