### PR TITLE
build: mark rules_angular and rules_sass as dev dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,13 +27,13 @@ local_path_override(
     path = "bazel/rules/rules_browsers",
 )
 
-bazel_dep(name = "rules_sass")
+bazel_dep(name = "rules_sass", dev_dependency = True)
 local_path_override(
     module_name = "rules_sass",
     path = "bazel/rules/rules_sass",
 )
 
-bazel_dep(name = "rules_angular")
+bazel_dep(name = "rules_angular", dev_dependency = True)
 local_path_override(
     module_name = "rules_angular",
     path = "bazel/rules/rules_angular",
@@ -65,7 +65,7 @@ node.toolchain(
 )
 use_repo(node, "nodejs_toolchains")
 
-rules_angular = use_extension("@rules_angular//setup:extensions.bzl", "rules_angular")
+rules_angular = use_extension("@rules_angular//setup:extensions.bzl", "rules_angular", dev_dependency = True)
 rules_angular.setup(
     name = "dev_infra_rules_angular_configurable_deps",
     angular_compiler_cli = "//:node_modules/@angular/compiler-cli",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -548,7 +548,7 @@
     "@@rules_angular+//setup:extensions.bzl%rules_angular": {
       "general": {
         "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
-        "usagesDigest": "VhEmCbgd+A0N+BXqk0/fozbWGR3zlPF+iWOFFGVm+dA=",
+        "usagesDigest": "LMwtgqME8o9NVFP3Yto4dbTfUlJa/hooXfv59iDO4K0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/bazel/rules/rules_angular/MODULE.bazel
+++ b/bazel/rules/rules_angular/MODULE.bazel
@@ -16,12 +16,6 @@ local_path_override(
     path = "../rules_browsers",
 )
 
-bazel_dep(name = "rules_sass", dev_dependency = True)
-local_path_override(
-    module_name = "rules_sass",
-    path = "../rules_sass",
-)
-
 bazel_dep(name = "devinfra", dev_dependency = True)
 local_path_override(
     module_name = "devinfra",

--- a/bazel/rules/rules_angular/MODULE.bazel.lock
+++ b/bazel/rules/rules_angular/MODULE.bazel.lock
@@ -211,7 +211,7 @@
     "//setup:extensions.bzl%rules_angular": {
       "general": {
         "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
-        "usagesDigest": "FEgK9//DoGVMYxymWXHDPFQOohPcpW+zJl/V44ljFaE=",
+        "usagesDigest": "naOhHX492QW2ixuMXolnDK20neJIV55BU/01AtqpEvQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -221,13 +221,6 @@
             "attributes": {
               "angular_compiler_cli": "@@//:node_modules/@angular/compiler-cli",
               "typescript": "@@//:node_modules/typescript"
-            }
-          },
-          "dev_infra_rules_angular_configurable_deps": {
-            "repoRuleId": "@@//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@devinfra+//:node_modules/typescript"
             }
           }
         },
@@ -4088,62 +4081,6 @@
             "rules_python++python+python_3_9_host"
           ]
         ]
-      }
-    },
-    "@@rules_sass+//src/toolchain:extensions.bzl%sass": {
-      "general": {
-        "bzlTransitiveDigest": "mOfuR8PsNuUWEq7JZ4MpIRbwyAGAqrCvkXXGaRNnlPQ=",
-        "usagesDigest": "R0KshhzIouLWuexMUCrl4HY+FUDwlVVgF9Z7UnwyUWA=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "linux_amd64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_linux_x64",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:linux",
-                "@@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "linux_arm64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_linux_arm",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:linux",
-                "@@platforms//cpu:arm64"
-              ]
-            }
-          },
-          "darwin_amd64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_mac_x64",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:macos",
-                "@@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "darwin_arm64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_mac_arm",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:macos",
-                "@@platforms//cpu:arm64"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     },
     "@@yq.bzl+//yq:extensions.bzl%yq": {

--- a/bazel/rules/rules_browsers/MODULE.bazel
+++ b/bazel/rules/rules_browsers/MODULE.bazel
@@ -33,18 +33,6 @@ bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
 # Dev dependencies
-bazel_dep(name = "rules_angular", dev_dependency = True)
-local_path_override(
-    module_name = "rules_angular",
-    path = "../rules_angular",
-)
-
-bazel_dep(name = "rules_sass", dev_dependency = True)
-local_path_override(
-    module_name = "rules_sass",
-    path = "../rules_sass",
-)
-
 bazel_dep(name = "devinfra", dev_dependency = True)
 local_path_override(
     module_name = "devinfra",

--- a/bazel/rules/rules_browsers/MODULE.bazel.lock
+++ b/bazel/rules/rules_browsers/MODULE.bazel.lock
@@ -78,8 +78,7 @@
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
     "https://bcr.bazel.build/modules/jq.bzl/0.4.0/MODULE.bazel": "a7b39b37589f2b0dad53fd6c1ccaabbdb290330caa920d7ef3e6aad068cd4ab2",
-    "https://bcr.bazel.build/modules/jq.bzl/0.6.1/MODULE.bazel": "f30c46e0a08a9f7566a8bf60a43d48abea960cd7f57b315b01e2762f1537eb52",
-    "https://bcr.bazel.build/modules/jq.bzl/0.6.1/source.json": "9ca9e2f90baa6a5bb0a49626ed9528554ec83165adf47b39792673ecc7feda22",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/source.json": "52ec7530c4618e03f634b30ff719814a68d7d39c235938b7aa2abbfe1eb1c52c",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -638,22 +637,12 @@
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "dhTbv9E6UfT1WJmmu3ORRPO6AKFJvgBjBxu+BO+u1RY=",
-        "usagesDigest": "eQBvD0rK9KXNT2C3yx+6OvYutklURI5LbfG7lzEscTU=",
+        "usagesDigest": "cb8Kby8xd7wp/hMGiCHzW6BkpGGnxVgn21jbMSAp/oo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "npm_rules_browsers_typescript": {
-            "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
-            "attributes": {
-              "version": "6.0.2",
-              "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-              "urls": [
-                "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
-              ]
-            }
-          },
-          "rules_angular_npm_typescript": {
             "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
             "attributes": {
               "version": "6.0.2",
@@ -755,32 +744,6 @@
             "bazel_tools"
           ]
         ]
