### PR TITLE
fix(bazel/rules_angular): ensure correct typescript version is utilized in persistent worker runfiles

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -547,7 +547,7 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
         "usagesDigest": "VhEmCbgd+A0N+BXqk0/fozbWGR3zlPF+iWOFFGVm+dA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -547,8 +547,8 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "wMUO8eqom13wkxWLavnqCGJ4zFZmKs0oe11W4sSbEBw=",
+        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "usagesDigest": "VhEmCbgd+A0N+BXqk0/fozbWGR3zlPF+iWOFFGVm+dA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -556,15 +556,15 @@
           "dev_infra_rules_angular_configurable_deps": {
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
-              "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript"
+              "angular_compiler_cli": "@@//:node_modules/@angular/compiler-cli",
+              "typescript": "@@//:node_modules/typescript"
             }
           },
           "rules_angular_configurable_deps": {
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
-              "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript"
+              "angular_compiler_cli": "@@//:node_modules/@angular/compiler-cli",
+              "typescript": "@@//:node_modules/typescript"
             }
           }
         },

--- a/bazel/rules/rules_angular/MODULE.bazel
+++ b/bazel/rules/rules_angular/MODULE.bazel
@@ -72,9 +72,11 @@ npm.npm_translate_lock(
 )
 use_repo(npm, "rules_angular_npm")
 
-rules_angular = use_extension("//setup:extensions.bzl", "rules_angular")
-rules_angular.setup(
+rules_angular_dev = use_extension("//setup:extensions.bzl", "rules_angular", dev_dependency = True)
+rules_angular_dev.setup(
     angular_compiler_cli = "//:node_modules/@angular/compiler-cli",
     typescript = "//:node_modules/typescript",
 )
+
+rules_angular = use_extension("//setup:extensions.bzl", "rules_angular")
 use_repo(rules_angular, "rules_angular_configurable_deps")

--- a/bazel/rules/rules_angular/MODULE.bazel.lock
+++ b/bazel/rules/rules_angular/MODULE.bazel.lock
@@ -210,8 +210,8 @@
   "moduleExtensions": {
     "//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "HEQ4Gmf3EPxCgnf3Tqa2HODnSVNDmEWlFWcP/XnMRbU=",
+        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "usagesDigest": "FEgK9//DoGVMYxymWXHDPFQOohPcpW+zJl/V44ljFaE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -226,8 +226,8 @@
           "dev_infra_rules_angular_configurable_deps": {
             "repoRuleId": "@@//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
-              "angular_compiler_cli": "@@//:node_modules/@angular/compiler-cli",
-              "typescript": "@@//:node_modules/typescript"
+              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
+              "typescript": "@@devinfra+//:node_modules/typescript"
             }
           }
         },

