### PR TITLE
fix(ng-dev/release): make package deprecation errors non-fatal

### DIFF
--- a/ng-dev/release/versioning/npm-command.ts
+++ b/ng-dev/release/versioning/npm-command.ts
@@ -11,6 +11,7 @@ import semver from 'semver';
 import {ChildProcess} from '../../utils/child-process.js';
 
 import {NpmDistTag} from './npm-registry.js';
+import {Log} from '../../utils/logging.js';
 
 export abstract class NpmCommand {
   /**
@@ -47,7 +48,13 @@ export abstract class NpmCommand {
       args.push('--registry', registryUrl);
     }
 
-    await ChildProcess.spawn('npm', args, {mode: 'silent'});
+    try {
+      await ChildProcess.spawn('npm', args, {mode: 'silent'});
+    } catch (e) {
+      // TODO(alanagius): remove try/catch block once https://buganizer.corp.google.com/u/1/issues/512428441 is fixed.
+      Log.error(e);
+      Log.error(`  ✘   An error occurred while deprecating "${packageName}".`);
+    }
   }
 
   /**

--- a/ng-dev/release/versioning/npm-command.ts
+++ b/ng-dev/release/versioning/npm-command.ts
@@ -52,8 +52,10 @@ export abstract class NpmCommand {
       await ChildProcess.spawn('npm', args, {mode: 'silent'});
     } catch (e) {
       // TODO(alanagius): remove try/catch block once https://buganizer.corp.google.com/u/1/issues/512428441 is fixed.
-      Log.error(e);
+      Log.error(Array(80).join('#'));
       Log.error(`  ✘   An error occurred while deprecating "${packageName}".`);
+      Log.error(e);
+      Log.error(Array(80).join('#'));
     }
   }
 


### PR DESCRIPTION
Catches and logs errors that occur during `npm deprecate` rather than allowing them to bubble up and cause the release process to fail. This serves as a temporary workaround for issues where package deprecation requests might fail unexpectedly.