### PR TITLE
chore: update renovate workflow schedule to run at 17 and 47 minutes past the hour

### DIFF
--- a/.github/workflows/ng-renovate.yml
+++ b/.github/workflows/ng-renovate.yml
@@ -3,8 +3,8 @@ name: Angular-Org Renovate
 on:
   workflow_dispatch:
   schedule:
-    # Runs every 30 minutes.
-    - cron: '*/30 * * * *'
+    # Run on the 17th and 47th minute of every hour.
+    - cron: '17,47 * * * *'
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION


Run cronjob at 17 and 47 minutes past the hour, which are much quieter than the top/bottom of the hour.