### PR TITLE
feat(bazel): add diff output to failing api-golden tests

### DIFF
--- a/bazel/api-golden/BUILD.bazel
+++ b/bazel/api-golden/BUILD.bazel
@@ -21,6 +21,7 @@ ts_project(
     deps = [
         "//bazel:node_modules/@microsoft/api-extractor",
         "//bazel:node_modules/@types/node",
+        "//bazel:node_modules/diff",
         "//bazel:node_modules/piscina",
         "//bazel:node_modules/typescript",
     ],

--- a/bazel/api-golden/index_npm_packages.cts
+++ b/bazel/api-golden/index_npm_packages.cts
@@ -14,6 +14,7 @@ import {testApiGolden} from './test_api_report.js';
 import * as fs from 'fs';
 import {Piscina} from 'piscina';
 import {styleText} from 'util';
+import {createPatch} from 'diff';
 
 /** Interface describing contents of a `package.json`. */
 export interface PackageJson {
@@ -89,7 +90,8 @@ async function main(
       const expected = await fs.promises.readFile(goldenFilePath, 'utf8');
       if (actual !== expected) {
         // Keep track of outdated goldens for error message.
-        outdatedGoldens.push(goldenName);
+        const patch = createPatch(goldenName, expected, actual);
+        outdatedGoldens.push({name: goldenName, diff: patch});
         return false;
       }
     }
@@ -97,7 +99,7 @@ async function main(
     return true;
   };
 
-  const outdatedGoldens: string[] = [];
+  const outdatedGoldens: {name: string; diff: string}[] = [];
   const tasks: Promise<boolean>[] = [];
   // Process in batches. Otherwise we risk out of memory errors.
   const batchSize = 10;
@@ -122,7 +124,11 @@ async function main(
     console.error(Array(80).fill('=').join(''));
     console.error(`${Array(35).fill('=').join('')} RESULTS ${Array(36).fill('=').join('')}`);
     console.error(Array(80).fill('=').join(''));
+
     if (singleFileMode) {
+      console.error(red(`Diff:`));
+      console.error(outdatedGoldens[0].diff);
+      console.info();
       console.error(
         red(
           `The golden is out of date and can be updated by running:\n  - bazel run ${process.env.TEST_TARGET}.accept`,
@@ -130,8 +136,16 @@ async function main(
       );
     } else {
       console.error(red(`The following goldens are outdated:`));
-      outdatedGoldens.forEach((name) => console.info(`-  ${name}`));
+      outdatedGoldens.forEach(({name}) => console.info(`-  ${name}`));
       console.info();
+
+      console.error(red(`Diffs:`));
+      outdatedGoldens.forEach(({name, diff}) => {
+        console.error(`\n--- Diff for ${name} ---`);
+        console.error(diff);
+      });
+      console.info();
+
       console.info(
         yellow(
           `The goldens can be updated by running:\n  - bazel run ${process.env.TEST_TARGET}.accept`,

--- a/bazel/package.json
+++ b/bazel/package.json
@@ -2,6 +2,7 @@
   "name": "@devinfra/bazel",
   "dependencies": {
     "@microsoft/api-extractor": "7.58.2",
+    "diff": "^9.0.0",
     "@types/babel__core": "7.20.5",
     "@types/browser-sync": "2.29.1",
     "@types/node": "24.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       browser-sync:
         specifier: 3.0.4
         version: 3.0.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       get-tsconfig:
         specifier: 4.14.0
         version: 4.14.0
@@ -3414,6 +3417,10 @@ packages:
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   discontinuous-range@1.0.0:
@@ -9501,6 +9508,8 @@ snapshots:
   diff@4.0.4: {}
 
   diff@8.0.4: {}
+
+  diff@9.0.0: {}
 
   discontinuous-range@1.0.0: {}
 


### PR DESCRIPTION
This commit adds unified diff output when `api_golden_test` fails, using the `diff` NPM package.