### PR TITLE
build: remove unused bazel build dependencies

### DIFF
--- a/apps/code-of-conduct/app/BUILD.bazel
+++ b/apps/code-of-conduct/app/BUILD.bazel
@@ -17,8 +17,6 @@ ng_project(
         "//apps/code-of-conduct:node_modules/@angular/material",
         "//apps/code-of-conduct:node_modules/@angular/router",
         "//apps/code-of-conduct/app/account",
-        "//apps/code-of-conduct/app/block-user",
-        "//apps/code-of-conduct/app/user-table",
     ],
 )
 

--- a/ng-dev/ai/skills/BUILD.bazel
+++ b/ng-dev/ai/skills/BUILD.bazel
@@ -27,7 +27,6 @@ ts_project(
         "//ng-dev:node_modules/@types/jasmine",
         "//ng-dev:node_modules/@types/node",
         "//ng-dev/utils",
-        "//ng-dev/utils/testing",
     ],
 )
 

--- a/ng-dev/pr/config/BUILD.bazel
+++ b/ng-dev/pr/config/BUILD.bazel
@@ -9,7 +9,6 @@ ts_project(
         "//ng-dev:__subpackages__",
     ],
     deps = [
-        "//ng-dev/commit-message",
         "//ng-dev/utils",
     ],
 )

--- a/ng-dev/release/notes/BUILD.bazel
+++ b/ng-dev/release/notes/BUILD.bazel
@@ -20,7 +20,6 @@ ts_project(
         "//ng-dev/commit-message",
         "//ng-dev/format",
         "//ng-dev/release/config",
-        "//ng-dev/release/versioning",
         "//ng-dev/utils",
     ],
 )

--- a/ng-dev/release/npm-dist-tag/delete/BUILD.bazel
+++ b/ng-dev/release/npm-dist-tag/delete/BUILD.bazel
@@ -33,7 +33,6 @@ ts_project(
         "//ng-dev/release/config",
         "//ng-dev/release/versioning",
         "//ng-dev/utils",
-        "//ng-dev/utils/testing",
     ],
 )
 

--- a/ng-dev/release/publish/BUILD.bazel
+++ b/ng-dev/release/publish/BUILD.bazel
@@ -21,7 +21,6 @@ ts_project(
         "//ng-dev/caretaker/merge-mode",
         "//ng-dev/commit-message",
         "//ng-dev/format",
-        "//ng-dev/pr/merge",
         "//ng-dev/release/build",
         "//ng-dev/release/config",
         "//ng-dev/release/info",


### PR DESCRIPTION
We've identified many redundant dependencies in bazel build scripts and refactored them, as part of a research project on dependency optimization.

Feel free to leave feedback, suggest improvements, or directly edit this PR.

Thanks for your support!