### PR TITLE
fix(ng-dev/release): ignore lock files when detecting snapshot changes

### DIFF
--- a/ng-dev/release/snapshot-publish/snapshots.ts
+++ b/ng-dev/release/snapshot-publish/snapshots.ts
@@ -158,7 +158,17 @@ export class SnapshotPublisher {
         this.git.run(['add', '-A'], {cwd: tmpRepoDir});
         const containsChanges =
           this.git.runGraceful(
-            ['diff-index', '--quiet', '-I', '0\\.0\\.0-[a-f0-9]+', 'HEAD', '--'],
+            [
+              'diff-index',
+              '--quiet',
+              '-I',
+              '0\\.0\\.0-[a-f0-9]+',
+              'HEAD',
+              '--',
+              '.',
+              ':(exclude)**/MODULE.bazel.lock',
+              ':(exclude)**/package-lock.json',
+            ],
             {cwd: tmpRepoDir},
           ).status === 1;
 


### PR DESCRIPTION
Update the `diff-index` command used during snapshot publishing to ignore `MODULE.bazel.lock` and `package-lock.json` files.

This prevents  triggering snapshot publishes when the only changes are in dependency lock files.