### PR TITLE
fix(ng-dev): remove unnecessary quotes from npm deprecate arguments

### DIFF
--- a/ng-dev/release/versioning/npm-command.ts
+++ b/ng-dev/release/versioning/npm-command.ts
@@ -40,7 +40,7 @@ export abstract class NpmCommand {
     message: string,
     registryUrl: string | undefined,
   ) {
-    const args = ['deprecate', `${packageName}@"${version}"`, `"${message}"`];
+    const args = ['deprecate', `${packageName}@${version}`, message];
 
     // If a custom registry URL has been specified, add the `--registry` flag.
     if (registryUrl !== undefined) {


### PR DESCRIPTION
With the recent changes to disable the shell in the ChildProcess wrappers, quotes are passed literally to the command. This removes the unnecessary quotes around the version to ensure the deprecate command functions correctly.