### PR TITLE
fix(ng-dev): remove quotes from bazel query in update-generated-files

### DIFF
--- a/ng-dev/misc/generated-files/update-generated-files.ts
+++ b/ng-dev/misc/generated-files/update-generated-files.ts
@@ -20,7 +20,7 @@ export async function updateGeneratedFileTargets(): Promise<void> {
       getBazelBin(),
       [
         'query',
-        `"kind(esbuild, //...) intersect attr(name, '_generated$', //...)"`,
+        `kind(esbuild, //...) intersect attr(name, '_generated$', //...)`,
         '--output',
         'label',
       ],


### PR DESCRIPTION
The quotes around the query expression caused Bazel to treat it as a target name instead of a query, leading to an error.