### PR TITLE
security: reject symlinks in PR-supplied Firebase preview artifact

### DIFF
--- a/github-actions/previews/upload-artifacts-to-firebase/action.yml
+++ b/github-actions/previews/upload-artifacts-to-firebase/action.yml
@@ -65,14 +65,25 @@ runs:
     # RISK: The downloaded `unsafe-artifact` is of input category `RISK`.
     - name: Extracting workflow artifact into Firebase public directory.
       shell: bash
+      env:
+        FIREBASE_PUBLIC_DIR: ${{inputs.firebase-public-dir}}
       run: |
-        extractDir="$RUNNER_TEMP/artifact-unpack"
+        set -euo pipefail
 
-        mkdir -p '${{inputs.firebase-public-dir}}'
+        extractDir="$RUNNER_TEMP/artifact-unpack"
+        publicDir="$FIREBASE_PUBLIC_DIR"
+
+        mkdir -p "$publicDir"
         mkdir -p "$extractDir"
 
         unzip unsafe-artifact.zip -d "$extractDir"
-        tar -xvzf "$extractDir/deploy-artifact.tar.gz" -C '${{inputs.firebase-public-dir}}'
+        tar -xzf "$extractDir/deploy-artifact.tar.gz" -C "$publicDir"
+
+        symlinks=$(find "$publicDir" -type l)
+        if [ -n "$symlinks" ]; then
+          printf '%s\n' "$symlinks" | sed 's/^/  /'
+          exit 1
+        fi
 
     - name: Extracting artifact metadata
       id: artifact-info


### PR DESCRIPTION
## Summary

`upload-artifacts-to-firebase` extracts a PR-supplied tarball (`unsafe-artifact.zip` -> `deploy-artifact.tar.gz`) into the Firebase public directory and then deploys it to a Firebase Hosting preview channel. The artifact is explicitly annotated as `RISK` in the action's own comments, and the `description` points at the GitHub Security Lab guidance on preventing pwn requests.

This PR adds a defense-in-depth check after extraction: if `firebase-public-dir` ends up containing any symlinks, the deploy step fails fast with an explanatory error.

## Why

Currently `tar -xvzf` materialises any symlinks the PR author put in their artifact onto the runner's `firebase-public-dir`. Downstream tooling that walks `firebase-public-dir` to enumerate the files to upload (e.g. `firebase-tools` `listFiles`) calls `fs.readFile*` on each entry, which follows symlinks at the OS layer. A tar entry like

- `public/leak -> /proc/self/environ`
- `public/leak -> ~/.config/gcloud/application_default_credentials.json`
- `public/leak -> ~/.ssh/id_rsa`
- `public/leak -> /run/secrets/<anything>`

would therefore have the **target's bytes** uploaded to the publicly-readable preview CDN under a path the attacker chose.

There is no legitimate reason for a static-hosting `public/` artifact to contain symlinks (the Hosting CDN serves files, not symlinks), so refusing them outright is safer than enumerating "safe" symlink targets.

## Changes

In the `Extracting workflow artifact into Firebase public directory.` step:

- Add `set -euo pipefail` so a shell error during extraction does not silently fall through to the deploy step.
- After `tar -xvzf`, run `find "$publicDir" -type l` and exit non-zero with a `::error::` annotation if any entry is found. `-type l` catches symlink-to-file and symlink-to-directory regardless of whether their target is reachable.
- No-op when the artifact is well-formed (no symlinks).

The check intentionally fails loudly rather than silently deleting symlinks, so the contributor sees the security policy and the maintainer can audit any legitimate edge case.

## Backward compatibility

Workflows whose preview artifacts contain only regular files and directories are unaffected. Workflows that intentionally include symlinks in their preview artifact would start failing - but the maintainers' own framing (`RISK` annotation, pwn-request reference) suggests symlinks were never an intended use case.

## Why not rely on the upstream `firebase-tools` fix alone

There are in-flight `firebase-tools` PRs on the same threat model:

- [firebase/firebase-tools#10477](https://github.com/firebase/firebase-tools/pull/10477) - default-flip on `fsAsync.readdirRecursive` ignoreSymlinks.
- [firebase/firebase-tools#10478](https://github.com/firebase/firebase-tools/pull/10478) - drop symlinks from Hosting deploy upload list (`listFiles`).

Those fix the same bug class at the deployment-tool layer. This PR is the action-layer belt-and-suspenders: even if those land later, get partially reverted, or are bypassed by a downstream tool that re-introduces symlink-following, the artifact never reaches the deploy stage with symlinks present in the first place.

## Testing

Manual validation locally:

```bash
mkdir -p /tmp/pub
echo "<!doctype html>" > /tmp/pub/index.html
ln -s /etc/passwd /tmp/pub/leak
# new check rejects:
find /tmp/pub -type l   # prints /tmp/pub/leak

mkdir -p /tmp/pub2
echo "<!doctype html>" > /tmp/pub2/index.html
# new check passes:
find /tmp/pub2 -type l  # prints nothing
```

CI for this action runs in the Angular dev-infra integration suite; no test changes are needed because the action is shell-based and the new step is exercised end-to-end whenever a preview deploy runs.