--- a/bazel/rules/rules_angular/MODULE.bazel.lock
+++ b/bazel/rules/rules_angular/MODULE.bazel.lock
@@ -210,7 +210,7 @@
   "moduleExtensions": {
     "//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
         "usagesDigest": "FEgK9//DoGVMYxymWXHDPFQOohPcpW+zJl/V44ljFaE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/rules/rules_angular/setup/extensions.bzl
+++ b/bazel/rules/rules_angular/setup/extensions.bzl
@@ -1,21 +1,37 @@
 load("//setup:repositories.bzl", "configurable_deps_repo")
 
 def _extension(ctx):
+    root_setup = None
+    generated = {}
     for mod in ctx.modules:
+        if mod.is_root and mod.tags.setup:
+            root_setup = mod.tags.setup[0]
+        elif not root_setup and mod.tags.setup:
+            root_setup = mod.tags.setup[0]
+
         for attr in mod.tags.setup:
-            configurable_deps_repo(
-                name = attr.name,
-                angular_compiler_cli = attr.angular_compiler_cli,
-                typescript = attr.typescript,
-            )
+            if attr.name not in generated:
+                generated[attr.name] = True
+                configurable_deps_repo(
+                    name = attr.name,
+                    angular_compiler_cli = attr.angular_compiler_cli,
+                    typescript = attr.typescript,
+                )
+
+    if "rules_angular_configurable_deps" not in generated and root_setup:
+        configurable_deps_repo(
+            name = "rules_angular_configurable_deps",
+            angular_compiler_cli = root_setup.angular_compiler_cli,
+            typescript = root_setup.typescript,
+        )
 
 rules_angular = module_extension(
     implementation = _extension,
     tag_classes = {
         "setup": tag_class(attrs = {
             "name": attr.string(default = "rules_angular_configurable_deps"),
-            "angular_compiler_cli": attr.string(mandatory = True),
-            "typescript": attr.string(mandatory = True),
+            "angular_compiler_cli": attr.label(mandatory = True),
+            "typescript": attr.label(mandatory = True),
         }),
     },
 )

--- a/bazel/rules/rules_angular/setup/extensions.bzl
+++ b/bazel/rules/rules_angular/setup/extensions.bzl
@@ -10,20 +10,22 @@ def _extension(ctx):
             root_setup = mod.tags.setup[0]
 
         for attr in mod.tags.setup:
-            if attr.name not in generated:
-                generated[attr.name] = True
-                configurable_deps_repo(
-                    name = attr.name,
-                    angular_compiler_cli = attr.angular_compiler_cli,
-                    typescript = attr.typescript,
-                )
+            if attr.name in generated:
+                fail("The repository '{}' is already registered by another module. Please use a different name.".format(attr.name))
+            generated[attr.name] = True
+            configurable_deps_repo(
+                name = attr.name,
+                angular_compiler_cli = attr.angular_compiler_cli,
+                typescript = attr.typescript,
+            )
 
-    if "rules_angular_configurable_deps" not in generated and root_setup:
-        configurable_deps_repo(
-            name = "rules_angular_configurable_deps",
-            angular_compiler_cli = root_setup.angular_compiler_cli,
-            typescript = root_setup.typescript,
-        )
+    if "rules_angular_configurable_deps" not in generated:
+        if root_setup:
+            configurable_deps_repo(
+                name = "rules_angular_configurable_deps",
+                angular_compiler_cli = root_setup.angular_compiler_cli,
+                typescript = root_setup.typescript,
+            )
 
 rules_angular = module_extension(
     implementation = _extension,

--- a/bazel/rules/rules_angular/src/private/symlink_package.bzl
+++ b/bazel/rules/rules_angular/src/private/symlink_package.bzl
@@ -65,7 +65,10 @@ def _symlink_impl(ctx):
         target_path = relative_file(src_manifest_path, destination_manifest_path),
     )
 
-    runfiles = ctx.runfiles(files = [destination, destination_build])
+    runfiles = ctx.runfiles(
+        files = [destination, destination_build],
+        transitive_files = src[JsInfo].transitive_sources,
+    )
 
     return [
         DefaultInfo(

--- a/bazel/rules/rules_angular/src/worker/bazel_safe_filesystem.mts
+++ b/bazel/rules/rules_angular/src/worker/bazel_safe_filesystem.mts
@@ -1,3 +1,4 @@
+import {createRequire} from 'node:module';
 import {NodeJSFileSystem, AbsoluteFsPath} from './angular_foundation_utils.mjs';
 
 // Guarding against unexpected scenarios from within the Bazel worker.
@@ -19,5 +20,11 @@ export class BazelSafeFilesystem extends NodeJSFileSystem {
   }
   removeDeep() {
     throw new Error('Not implemented');
+  }
+
+  getDefaultLibLocation(): AbsoluteFsPath {
+    const requireFn = createRequire(import.meta.filename);
+
+    return this.resolve(requireFn.resolve('typescript'), '..');
   }
 }

--- a/bazel/rules/rules_angular/src/worker/compiler_host_base.mts
+++ b/bazel/rules/rules_angular/src/worker/compiler_host_base.mts
@@ -6,7 +6,37 @@ import ts from 'typescript';
 
 export type AngularHostFactoryFn = (fs: FileSystem, options: ts.CompilerOptions) => ts.CompilerHost;
 
-export function createBaseCompilerHost<Host extends ts.CompilerHost>(
+/**
+ * A compiler host that is used for vanilla TypeScript compilations.
+ * It extends the AngularCompilerHostForVanillaCompilations class and overrides
+ * the methods in the base class to ensure the correct TS version is used.
+ */
+class CompilerHostForVanillaCompilations extends AngularCompilerHostForVanillaCompilations {
+  constructor(fs: FileSystem, options: ts.CompilerOptions) {
+    super(fs, options);
+  }
+
+  override getDefaultLibFileName(options: ts.CompilerOptions): string {
+    return this.fs.join(this.fs.getDefaultLibLocation(), ts.getDefaultLibFileName(options));
+  }
+
+  override getSourceFile(
+    fileName: string,
+    languageVersion: ts.ScriptTarget,
+  ): ts.SourceFile | undefined {
+    const text = this.readFile(fileName);
+    return text !== undefined
+      ? ts.createSourceFile(fileName, text, languageVersion, true)
+      : undefined;
+  }
+}
+
+/**
+ * Creates a compiler host for the given options and file system.
+ * If an Angular factory function is provided, it will be used to create the compiler host.
+ * Otherwise, a compiler host for vanilla TypeScript compilations will be created.
+ */
+export function createBaseCompilerHost(
   options: ts.CompilerOptions,
   fs: FileSystem,
   angularFactoryFn: AngularHostFactoryFn | null,
@@ -15,7 +45,7 @@ export function createBaseCompilerHost<Host extends ts.CompilerHost>(
     ? angularFactoryFn(fs, options)
     : // Even for vanilla compilations, we want to use a FS-respecting host. We can
       // just use the one from npm safely then.
-      new AngularCompilerHostForVanillaCompilations(fs, options);
+      new CompilerHostForVanillaCompilations(fs, options);
 
   // Support `--traceResolution`.
   base.trace = (output) => console.error(output);

--- a/bazel/rules/rules_angular/src/worker/loop.mts
+++ b/bazel/rules/rules_angular/src/worker/loop.mts
@@ -13,17 +13,9 @@ import {TsStructureIsReused} from './program_abstractions/structure_reused.mjs';
 import {VanillaTsProgram} from './program_abstractions/vanilla_ts.mjs';
 import {ProgramCache, WorkerProgramCacheEntry} from './program_cache.mjs';
 import {WorkRequest} from './protocol/worker.cjs';
-import {
-  AbsoluteFsPath,
-  NodeJSFileSystem,
-  readConfiguration,
-  FileSystem,
-  setFileSystem,
-} from './angular_foundation_utils.mjs';
-import {
-  ProgramDescriptor,
-  ProgramDescriptorCtor,
-} from './program_abstractions/program_descriptor.mjs';
+import {AbsoluteFsPath, readConfiguration, setFileSystem} from './angular_foundation_utils.mjs';
+import {ProgramDescriptorCtor} from './program_abstractions/program_descriptor.mjs';
+import {BazelSafeFilesystem} from './bazel_safe_filesystem.mjs';
 
 // Used for debug counting.
 let buildCount = 0;
@@ -70,7 +62,7 @@ export async function executeBuild(
   const fs =
     workerSortedInputFileNames !== null
       ? new WorkerSandboxFileSystem(workerSortedInputFileNames)
-      : new NodeJSFileSystem();
+      : new BazelSafeFilesystem();
 
   // Note: This is needed because functions like `readConfiguration` do not properly
   // re-use the passed `fs`, but call `getFileSystem`.

--- a/bazel/rules/rules_browsers/MODULE.bazel.lock
+++ b/bazel/rules/rules_browsers/MODULE.bazel.lock
@@ -759,7 +759,7 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
         "usagesDigest": "0yL3Q65d62LRr6A6p/EyQpayxnPEYgTgBuWpe5HcsBM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/rules/rules_browsers/MODULE.bazel.lock
+++ b/bazel/rules/rules_browsers/MODULE.bazel.lock
@@ -759,24 +759,24 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "bW3NjO5IwkrQn0yIQPRNd4Lb077vl5Gu8AOzyN+zmCw=",
+        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "usagesDigest": "0yL3Q65d62LRr6A6p/EyQpayxnPEYgTgBuWpe5HcsBM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "rules_angular_configurable_deps": {
-            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript"
-            }
-          },
           "dev_infra_rules_angular_configurable_deps": {
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
-              "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript"
+              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
+              "typescript": "@@devinfra+//:node_modules/typescript"
+            }
+          },
+          "rules_angular_configurable_deps": {
+            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
+            "attributes": {
+              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
+              "typescript": "@@devinfra+//:node_modules/typescript"
             }
           }
         },

--- a/bazel/rules/rules_browsers/test/MODULE.bazel.lock
+++ b/bazel/rules/rules_browsers/test/MODULE.bazel.lock
@@ -547,24 +547,24 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "bW3NjO5IwkrQn0yIQPRNd4Lb077vl5Gu8AOzyN+zmCw=",
+        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "usagesDigest": "0yL3Q65d62LRr6A6p/EyQpayxnPEYgTgBuWpe5HcsBM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "rules_angular_configurable_deps": {
-            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript"
-            }
-          },
           "dev_infra_rules_angular_configurable_deps": {
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
-              "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript"
+              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
+              "typescript": "@@devinfra+//:node_modules/typescript"
+            }
+          },
+          "rules_angular_configurable_deps": {
+            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
+            "attributes": {
+              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
+              "typescript": "@@devinfra+//:node_modules/typescript"
             }
           }
         },

