### PR TITLE
ci: remove ai-tutor from renovate workflow

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -23,7 +23,6 @@ jobs:
           - angular/dev-infra
           - angular/components
           - angular/angular-cli
-          - angular/ai-tutor
           - angular/web-codegen-scorer
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This repository can be archived as firebase studio is deprecated.