### PR TITLE
refactor(github-actions): update labeling prompt with descriptions

### DIFF
--- a/github-actions/labeling/issue/lib/issue-labeling.spec.ts
+++ b/github-actions/labeling/issue/lib/issue-labeling.spec.ts
@@ -16,12 +16,16 @@ describe('IssueLabeling', () => {
 
   beforeEach(() => {
     mockGit = jasmine.createSpyObj('Octokit', ['paginate', 'issues', 'pulls']);
-    mockGit.issues = jasmine.createSpyObj('issues', ['addLabels', 'get']);
+    mockGit.issues = jasmine.createSpyObj('issues', ['addLabels', 'get', 'listLabelsForRepo']);
 
     // Mock paginate to return the result of the promise if it's a list, or just execute the callback
     (mockGit.paginate as jasmine.Spy).and.callFake((fn: any, args: any) => {
-      if (fn === mockGit.issues.listLabelsOnIssue) {
-        return Promise.resolve([{name: 'area: core'}, {name: 'area: router'}, {name: 'bug'}]);
+      if (fn === mockGit.issues.listLabelsForRepo) {
+        return Promise.resolve([
+          {name: 'area: core', description: 'Core Angular framework'},
+          {name: 'area: router', description: 'Angular Router'},
+          {name: 'bug', description: 'Bug report'},
+        ]);
       }
       return Promise.resolve([]);
     });

--- a/github-actions/labeling/issue/lib/issue-labeling.ts
+++ b/github-actions/labeling/issue/lib/issue-labeling.ts
@@ -8,7 +8,7 @@ import {Labeling} from '../../shared/labeling.js';
 export class IssueLabeling extends Labeling {
   readonly type = 'Issue';
   /** Set of area labels available in the current repository. */
-  repoAreaLabels = new Set<string>();
+  repoAreaLabels = new Map<string, string>();
   /** The issue data fetched from Github. */
   issueData?: components['schemas']['issue'];
 
@@ -17,7 +17,7 @@ export class IssueLabeling extends Labeling {
 
     // Determine if the issue already has an area label, if it does we can exit early.
     if (
-      this.issueData?.labels.some((label) =>
+      this.issueData?.labels.some((label: string | {name?: string}) =>
         (typeof label === 'string' ? label : label.name)?.startsWith('area: '),
       )
     ) {
@@ -37,10 +37,13 @@ ${this.issueData!.body}
 
 The available area labels are:
 ${Array.from(this.repoAreaLabels)
-  .map((label) => ` - ${label}`)
+  .map(
+    ([label, description]) =>
+      ` - Label: ${label}${description ? `, Description: ${description}` : ''}`,
+  )
   .join('\n')}
 
-Based on the content, which area label is the best fit?
+Based on the content of the issue and the available labels, which area label is the best fit?
 Respond ONLY with the exact label name (e.g. "area: core").
 If you are strictly unsure or if multiple labels match equally well, respond with "ambiguous".
 If no area label applies, respond with "none".
@@ -82,7 +85,7 @@ If no area label applies, respond with "none".
         .then((labels) =>
           labels
             .filter((l) => l.name.startsWith('area: '))
-            .forEach((l) => this.repoAreaLabels.add(l.name)),
+            .forEach((l) => this.repoAreaLabels.set(l.name, l.description ?? '')),
         ),
       this.git.issues.get({owner, repo, issue_number: context.issue.number}).then((resp) => {
         this.issueData = resp.data;


### PR DESCRIPTION
This allows for providing more info via github label descriptions so the prompt can possibly do a better job of automatically labeling issues.