--- a/bazel/rules/rules_browsers/test/MODULE.bazel.lock
+++ b/bazel/rules/rules_browsers/test/MODULE.bazel.lock
@@ -547,7 +547,7 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
         "usagesDigest": "0yL3Q65d62LRr6A6p/EyQpayxnPEYgTgBuWpe5HcsBM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/bazel/rules/rules_sass/MODULE.bazel.lock
+++ b/bazel/rules/rules_sass/MODULE.bazel.lock
@@ -603,24 +603,24 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "fkaH7HMicL3g7/NDaFzlq39kcLopMyQ3KdbDn+5CRzA=",
-        "usagesDigest": "bW3NjO5IwkrQn0yIQPRNd4Lb077vl5Gu8AOzyN+zmCw=",
+        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "usagesDigest": "0yL3Q65d62LRr6A6p/EyQpayxnPEYgTgBuWpe5HcsBM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "rules_angular_configurable_deps": {
-            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript"
-            }
-          },
           "dev_infra_rules_angular_configurable_deps": {
             "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
             "attributes": {
-              "angular_compiler_cli": "@@rules_angular+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@rules_angular+//:node_modules/typescript"
+              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
+              "typescript": "@@devinfra+//:node_modules/typescript"
+            }
+          },
+          "rules_angular_configurable_deps": {
+            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
+            "attributes": {
+              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
+              "typescript": "@@devinfra+//:node_modules/typescript"
             }
           }
         },

