### PR TITLE
feat(bazel): validate that checked-in bundles are ignored in prettierignore

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@ ts_config(
 
 exports_files([
     "package.json",
+    ".prettierignore",
 ])
 
 validate_ts_version_matching(

--- a/bazel/validation/BUILD.bazel
+++ b/bazel/validation/BUILD.bazel
@@ -9,3 +9,13 @@ copy_to_bin(
         "//visibility:public",
     ],
 )
+
+copy_to_bin(
+    name = "verify-prettierignore",
+    srcs = [
+        "verify-prettierignore.mjs",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/bazel/validation/defs.bzl
+++ b/bazel/validation/defs.bzl
@@ -13,3 +13,20 @@ def validate_ts_version_matching(package_json, module_lock_file):
             "$(rlocationpath %s)" % module_lock_file,
         ],
     )
+
+def validate_prettierignore(name, prettierignore, bundle):
+    js_test(
+        name = name,
+        data = [
+            prettierignore,
+            bundle,
+        ],
+        entry_point = "@devinfra//bazel/validation:verify-prettierignore",
+        no_copy_to_bin = [
+            prettierignore,
+        ],
+        fixed_args = [
+            "$(rlocationpath %s)" % prettierignore,
+            "$(rlocationpath %s)" % bundle,
+        ],
+    )

--- a/bazel/validation/verify-prettierignore.mjs
+++ b/bazel/validation/verify-prettierignore.mjs
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {readFile} from 'node:fs/promises';
+import {join} from 'node:path';
+import assert from 'node:assert';
+
+/** The runfiles directory for the script. */
+const runfiles = process.env['JS_BINARY__RUNFILES'];
+assert(runfiles, 'Expected `JS_BINARY__RUNFILES` to be set.');
+
+async function main([prettierIgnorePath, bundlePath]) {
+  const prettierIgnoreContent = await readFile(join(runfiles, prettierIgnorePath), 'utf8');
+  const ignoredFiles = new Set(
+    prettierIgnoreContent
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#')),
+  );
+
+  // The bundlePath is relative to the runfiles, e.g., "devinfra/.github/local-actions/update-models/main.js"
+  // We need to clean it up to match the relative workspace path.
+  // Aspect JS rules prefix the path with the workspace name segment (e.g. "_main" or "devinfra").
+  // Removing the first segment gets the workspace-relative path.
+  const relativePath = bundlePath.replace(/^[^/]+\//, '');
+
+  if (!ignoredFiles.has(relativePath)) {
+    console.error(
+      `Error: The checked-in bundle "${relativePath}" is not ignored in .prettierignore.`,
+    );
+    console.error(
+      `Please add "${relativePath}" to .prettierignore to prevent formatting check-in mismatches.`,
+    );
+    process.exitCode = 1;
+  } else {
+    console.info(`Validation passed: "${relativePath}" is correctly ignored in .prettierignore.`);
+  }
+}
+
+main(process.argv.slice(2)).catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -11,6 +11,7 @@ load("@rules_sass//src:index.bzl", _npm_sass_library = "npm_sass_library", _sass
 load("//bazel:extract_types.bzl", _extract_types = "extract_types")
 load("//bazel/jasmine:jasmine.bzl", _jasmine_test = "jasmine_test")
 load("//bazel/ts_project:index.bzl", _strict_deps_test = "strict_deps_test")
+load("//bazel/validation:defs.bzl", "validate_prettierignore")
 
 copy_to_bin = _copy_to_bin
 ts_config = _ts_config
@@ -167,4 +168,10 @@ def esbuild_checked_in(name, platform = None, config = {}, **kwargs):
         name = name,
         out_file = "%s.js" % name,
         in_file = ":%s_sanitized" % name,
+    )
+
+    validate_prettierignore(
+        name = "%s_prettierignore_test" % name,
+        prettierignore = "//:.prettierignore",
+        bundle = "%s.js" % name,
     )


### PR DESCRIPTION
Adds a Bazel js_test validation check to the esbuild_checked_in macro that asserts that the checked-in bundle is ignored in .prettierignore, preventing format check-in mismatches.