### PR TITLE
ci: include bazel and bazelisk managers in renovate post-upgrade tasks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
         ],
         "executionMode": "branch"
       },
-      "matchManagers": ["npm"]
+      "matchManagers": ["npm", "bazel", "bazel-module", "bazelisk"]
     },
     {
       "postUpgradeTasks": {


### PR DESCRIPTION
Ensure that post-upgrade tasks, such as module synchronization and generated file updates, are executed when Renovate updates Bazel dependencies or Bazelisk versions.