--- a/bazel/rules/rules_sass/MODULE.bazel.lock
+++ b/bazel/rules/rules_sass/MODULE.bazel.lock
@@ -603,7 +603,7 @@
     },
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
-        "bzlTransitiveDigest": "4H2tnLKiAgAf8vLqcZCt5VmtZcU0fNbRrBpqTISsdkU=",
+        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
         "usagesDigest": "0yL3Q65d62LRr6A6p/EyQpayxnPEYgTgBuWpe5HcsBM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/package.json
+++ b/package.json
@@ -20,8 +20,11 @@
       "default": "./*"
     }
   },
-  "devDependencies": {
+  "dependencies": {
     "@angular/compiler-cli": "22.0.0-next.7",
+    "typescript": "6.0.2"
+  },
+  "devDependencies": {
     "@bazel/bazelisk": "1.28.1",
     "@bazel/buildifier": "8.2.1",
     "firebase-tools": "15.13.0",
@@ -32,8 +35,7 @@
     "prettier": "3.8.1",
     "tslib": "^2.5.2",
     "tslint": "6.1.3",
-    "tsx": "^4.15.7",
-    "typescript": "6.0.2"
+    "tsx": "^4.15.7"
   },
   "pnpm": {
     "packageExtensions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,14 @@ packageExtensionsChecksum: sha256-3L73Fw32UVtE6x5BJxJPBtQtH/mgsr31grNpdhHP1IY=
 importers:
 
   .:
-    devDependencies:
+    dependencies:
       '@angular/compiler-cli':
         specifier: 22.0.0-next.7
         version: 22.0.0-next.7(@angular/compiler@22.0.0-next.7)(typescript@6.0.2)
+      typescript:
+        specifier: 6.0.2
+        version: 6.0.2
+    devDependencies:
       '@bazel/bazelisk':
         specifier: 1.28.1
         version: 1.28.1
@@ -46,9 +50,6 @@ importers:
       tsx:
         specifier: ^4.15.7
         version: 4.21.0
-      typescript:
-        specifier: 6.0.2
-        version: 6.0.2
 
   .github/local-actions:
     dependencies:


### PR DESCRIPTION


Updates the symlink_package rule to correctly propagate transitive source files, including standard library definitions, into the generated Bzlmod runfiles layout. Additionally, integrates the BazelSafeFilesystem instance within the persistent compiler worker to reliably resolve and load the workspace-provided TS toolchain at execution time.