### PR TITLE
fix(apps): prevent reflected XSS via un-encoded response

### DIFF
--- a/apps/functions/dns-redirecting/index.ts
+++ b/apps/functions/dns-redirecting/index.ts
@@ -64,6 +64,7 @@ export const dnsRedirecting = functions.https.onRequest(
     } else {
       // If no redirect is matched, we return a failure message
       response.status(404);
+      response.type('text/plain');
       response.send(
         `No redirect defined for ${request.protocol}://${request.hostname}${request.originalUrl}`,
       );


### PR DESCRIPTION
Fixes a reflected XSS vulnerability in the dns-redirecting cloud function by properly setting the Content-Type to text/plain before returning a 404 response.

Validated via testing and manual PoC verification.