### PR TITLE
build: remove redundant Bazel lockfile update workarounds

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -42,22 +42,6 @@
     // GENERAL GROUPING & UPDATE BEHAVIOR
     // ============================================================================
 
-    // Enable 'postUpdateTasks' for changes that effect the BAZEL lockfile or generated files.
-    // Renovate does not update Bazel lockfile for the time being.
-    // Workaround for https://github.com/renovatebot/renovate/issues/25557
-    {
-      postUpgradeTasks: {
-        matchManagers: ['bazel', 'bazel-module', 'bazelisk'],
-        commands: [
-          'bash -c "git restore .npmrc || true"', // If `.npmrc` doesn't exist, avoid a hard error.
-          'bazel mod deps --lockfile_mode=update',
-        ],
-        // This is theory should be `branch` but in some cases this is causing the command not to
-        // run when in the same branch there are mixtures of update types by different managers.
-        executionMode: 'update',
-      },
-    },
-
     // Enable 'postUpdateTasks' for changes that effect the typescript and pnpm versions.
     // This is to ensure that the `MODULE.bazel` is updated with the correct versions.
     {

--- a/tools/sync-all-modules.sh
+++ b/tools/sync-all-modules.sh
@@ -6,9 +6,6 @@ export BAZEL="$(git rev-parse --show-toplevel)/node_modules/.bin/bazel"
 
 echo "Starting synchronization of all Bazel modules..."
 
-# Update the root lockfile. This is needed for the sync-module-bazel command to work.
-"$BAZEL" mod deps --lockfile_mode=update
-
 # Find and store all MODULE.bazel directories
 module_dirs=()
 while IFS= read -r -d '' module_file; do


### PR DESCRIPTION
Renovate now natively supports updating Bazel lockfiles.

This change removes the `postUpgradeTasks` workaround in Renovate presets and a redundant synchronization step in the `sync-all-modules.sh` script that were previously used to manually update Bazel lockfiles.
