### PR TITLE
ci: update GitHub Actions node runner to node24

### DIFF
--- a/.github/local-actions/branch-manager/action.yml
+++ b/.github/local-actions/branch-manager/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: 'The latest sha for the pull request'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'

--- a/.github/local-actions/labels-sync/action.yml
+++ b/.github/local-actions/labels-sync/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'

--- a/.github/local-actions/lock-closed/action.yml
+++ b/.github/local-actions/lock-closed/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: 'The repositories to check for lockable issues'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'

--- a/github-actions/bazel/configure-remote/action.yml
+++ b/github-actions/bazel/configure-remote/action.yml
@@ -21,5 +21,5 @@ inputs:
       Whether the environment should be considerd a trusted build.
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'configure-remote.js'

--- a/github-actions/branch-manager/BUILD.bazel
+++ b/github-actions/branch-manager/BUILD.bazel
@@ -29,5 +29,5 @@ esbuild_checked_in(
     entry_point = "lib/main.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )

--- a/github-actions/branch-manager/action.yml
+++ b/github-actions/branch-manager/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'The private key for the Angular Robot Github app.'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'

--- a/github-actions/google-internal-tests/BUILD.bazel
+++ b/github-actions/google-internal-tests/BUILD.bazel
@@ -26,5 +26,5 @@ esbuild_checked_in(
     entry_point = "lib/main.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )

--- a/github-actions/google-internal-tests/action.yml
+++ b/github-actions/google-internal-tests/action.yml
@@ -18,5 +18,5 @@ inputs:
       URL to post into the GitHub commit status when Google Internal
       tests need to be run. This is useful for helping other Googlers.
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'

--- a/github-actions/labeling/issue/BUILD.bazel
+++ b/github-actions/labeling/issue/BUILD.bazel
@@ -60,5 +60,5 @@ esbuild_checked_in(
     entry_point = "lib/main.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )

--- a/github-actions/labeling/issue/action.yml
+++ b/github-actions/labeling/issue/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: 'The API key for Google Generative AI'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'

--- a/github-actions/labeling/pull-request/BUILD.bazel
+++ b/github-actions/labeling/pull-request/BUILD.bazel
@@ -52,7 +52,7 @@ esbuild_checked_in(
     entry_point = "lib/main.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )
 
 jasmine_test(

--- a/github-actions/labeling/pull-request/action.yml
+++ b/github-actions/labeling/pull-request/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: 'A map of labels to the paths that they should be applied to which are affected by the PR'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'

--- a/github-actions/org-file-sync/BUILD.bazel
+++ b/github-actions/org-file-sync/BUILD.bazel
@@ -27,5 +27,5 @@ esbuild_checked_in(
     entry_point = "lib/main.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )

--- a/github-actions/org-file-sync/action.yml
+++ b/github-actions/org-file-sync/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'

--- a/github-actions/post-approval-changes/BUILD.bazel
+++ b/github-actions/post-approval-changes/BUILD.bazel
@@ -27,5 +27,5 @@ esbuild_checked_in(
     entry_point = "lib/main.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )

--- a/github-actions/post-approval-changes/action.yml
+++ b/github-actions/post-approval-changes/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'The private key for the Angular Robot Github app.'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'

--- a/github-actions/previews/pack-and-upload-artifact/BUILD.bazel
+++ b/github-actions/previews/pack-and-upload-artifact/BUILD.bazel
@@ -23,5 +23,5 @@ esbuild_checked_in(
     entry_point = "lib/inject-artifact-metadata.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )

--- a/github-actions/previews/upload-artifacts-to-firebase/BUILD.bazel
+++ b/github-actions/previews/upload-artifacts-to-firebase/BUILD.bazel
@@ -32,7 +32,7 @@ esbuild_checked_in(
     entry_point = "lib/fetch-workflow-artifact.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )
 
 esbuild_checked_in(
@@ -43,5 +43,5 @@ esbuild_checked_in(
     entry_point = "lib/extract-artifact-metadata.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )

--- a/github-actions/unified-status-check/BUILD.bazel
+++ b/github-actions/unified-status-check/BUILD.bazel
@@ -30,5 +30,5 @@ esbuild_checked_in(
     entry_point = "lib/main.ts",
     format = "esm",
     platform = "node",
-    target = "node22",
+    target = "node24",
 )

--- a/github-actions/unified-status-check/action.yml
+++ b/github-actions/unified-status-check/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: false
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'


### PR DESCRIPTION
This PR updates all GitHub Actions defined in this repo that use Node for their runner to use Node 24.