### PR TITLE
fix(ng-dev): prevent arbitrary code execution via option injection

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -49,7 +49,7 @@
       matchDepNames: ['pnpm', 'typescript', 'node'],
       postUpgradeTasks: {
         commands: [
-          'pnpm install --frozen-lockfile',
+          'pnpm install --frozen-lockfile --ignore-scripts',
           'bash -c "pnpm ng-dev misc sync-module-bazel || true"', // If `ng-dev` doesn't exist, avoid a hard error.
         ],
         executionMode: 'branch',

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     {
       "postUpgradeTasks": {
         "commands": [
-          "pnpm install --frozen-lockfile",
+          "pnpm install --frozen-lockfile --ignore-scripts",
           "bash ./tools/sync-all-modules.sh",
           "pnpm update-generated-files"
         ],
@@ -22,7 +22,7 @@
     {
       "postUpgradeTasks": {
         "commands": [
-          "pnpm install --frozen-lockfile",
+          "pnpm install --frozen-lockfile --ignore-scripts",
           "bash ./tools/sync-all-modules.sh",
           "pnpm update-generated-files"
         ],


### PR DESCRIPTION
Adding `--ignore-scripts` to `pnpm install` commands in Renovate configurations to prevent arbitrary code execution from malicious lifecycle scripts during automated dependency updates.