### PR TITLE
fix(ng-dev): validate nvmrc-sourced Node.js version before fetch

### DIFF
--- a/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
+++ b/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
@@ -139,9 +139,11 @@ async function processNodeToolchainArgs(
     return args;
   }
 
-  if (!semver.valid(effectiveVersion)) {
-    throw new Error(`Invalid Node.js version: ${effectiveVersion}`);
+  const validatedVersion = semver.valid(effectiveVersion);
+  if (!validatedVersion) {
+    throw new Error('Invalid Node.js version: ' + effectiveVersion);
   }
+  effectiveVersion = validatedVersion;
 
   Log.info(`Resolving Node.js repositories for v${effectiveVersion}...`);
   const repositories = await getNodeJsRepositories(effectiveVersion);

--- a/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
+++ b/ng-dev/misc/sync-module-bazel/sync-module-bazel.ts
@@ -139,6 +139,10 @@ async function processNodeToolchainArgs(
     return args;
   }
 
+  if (!semver.valid(effectiveVersion)) {
+    throw new Error(`Invalid Node.js version: ${effectiveVersion}`);
+  }
+
   Log.info(`Resolving Node.js repositories for v${effectiveVersion}...`);
   const repositories = await getNodeJsRepositories(effectiveVersion);
   const lines = repositories.map(({filename, sha, type}) => {


### PR DESCRIPTION
## Summary

#75773923 added `semver.valid()` validation to the PNPM and TypeScript version strings before they are interpolated into registry fetch URLs (`syncPnpm`, `syncTypeScript`), but the Node.js version path was left unguarded.

In `processNodeToolchainArgs` (`ng-dev/misc/sync-module-bazel/sync-module-bazel.ts`), `effectiveVersion` can originate from the `.nvmrc` file (`node_version_from_nvmrc`) and is passed to `getNodeJsRepositories`, which interpolates it into:

```
fetch(`https://nodejs.org/dist/v${version}/SHASUMS256.txt`)
```

without the same validation, leaving the URL path open to manipulation via the version string.

## Fix

Apply the existing `semver.valid()` guard to `effectiveVersion` before it is used, consistent with the PNPM and TypeScript checks added in #75773923.