### PR TITLE
fix(ng-dev): call correct subcommand for setting npm tags

### DIFF
--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -61,7 +61,8 @@ export abstract class ExternalCommands {
         [
           'ng-dev',
           'release',
-          'set-dist-tag',
+          'npm-dist-tag',
+          'set',
           npmDistTag,
           version.format(),
           `--skip-experimental-packages=${options.skipExperimentalPackages}`,


### PR DESCRIPTION
After renaming the npm tagging sub command we failed to update the location where the script is called by the main release process