### PR TITLE
fix(ng-dev/release): improve lockfile exclusion logic in snapshot publishing

### DIFF
--- a/ng-dev/release/snapshot-publish/snapshots.ts
+++ b/ng-dev/release/snapshot-publish/snapshots.ts
@@ -34,7 +34,16 @@ interface SnapshotRepo {
 /**
  * Paths to exclude from the snapshot commit.
  */
-const PATHS_TO_EXCLUDE = ['**/MODULE.bazel.lock', '**/package-lock.json', '**/pubspec.lock'];
+const PATHS_TO_EXCLUDE = [
+  'MODULE.bazel.lock',
+  '**/MODULE.bazel.lock',
+
+  'pnpm-lock.yaml',
+  '**/pnpm-lock.yaml',
+
+  'pubspec.lock',
+  '**/pubspec.lock',
+];
 
 export class SnapshotPublisher {
   /** The current branch name. */


### PR DESCRIPTION

Update the snapshot publishing logic to more robustly exclude lockfiles from determining if a snapshot is affected by changes.

Specifically:
- Added pnpm-lock.yaml to the list of excluded paths.
- Added both root-level and glob variants for MODULE.bazel.lock, pnpm-lock.yaml, and pubspec.lock.