### PR TITLE
fix(ng-dev): prevent path traversal via package.json version string

### DIFF
--- a/ng-dev/misc/BUILD.bazel
+++ b/ng-dev/misc/BUILD.bazel
@@ -6,7 +6,9 @@ ts_project(
     visibility = ["//ng-dev:__subpackages__"],
     deps = [
         "//ng-dev:node_modules/@types/node",
+        "//ng-dev:node_modules/@types/semver",
         "//ng-dev:node_modules/@types/yargs",
+        "//ng-dev:node_modules/semver",
         "//ng-dev/format",
         "//ng-dev/release/build",
         "//ng-dev/release/config",

--- a/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
+++ b/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
@@ -7,6 +7,7 @@
  */
 
 import {Log} from '../../utils/logging';
+import semver from 'semver';
 
 export interface PackageJson {
   engines?: {
@@ -158,6 +159,9 @@ async function processNodeToolchainArgs(
 
 /** Synchronizes the PNPM version and integrity in MODULE.bazel. */
 export async function syncPnpm(content: string, version: string): Promise<string> {
+  if (!semver.valid(version)) {
+    throw new Error(`Invalid PNPM version: ${version}`);
+  }
   if (!PNPM_VERSION_REGEXP.test(content)) {
     return content;
   }
@@ -178,6 +182,9 @@ export async function syncPnpm(content: string, version: string): Promise<string
 
 /** Synchronizes the TypeScript version and integrity in MODULE.bazel. */
 export async function syncTypeScript(content: string, version: string): Promise<string> {
+  if (!semver.valid(version)) {
+    throw new Error(`Invalid TypeScript version: ${version}`);
+  }
   if (!TS_VERSION_REGEXP.test(content)) {
     return content;
   }


### PR DESCRIPTION
This PR fixes a critical path traversal vulnerability in sync-module-bazel by validating the version string against semver.