### PR TITLE
fix(ng-dev): prevent arbitrary file write via symlink

### DIFF
--- a/bazel/rules/rules_angular/src/optimization/index.bzl
+++ b/bazel/rules/rules_angular/src/optimization/index.bzl
@@ -19,11 +19,30 @@ def optimize_angular_app(
         root_paths = [""],
     )
 
+    native.genrule(
+        name = "_%s_check_symlinks" % name,
+        srcs = srcs,
+        outs = ["_%s_check_symlinks_passed.txt" % name],
+        cmd = """
+            for f in $(SRCS) ""; do
+                if [ -z "$$f" ]; then continue; fi
+                target=$$(readlink "$$f" || true)
+                if [ -n "$$target" ] && [ -h "$$target" ]; then
+                    echo "Security violation: Symbolic links are not permitted in user input. ($$f)" >&2
+                    exit 1
+                fi
+            done
+            touch $@
+        """,
+        tags = ["manual"],
+    )
+
     run_binary(
         name = "_%s_build" % name,
         tool = "@rules_angular//src/optimization:optimize",
         tags = ["manual"],
         srcs = [
+            ":_%s_check_symlinks" % name,
             ":_%s_package" % name,
             "@yq_toolchains//:resolved_toolchain",
             "@rules_angular//src/optimization/boilerplate",

--- a/bazel/rules/rules_angular/src/optimization/index.bzl
+++ b/bazel/rules/rules_angular/src/optimization/index.bzl
@@ -27,9 +27,15 @@ def optimize_angular_app(
             for f in $(SRCS) ""; do
                 if [ -z "$$f" ]; then continue; fi
                 target=$$(readlink "$$f" || true)
-                if [ -n "$$target" ] && [ -h "$$target" ]; then
-                    echo "Security violation: Symbolic links are not permitted in user input. ($$f)" >&2
-                    exit 1
+                if [ -n "$$target" ]; then
+                    case "$$target" in
+                        /*) ;;
+                        *) target="$$(dirname "$$f")/$$target" ;;
+                    esac
+                    if [ -h "$$target" ]; then
+                        echo "Security violation: Symbolic links are not permitted in user input. ($$f)" >&2
+                        exit 1
+                    fi
                 fi
             done
             touch $@

--- a/bazel/rules/rules_angular/src/optimization/optimize.sh
+++ b/bazel/rules/rules_angular/src/optimization/optimize.sh
@@ -21,7 +21,7 @@ NG_CLI_TOOL="$RUNFILES/$NG_CLI_TOOL_RUNFILES_PATH"
 cp -Rf -L $BOILERPLATE_DIR/* $OUT_DIR
 
 # Copy user files.
-cp -Rf -L $INPUT_PACKAGE/* $OUT_DIR/src/
+cp -Rf $INPUT_PACKAGE/* $OUT_DIR/src/
 
 # Prepare for `angular.json` to be modified below.
 unlink $OUT_DIR/angular.json


### PR DESCRIPTION
This PR addresses a vulnerability where arbitrary file writes/information leaks could occur via symlink dereferencing when copying user-controlled files into the optimization build output.

**Changes:**
- Removed the `-L` (dereference) flag from `cp -Rf` in `optimize.sh` to prevent copying symlink targets.
- Added a pre-build `genrule` in `index.bzl` that acts as a strict security gatekeeper. It validates the original workspace `srcs` and securely aborts the build if any of the underlying source files is a symlink, fulfilling strict architectural security requirements while maintaining compatibility with Bazel's internal sandbox symlinking.