### PR TITLE
ci: run renovate post-upgrade tasks only for npm and lockfile maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,18 @@
         ],
         "executionMode": "branch"
       },
-      "matchManagers": ["bazel", "bazel-module", "bazelisk", "npm"]
+      "matchManagers": ["npm"]
+    },
+    {
+      "postUpgradeTasks": {
+        "commands": [
+          "pnpm install --frozen-lockfile",
+          "bash ./tools/sync-all-modules.sh",
+          "pnpm update-generated-files"
+        ],
+        "executionMode": "branch"
+      },
+      "matchUpdateTypes": ["lockFileMaintenance"]
     }
   ]
 }


### PR DESCRIPTION

Update the Renovate configuration to only trigger post-upgrade commands (pnpm install, sync-all-modules.sh, and update-generated-files) when the npm manager is used or during lock-file maintenance. This ensures that Bazel manager updates not impacting the NPM lock-file or sync-module-bazel will not trigger those tasks.