### PR TITLE
fix(apps): prevent open redirect via backslash manipulation in Host header

### DIFF
--- a/apps/functions/dns-redirecting/index.ts
+++ b/apps/functions/dns-redirecting/index.ts
@@ -1,5 +1,10 @@
 import * as functions from 'firebase-functions';
 
+const isValidDomain = (domain: string): boolean => {
+  // Only allow alphanumeric characters, dots, and hyphens
+  return /^[a-zA-Z0-9.-]+$/.test(domain);
+};
+
 export const dnsRedirecting = functions.https.onRequest(
   {
     cors: true,
@@ -28,6 +33,11 @@ export const dnsRedirecting = functions.https.onRequest(
         );
         return;
       }
+    }
+
+    if (!isValidDomain(hostname)) {
+      response.status(400).send('Invalid Hostname');
+      return;
     }
 
     if (hostname === 'code-of-conduct.angular.io') {


### PR DESCRIPTION
This PR fixes an Open Redirect vulnerability in the `dns-redirecting` Cloud Function. The fix implements strict hostname validation (`isValidDomain`) to ensure only alphanumeric characters, dots, and hyphens are allowed, securely preventing attackers from bypassing subdomain verification via backslashes.\n\nValidated that tests pass and the bypass via `evil.com\\.material.angular.io` is appropriately rejected with a 400 Bad Request.