### PR TITLE
fix(ng-dev): prevent shell command injection in git push command

### DIFF
--- a/ng-dev/pr/common/checkout-pr.ts
+++ b/ng-dev/pr/common/checkout-pr.ts
@@ -99,6 +99,8 @@ export async function checkOutPullRequestLocally(
   // https://git-scm.com/docs/git-push#Documentation/git-push.txt---force-with-leaseltrefnamegtltexpectgt
   /** Flag for a force push with lease back to upstream. */
   const forceWithLeaseFlag = `--force-with-lease=${headRefName}:${pr.headRefOid}`;
+  const escapedHeadRefName = `'${headRefName.replace(/'/g, "'\\''")}'`;
+  const escapedForceWithLeaseFlag = `--force-with-lease=${escapedHeadRefName}:${pr.headRefOid}`;
 
   // If the PR does not allow maintainers to modify it, exit as the rebased PR cannot
   // be pushed up.
@@ -130,7 +132,7 @@ export async function checkOutPullRequestLocally(
     resetGitState: (): boolean => {
       return git.checkout(previousBranchOrRevision, true);
     },
-    pushToUpstreamCommand: `git push ${upstreamUrlToPush(pr.headRef.repository.url)} HEAD:${headRefName} ${forceWithLeaseFlag}`,
+    pushToUpstreamCommand: `git push ${upstreamUrlToPush(pr.headRef.repository.url)} HEAD:${escapedHeadRefName} ${escapedForceWithLeaseFlag}`,
     resetGitStateCommand: `git rebase --abort && git reset --hard && git checkout ${previousBranchOrRevision}`,
     pullRequest: pr,
   };

--- a/ng-dev/pr/rebase/index.ts
+++ b/ng-dev/pr/rebase/index.ts
@@ -55,6 +55,8 @@ export async function rebasePr(prNumber: number, interactive: boolean = false): 
   // See:
   // https://git-scm.com/docs/git-push#Documentation/git-push.txt---force-with-leaseltrefnamegtltexpectgt
   const forceWithLeaseFlag = `--force-with-lease=${headRefName}:${pr.headRefOid}`;
+  const escapedHeadRefName = `'${headRefName.replace(/'/g, "'\\''")}'`;
+  const escapedForceWithLeaseFlag = `--force-with-lease=${escapedHeadRefName}:${pr.headRefOid}`;
 
   // If the PR does not allow maintainers to modify it, exit as the rebased PR cannot
   // be pushed up.
@@ -143,7 +145,9 @@ export async function rebasePr(prNumber: number, interactive: boolean = false): 
     Log.info(
       `After manually completing rebase, run the following command to update PR #${prNumber}:`,
     );
-    Log.info(` $ git push ${pr.headRef.repository.url} HEAD:${headRefName} ${forceWithLeaseFlag}`);
+    Log.info(
+      ` $ git push ${pr.headRef.repository.url} HEAD:${escapedHeadRefName} ${escapedForceWithLeaseFlag}`,
+    );
     Log.info();
     Log.info(`To abort the rebase and return to the state of the repository before this command`);
     Log.info(`run the following command:`);


### PR DESCRIPTION
This PR mitigates a command injection vulnerability where a malicious PR branch name could lead to arbitrary shell command execution when copy-pasting the printed ng-dev checkout or rebase commands.