-      }
-    },
-    "@@rules_angular+//setup:extensions.bzl%rules_angular": {
-      "general": {
-        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
-        "usagesDigest": "0yL3Q65d62LRr6A6p/EyQpayxnPEYgTgBuWpe5HcsBM=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "dev_infra_rules_angular_configurable_deps": {
-            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@devinfra+//:node_modules/typescript"
-            }
-          },
-          "rules_angular_configurable_deps": {
-            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@devinfra+//:node_modules/typescript"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     },
     "@@rules_fuzzing+//fuzzing/private:extensions.bzl%non_module_dependencies": {
@@ -933,7 +896,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "4pUxCNc22K4I+6+4Nxu52Hur12tFRfa1JMsN5mdDv60=",
-        "usagesDigest": "qTh6l4/fB3Fpvs4QaKcyxjE/mcK7MXSYElmD3LaZf94=",
+        "usagesDigest": "0pEbiCiFuc80eTkbBcVGyuOlFqsmfTJLCi8mQAP8m7M=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -4090,66 +4053,10 @@
         ]
       }
     },
-    "@@rules_sass+//src/toolchain:extensions.bzl%sass": {
-      "general": {
-        "bzlTransitiveDigest": "mOfuR8PsNuUWEq7JZ4MpIRbwyAGAqrCvkXXGaRNnlPQ=",
-        "usagesDigest": "R0KshhzIouLWuexMUCrl4HY+FUDwlVVgF9Z7UnwyUWA=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "linux_amd64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_linux_x64",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:linux",
-                "@@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "linux_arm64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_linux_arm",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:linux",
-                "@@platforms//cpu:arm64"
-              ]
-            }
-          },
-          "darwin_amd64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_mac_x64",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:macos",
-                "@@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "darwin_arm64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_mac_arm",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:macos",
-                "@@platforms//cpu:arm64"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
     "@@yq.bzl+//yq:extensions.bzl%yq": {
       "general": {
         "bzlTransitiveDigest": "UfFMy8CWK4/dVo/tfaSAIYUiDGNAPes5eRllx9O9Q9Q=",
-        "usagesDigest": "umLriVxpGOcFzE0gKLxWJymQRp9eDPEe28SFkQxcVvs=",
+        "usagesDigest": "FO2bM4MZoGua3d4+POpaQX0r4pJLqmQMTeSWUl7BGoE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/bazel/rules/rules_browsers/test/MODULE.bazel
+++ b/bazel/rules/rules_browsers/test/MODULE.bazel
@@ -3,18 +3,6 @@
 module(name = "rules_browsers_test")
 
 # Dev dependencies
-bazel_dep(name = "rules_angular", dev_dependency = True)
-local_path_override(
-    module_name = "rules_angular",
-    path = "../../rules_angular",
-)
-
-bazel_dep(name = "rules_sass", dev_dependency = True)
-local_path_override(
-    module_name = "rules_sass",
-    path = "../../rules_sass",
-)
-
 bazel_dep(name = "devinfra", dev_dependency = True)
 local_path_override(
     module_name = "devinfra",

--- a/bazel/rules/rules_browsers/test/MODULE.bazel.lock
+++ b/bazel/rules/rules_browsers/test/MODULE.bazel.lock
@@ -78,8 +78,7 @@
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
     "https://bcr.bazel.build/modules/jq.bzl/0.4.0/MODULE.bazel": "a7b39b37589f2b0dad53fd6c1ccaabbdb290330caa920d7ef3e6aad068cd4ab2",
-    "https://bcr.bazel.build/modules/jq.bzl/0.6.1/MODULE.bazel": "f30c46e0a08a9f7566a8bf60a43d48abea960cd7f57b315b01e2762f1537eb52",
-    "https://bcr.bazel.build/modules/jq.bzl/0.6.1/source.json": "9ca9e2f90baa6a5bb0a49626ed9528554ec83165adf47b39792673ecc7feda22",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/source.json": "52ec7530c4618e03f634b30ff719814a68d7d39c235938b7aa2abbfe1eb1c52c",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -426,21 +425,11 @@
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "dhTbv9E6UfT1WJmmu3ORRPO6AKFJvgBjBxu+BO+u1RY=",
-        "usagesDigest": "7cp0TnszzHee3829A826wopw+7QhjZhWsLllh5ALFNw=",
+        "usagesDigest": "6l1PJdSOZ06aPVtgHa4HFgyBs5QQ2c11hqon41B7fjo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "rules_angular_npm_typescript": {
-            "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
-            "attributes": {
-              "version": "6.0.2",
-              "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-              "urls": [
-                "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
-              ]
-            }
-          },
           "npm_typescript": {
             "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
             "attributes": {
@@ -543,32 +532,6 @@
             "bazel_tools"
           ]
         ]
-      }
-    },
-    "@@rules_angular+//setup:extensions.bzl%rules_angular": {
-      "general": {
-        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
-        "usagesDigest": "0yL3Q65d62LRr6A6p/EyQpayxnPEYgTgBuWpe5HcsBM=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "dev_infra_rules_angular_configurable_deps": {
-            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@devinfra+//:node_modules/typescript"
-            }
-          },
-          "rules_angular_configurable_deps": {
-            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@devinfra+//:node_modules/typescript"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     },
     "@@rules_browsers+//browsers:extensions.bzl%browsers": {
@@ -933,7 +896,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "4pUxCNc22K4I+6+4Nxu52Hur12tFRfa1JMsN5mdDv60=",
-        "usagesDigest": "+o53v8j7mIZ+e+I5FIQvTXpJDYDIMoBYH49qHqPzS5Y=",
+        "usagesDigest": "7NivKODez1wnhdpcUhS2VDEmDRNcN1QEYenraK5MHxg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -4090,66 +4053,10 @@
         ]
       }
     },
