### PR TITLE
fix(github-actions): add MPL-2.0 as a permissible license

### DIFF
--- a/github-actions/linting/licenses/dependency-review-config.yml
+++ b/github-actions/linting/licenses/dependency-review-config.yml
@@ -14,6 +14,7 @@ allow-licenses:
   - 'LGPL-3.0+'
   - 'MIT'
   - 'MIT-0'
+  - 'MPL-2.0'
   - 'Python-2.0'
   - 'Unlicense'
 allow-dependencies-licenses:


### PR DESCRIPTION
Adds MPL-2.0 as an allowed license for dependencies.