### PR TITLE
fix: read Bazel RBE auth tag from NGAT env instead of hardcoding

### DIFF
--- a/github-actions/bazel/configure-remote/constants.ts
+++ b/github-actions/bazel/configure-remote/constants.ts
@@ -7,6 +7,6 @@
  */
 
 export const alg = 'aes-256-gcm';
-export const at = 'QwbjZ/z+yDtD+XZjKj9Ynw==';
+export const at = process.env.NGAT!;
 export const k = process.env.GITHUB_REPOSITORY_OWNER!.padEnd(32, '<');
 export const iv = '000003213213123213';


### PR DESCRIPTION
## fix: read Bazel RBE auth tag from `NGAT` env instead of hardcoding

### Problem

The `github-actions/bazel/configure-remote/constants.ts` file hardcodes the AES-256-GCM authentication tag used to decrypt `gcp_token.data`:

```typescript
// Current (vulnerable)
export const at = 'QwbjZ/z+yDtD+XZjKj9Ynw==';
```

This means **all four parameters** needed to decrypt the embedded GCP service account credential are publicly available:

| Parameter | Source | Public? |
|-----------|--------|---------|
| Algorithm | `constants.ts` → `aes-256-gcm` | ✅ |
| Key | Derived from `GITHUB_REPOSITORY_OWNER` ("angular") | ✅ |
| IV | Hardcoded in `constants.ts` | ✅ |
| Auth Tag | Hardcoded in `constants.ts` | ✅ |
| Ciphertext | `gcp_token.data` in repo | ✅ |

The credential can be decrypted entirely offline — no secrets, authentication, or internal access required.

### Existing Pattern

The **SauceLabs** and **BrowserStack** actions in this same repository already handle this correctly by reading the auth tag from a secret environment variable:

```typescript
// github-actions/saucelabs/constants.ts — correct
export const at = process.env.NGAT!;

// github-actions/browserstack/constants.ts — correct
export const at = process.env.NGAT!;
```

### Fix

This PR applies the same pattern to the Bazel configure-remote action:

```diff
- export const at = 'QwbjZ/z+yDtD+XZjKj9Ynw==';
+ export const at = process.env.NGAT!;
```

### Additional Steps Required by Maintainers

1. **Rebuild the checked-in bundle**: `configure-remote.js` needs to be regenerated via the Bazel build after this TypeScript change.
2. **Rotate the exposed credential**: The GCP service account key for project `internal-200822` should be rotated, since the current `gcp_token.data` is decryptable with the previously hardcoded auth tag.
3. **Re-encrypt `gcp_token.data`**: After rotation, re-encrypt the new credential using `encrypt.ts` (which will now produce a new auth tag that should be set as the `NGAT` secret).
4. **Ensure `NGAT` is available**: Verify that the `NGAT` secret is passed to workflow steps that invoke `configure-remote` (it is already available for SauceLabs/BrowserStack steps).

### Secondary Concern: AES-GCM Nonce Reuse

The Bazel and SauceLabs integrations share the same `(key, IV)` pair (`angular<<<...`, `000003213213123213`). Since AES-GCM is a stream cipher mode, reusing the same key+nonce for different plaintexts enables crib-dragging attacks. Ideally each integration should use a unique IV. This is noted for awareness but not addressed in this PR to keep the change minimal and focused.

### Related

- Google Issue Tracker: 495423772
