### PR TITLE
fix(ng-dev/release): silence nvm which command output during release verification

### DIFF
--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -212,7 +212,7 @@ export abstract class ExternalCommands {
       // but a shell function. The dot (.) built-in and && operator require shell: true here.
       // We redirect stdout of nvm install to stderr so that stdout only contains the result of nvm which.
       const {stdout} = await ChildProcess.spawn(
-        '. ~/.nvm/nvm.sh && nvm install >&2 && nvm which',
+        '. ~/.nvm/nvm.sh && nvm install >&2 && nvm which --silent',
         [],
         {
           cwd: projectDir,


### PR DESCRIPTION
Suppresses unwanted output to stdout during nvm node path resolution by passing the --silent flag to nvm which.