### PR TITLE
fix(github-actions): update issue labeler Gemini model to gemini-3.1-flash-lite

### DIFF
--- a/github-actions/labeling/issue/lib/issue-labeling.ts
+++ b/github-actions/labeling/issue/lib/issue-labeling.ts
@@ -94,7 +94,7 @@ If no area label applies, respond with "none".
 
     try {
       const response = await ai.models.generateContent({
-        model: 'gemini-3.1-flash-lite-preview',
+        model: 'gemini-3.1-flash-lite',
         contents: prompt,
       });
       const text = (response.text || '').trim();


### PR DESCRIPTION
Updates the issue labeling action to use the stable `gemini-3.1-flash-lite` model as the preview version has been retired.