### PR TITLE
ci: allow bazelModDeps unsafe execution in renovate runner config

### DIFF
--- a/.github/ng-renovate/runner-config.js
+++ b/.github/ng-renovate/runner-config.js
@@ -9,6 +9,8 @@ module.exports = {
   // Renovate fork PRs should never be editable as Renovate would otherwise
   // not be able to delete the branches and future updates would be missed.
   forkModeDisallowMaintainerEdits: true,
+  // Needed for `bazel mod deps --lockfile_mode=update`.
+  allowedUnsafeExecutions: ['bazelModDeps'],
   onboarding: false,
   persistRepoData: true,
   allowedCommands: ['.'],


### PR DESCRIPTION
Renovate requires permission to run `bazel mod deps --lockfile_mode=update` when updating Bazel module dependencies. This commit adds `bazelModDeps` to `allowedUnsafeExecutions` in the Renovate runner configuration to prevent updates from failing with permission errors.