### PR TITLE
fix(ng-dev): prevent arbitrary code execution via PullApprove VM sandbox escape

### DIFF
--- a/ng-dev/pullapprove/BUILD.bazel
+++ b/ng-dev/pullapprove/BUILD.bazel
@@ -18,6 +18,7 @@ ts_project(
         "//ng-dev:node_modules/@types/node",
         "//ng-dev:node_modules/@types/yargs",
         "//ng-dev:node_modules/minimatch",
+        "//ng-dev:node_modules/typescript",
         "//ng-dev:node_modules/yaml",
         "//ng-dev:node_modules/yargs",
         "//ng-dev/utils",

--- a/ng-dev/pullapprove/condition_evaluator.ts
+++ b/ng-dev/pullapprove/condition_evaluator.ts
@@ -11,7 +11,7 @@ import {PullApproveGroupArray, PullApproveStringArray} from './pullapprove_array
 import {PullApproveAuthorStateDependencyError} from './condition_errors.js';
 import {PullApproveGroup} from './group.js';
 import {getOrCreateGlob} from './utils.js';
-import {runInNewContext} from 'vm';
+import ts from 'typescript';
 
 /**
  * Context object that will be used as global context in condition evaluation.
@@ -49,18 +49,22 @@ const conditionEvaluationContext: object = (() => {
 export function convertConditionToFunction(
   expr: string,
 ): (files: string[], groups: PullApproveGroup[]) => boolean {
-  const jsExpression = `
-    (files, groups) => {
-      return (${transformExpressionToJs(expr)});
-    }
-  `;
-  const isMatchingFn = runInNewContext(jsExpression, conditionEvaluationContext);
+  const jsExpressionStr = transformExpressionToJs(expr);
+
+  const sourceFile = ts.createSourceFile(
+    'expr.ts',
+    jsExpressionStr,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
 
   return (files, groups) => {
-    const result = isMatchingFn(
-      new PullApproveStringArray(...files),
-      new PullApproveGroupArray(...groups),
-    );
+    const evaluationContext = Object.create(conditionEvaluationContext);
+    evaluationContext['files'] = new PullApproveStringArray(...files);
+    evaluationContext['groups'] = new PullApproveGroupArray(...groups);
+
+    const result = evaluateNode(sourceFile, evaluationContext);
 
     // If an array is returned, we consider the condition as active if the array is not
     // empty. This matches PullApprove's condition evaluation that is based on Python.
@@ -68,6 +72,176 @@ export function convertConditionToFunction(
       return result.length !== 0;
     }
     return !!result;
+  };
+}
+
+function evaluateNode(node: ts.Node, context: any): any {
+  if (ts.isSourceFile(node)) {
+    if (node.statements.length !== 1) {
+      throw new Error('Invalid expression: multiple statements not allowed');
+    }
+    const stmt = node.statements[0];
+    if (!ts.isExpressionStatement(stmt)) {
+      throw new Error('Invalid expression: must be an expression');
+    }
+    return evaluateNode(stmt.expression, context);
+  }
+
+  if (ts.isExpressionStatement(node)) {
+    return evaluateNode(node.expression, context);
+  }
+
+  if (ts.isParenthesizedExpression(node)) {
+    return evaluateNode(node.expression, context);
+  }
+
+  if (ts.isPrefixUnaryExpression(node)) {
+    if (node.operator === ts.SyntaxKind.ExclamationToken) {
+      return !evaluateNode(node.operand, context);
+    }
+    throw new Error(`Unsupported prefix operator: ${node.operator}`);
+  }
+
+  if (ts.isBinaryExpression(node)) {
+    const left = evaluateNode(node.left, context);
+
+    if (node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken) {
+      return left && evaluateNode(node.right, context);
+    }
+    if (node.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
+      return left || evaluateNode(node.right, context);
+    }
+
+    const right = evaluateNode(node.right, context);
+    switch (node.operatorToken.kind) {
+      case ts.SyntaxKind.EqualsEqualsToken:
+      case ts.SyntaxKind.EqualsEqualsEqualsToken:
+        return left === right;
+      case ts.SyntaxKind.ExclamationEqualsToken:
+      case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+        return left !== right;
+      case ts.SyntaxKind.GreaterThanToken:
+        return left > right;
+      case ts.SyntaxKind.GreaterThanEqualsToken:
+        return left >= right;
+      case ts.SyntaxKind.LessThanToken:
+        return left < right;
+      case ts.SyntaxKind.LessThanEqualsToken:
+        return left <= right;
+      default:
+        throw new Error(`Unsupported binary operator: ${node.operatorToken.kind}`);
+    }
+  }
+
+  if (ts.isIdentifier(node)) {
+    const name = node.text;
+    if (name in context) {
+      return context[name];
+    }
+    throw new Error(`Undefined variable or function: ${name}`);
+  }
+
+  if (ts.isPropertyAccessExpression(node)) {
+    const obj = evaluateNode(node.expression, context);
+    const prop = node.name.text;
+
+    if (obj && (typeof obj === 'object' || typeof obj === 'string')) {
+      if (Array.isArray(obj)) {
+        if (prop === 'length') {
+          return obj.length;
+        }
+        if (prop === 'includes') {
+          return obj.includes.bind(obj);
+        }
+        if (prop === 'some') {
+          return obj.some.bind(obj);
+        }
+        if (prop === 'filter') {
+          return obj.filter.bind(obj);
+        }
+        if (prop === 'include' && typeof (obj as any).include === 'function') {
+          return (obj as any).include.bind(obj);
+        }
+        if (prop === 'exclude' && typeof (obj as any).exclude === 'function') {
+          return (obj as any).exclude.bind(obj);
+        }
+        if (prop === 'names') {
+          return (obj as any).names;
+        }
+        if (prop === 'active') {
+          return (obj as any).active;
+        }
+        if (prop === 'approved') {
+          return (obj as any).approved;
+        }
+        if (prop === 'pending') {
+          return (obj as any).pending;
+        }
+        if (prop === 'inactive') {
+          return (obj as any).inactive;
+        }
+        if (prop === 'rejected') {
+          return (obj as any).rejected;
+        }
+      } else if (obj instanceof String || typeof obj === 'string') {
+        if (prop === 'matchesAny') {
+          return (obj as any).matchesAny;
+        }
+      } else if (obj instanceof PullApproveGroup) {
+        if (prop === 'groupName') {
+          return obj.groupName;
+        }
+        if (prop === 'precedingGroups') {
+          return obj.precedingGroups;
+        }
+      }
+    }
+    throw new Error(`Forbidden property access: ${prop}`);
+  }
+
+  if (ts.isCallExpression(node)) {
+    const fn = evaluateNode(node.expression, context);
+    if (typeof fn !== 'function') {
+      throw new Error(`Expression is not a function`);
+    }
+
+    const args: any[] = [];
+    for (const arg of node.arguments) {
+      if (ts.isArrowFunction(arg)) {
+        args.push(createCallback(arg, context));
+      } else {
+        args.push(evaluateNode(arg, context));
+      }
+    }
+
+    return fn(...args);
+  }
+
+  if (ts.isStringLiteral(node)) {
+    return node.text;
+  }
+
+  if (ts.isNumericLiteral(node)) {
+    return Number(node.text);
+  }
+
+  if (ts.isArrayLiteralExpression(node)) {
+    return node.elements.map((el) => evaluateNode(el, context));
+  }
+
+  throw new Error(`Unsupported expression node type: ${ts.SyntaxKind[node.kind]}`);
+}
+function createCallback(arrowFn: ts.ArrowFunction, context: any): Function {
+  if (arrowFn.parameters.length !== 1) {
+    throw new Error('Only arrow functions with exactly 1 parameter are supported');
+  }
+  const paramName = (arrowFn.parameters[0].name as ts.Identifier).text;
+
+  return (val: any) => {
+    const childContext = Object.create(context);
+    childContext[paramName] = val;
+
+    return evaluateNode(arrowFn.body, childContext);
   };
 }
 

--- a/ng-dev/pullapprove/verify.spec.ts
+++ b/ng-dev/pullapprove/verify.spec.ts
@@ -133,6 +133,26 @@ describe('group parsing', () => {
       expect(passGroup.testFile('any')).toBe(true);
     });
   });
+
+  describe('security sandbox', () => {
+    it('should not allow escaping the sandbox to access process', () => {
+      const groups = getGroupsFromYaml(`
+        groups:
+          exploit:
+            conditions:
+              - "this.constructor.constructor('return process')().env.JE_ESCAPED = 'true'"
+      `);
+      const exploitGroup = getGroupByName(groups, 'exploit')!;
+      delete process.env['JE_ESCAPED'];
+
+      const exitSpy = spyOn(process, 'exit');
+
+      exploitGroup.testFile('any');
+
+      expect(process.env['JE_ESCAPED']).toBeUndefined();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
 });
 
 function getGroupByName(groups: PullApproveGroup[], name: string): PullApproveGroup | undefined {


### PR DESCRIPTION
This PR fixes a Remote Code Execution (RCE) vulnerability in the PullApprove condition evaluator.
The previous implementation evaluated python expressions by translating them to JS and running them via Node's `vm.runInNewContext`. Because the `vm` module is not a secure sandbox, an attacker could traverse the prototype chain (e.g. using `this.constructor.constructor`) to access the host's `process` object and execute arbitrary shell commands.

This fix replaces `vm.runInNewContext` with a custom AST-based parser and evaluator (using `typescript` compiler API). The evaluator only processes a safe, whitelisted set of nodes and property accesses, preventing prototype traversal and arbitrary code execution entirely.