-    "@@rules_sass+//src/toolchain:extensions.bzl%sass": {
-      "general": {
-        "bzlTransitiveDigest": "mOfuR8PsNuUWEq7JZ4MpIRbwyAGAqrCvkXXGaRNnlPQ=",
-        "usagesDigest": "R0KshhzIouLWuexMUCrl4HY+FUDwlVVgF9Z7UnwyUWA=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "linux_amd64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_linux_x64",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:linux",
-                "@@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "linux_arm64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_linux_arm",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:linux",
-                "@@platforms//cpu:arm64"
-              ]
-            }
-          },
-          "darwin_amd64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_mac_x64",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:macos",
-                "@@platforms//cpu:x86_64"
-              ]
-            }
-          },
-          "darwin_arm64_sass": {
-            "repoRuleId": "@@rules_sass+//src/toolchain:configure_sass.bzl%configure_sass",
-            "attributes": {
-              "file": "@rules_sass//src/compiler/built:sass_mac_arm",
-              "sha256": "",
-              "constraints": [
-                "@@platforms//os:macos",
-                "@@platforms//cpu:arm64"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
-      }
-    },
     "@@yq.bzl+//yq:extensions.bzl%yq": {
       "general": {
         "bzlTransitiveDigest": "UfFMy8CWK4/dVo/tfaSAIYUiDGNAPes5eRllx9O9Q9Q=",
-        "usagesDigest": "umLriVxpGOcFzE0gKLxWJymQRp9eDPEe28SFkQxcVvs=",
+        "usagesDigest": "FO2bM4MZoGua3d4+POpaQX0r4pJLqmQMTeSWUl7BGoE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/bazel/rules/rules_sass/MODULE.bazel
+++ b/bazel/rules/rules_sass/MODULE.bazel
@@ -18,12 +18,6 @@ bazel_dep(name = "bazel_lib", version = "3.2.2")
 bazel_dep(name = "aspect_rules_js", version = "3.0.3")
 
 # Dev dependencies
-bazel_dep(name = "rules_angular", dev_dependency = True)
-local_path_override(
-    module_name = "rules_angular",
-    path = "../rules_angular",
-)
-
 bazel_dep(name = "rules_browsers", dev_dependency = True)
 local_path_override(
     module_name = "rules_browsers",

--- a/bazel/rules/rules_sass/MODULE.bazel.lock
+++ b/bazel/rules/rules_sass/MODULE.bazel.lock
@@ -78,8 +78,7 @@
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
     "https://bcr.bazel.build/modules/jq.bzl/0.4.0/MODULE.bazel": "a7b39b37589f2b0dad53fd6c1ccaabbdb290330caa920d7ef3e6aad068cd4ab2",
-    "https://bcr.bazel.build/modules/jq.bzl/0.6.1/MODULE.bazel": "f30c46e0a08a9f7566a8bf60a43d48abea960cd7f57b315b01e2762f1537eb52",
-    "https://bcr.bazel.build/modules/jq.bzl/0.6.1/source.json": "9ca9e2f90baa6a5bb0a49626ed9528554ec83165adf47b39792673ecc7feda22",
+    "https://bcr.bazel.build/modules/jq.bzl/0.4.0/source.json": "52ec7530c4618e03f634b30ff719814a68d7d39c235938b7aa2abbfe1eb1c52c",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -482,21 +481,11 @@
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "dhTbv9E6UfT1WJmmu3ORRPO6AKFJvgBjBxu+BO+u1RY=",
-        "usagesDigest": "Mq6Ktk2Omtgucwc7CrEtsxbAYvdifsCAVV4HPjBURHA=",
+        "usagesDigest": "IKOHCcSLsCn6pSQnk+LRFQ5u1qwcVoz09WJbkcJCbso=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "rules_angular_npm_typescript": {
-            "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
-            "attributes": {
-              "version": "6.0.2",
-              "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-              "urls": [
-                "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
-              ]
-            }
-          },
           "npm_rules_browsers_typescript": {
             "repoRuleId": "@@aspect_rules_ts+//ts/private:npm_repositories.bzl%http_archive_version",
             "attributes": {
@@ -599,32 +588,6 @@
             "bazel_tools"
           ]
         ]
-      }
-    },
-    "@@rules_angular+//setup:extensions.bzl%rules_angular": {
-      "general": {
-        "bzlTransitiveDigest": "aS7Uud1IzoU7PPLzH3s6IfFS4b2fa0SRWDi2/fS4bQU=",
-        "usagesDigest": "0yL3Q65d62LRr6A6p/EyQpayxnPEYgTgBuWpe5HcsBM=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "dev_infra_rules_angular_configurable_deps": {
-            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@devinfra+//:node_modules/typescript"
-            }
-          },
-          "rules_angular_configurable_deps": {
-            "repoRuleId": "@@rules_angular+//setup:repositories.bzl%configurable_deps_repo",
-            "attributes": {
-              "angular_compiler_cli": "@@devinfra+//:node_modules/@angular/compiler-cli",
-              "typescript": "@@devinfra+//:node_modules/typescript"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     },
     "@@rules_browsers+//browsers:extensions.bzl%browsers": {
@@ -989,7 +952,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "4pUxCNc22K4I+6+4Nxu52Hur12tFRfa1JMsN5mdDv60=",
-        "usagesDigest": "Fm0QMRp1aBpfVymheGpnTf0l98al60aj1wRI7WXPxSI=",
+        "usagesDigest": "s5tw+9kK7+wIuZryCdw2i/Chm6aD5Qjz7kHoAOdeMBg=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -4149,7 +4112,7 @@
     "@@yq.bzl+//yq:extensions.bzl%yq": {
       "general": {
         "bzlTransitiveDigest": "UfFMy8CWK4/dVo/tfaSAIYUiDGNAPes5eRllx9O9Q9Q=",
-        "usagesDigest": "EAm9ZbzYkZwWIfvddAk5ZY3Toez+rklOENwRzPCWChs=",
+        "usagesDigest": "a75TnHFcGrtqY0PhWXPM9uOdh7SmnSndn0I7Q0Q/BhI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
rules_angular and rules_sass are only needed for development and testing, and should not be propagated to downstream consumers.