### PR TITLE
build: add explanation comment to confirmModulesPurge setting

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,10 @@ packageExtensions:
 engineStrict: false
 hoist: false
 autoInstallPeers: false
+
+# Avoid prompting for confirmation when pnpm determines node_modules needs to be purged and recreated.
+confirmModulesPurge: false
+
 allowBuilds:
   '@apollo/protobufjs': false
   '@firebase/util': false


### PR DESCRIPTION
Add to the `confirmModulesPurge: false` setting in `pnpm-workspace.yaml`.