### PR TITLE
fix(renovate-presets): move PR changelog to the bottom

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -30,7 +30,7 @@
   },
 
   // Manually define pull request body template to only include desired sections
-  prBodyTemplate: '{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}',
+  prBodyTemplate: '{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{controls}}}{{{changelogs}}}',
 
   // Ignored dependencies in all repositories
   ignoreDeps: [


### PR DESCRIPTION
Moves the changelog section of the PR body template to the bottom of the body to ensure that the PR controls are not hidden or truncated when the changelog is excessively long.