### PR TITLE
fix(ng-dev/pr): prevent option injection in git fetch calls

### DIFF
--- a/ng-dev/pr/checkout/target.ts
+++ b/ng-dev/pr/checkout/target.ts
@@ -61,7 +61,7 @@ export async function checkoutToTargetBranch(
   const baseRefUrl = addTokenToGitHttpsUrl(pullRequest.baseRef.repository.url, git.githubToken);
 
   git.run(['checkout', '-q', targetBranch]);
-  git.run(['fetch', '-q', baseRefUrl, targetBranch, '--deepen=500']);
+  git.run(['fetch', '-q', baseRefUrl, '--deepen=500', '--', targetBranch]);
   git.run(['checkout', '-b', branchName]);
 
   Log.info(`Running cherry-pick`);

--- a/ng-dev/pr/common/checkout-pr.ts
+++ b/ng-dev/pr/common/checkout-pr.ts
@@ -108,7 +108,7 @@ export async function checkOutPullRequestLocally(
 
   try {
     // Fetch the branch at the commit of the PR, and check it out in a detached state.
-    git.run(['fetch', '-q', headRefUrl, headRefName]);
+    git.run(['fetch', '-q', headRefUrl, '--', headRefName]);
     git.run(['checkout', '--detach', 'FETCH_HEAD']);
   } catch (e) {
     git.checkout(previousBranchOrRevision, true);

--- a/ng-dev/pr/discover-new-conflicts/index.ts
+++ b/ng-dev/pr/discover-new-conflicts/index.ts
@@ -71,11 +71,11 @@ export async function discoverNewConflictsForPr(newPrNumber: number, updatedAfte
   Log.info(`Checking ${pendingPrs.length} PRs for conflicts after a merge of #${newPrNumber}`);
 
   // Fetch and checkout the PR being checked.
-  git.run(['fetch', '-q', requestedPr.headRef.repository.url, requestedPr.headRef.name]);
+  git.run(['fetch', '-q', requestedPr.headRef.repository.url, '--', requestedPr.headRef.name]);
   git.run(['checkout', '-q', '-B', tempWorkingBranch, 'FETCH_HEAD']);
 
   // Rebase the PR against the PRs target branch.
-  git.run(['fetch', '-q', requestedPr.baseRef.repository.url, requestedPr.baseRef.name]);
+  git.run(['fetch', '-q', requestedPr.baseRef.repository.url, '--', requestedPr.baseRef.name]);
   try {
     git.run(['rebase', 'FETCH_HEAD'], {stdio: 'ignore'});
   } catch (err) {
@@ -93,7 +93,7 @@ export async function discoverNewConflictsForPr(newPrNumber: number, updatedAfte
   // Check each PR to determine if it can merge cleanly into the repo after the target PR.
   for (const pr of pendingPrs) {
     // Fetch and checkout the next PR
-    git.run(['fetch', '-q', pr.headRef.repository.url, pr.headRef.name]);
+    git.run(['fetch', '-q', pr.headRef.repository.url, '--', pr.headRef.name]);
     git.run(['checkout', '-q', '--detach', 'FETCH_HEAD']);
     // Check if the PR cleanly rebases into the repo after the target PR.
     try {

--- a/ng-dev/pr/rebase/index.ts
+++ b/ng-dev/pr/rebase/index.ts
@@ -72,11 +72,11 @@ export async function rebasePr(prNumber: number, interactive: boolean = false): 
 
     // Fetch the branch at the commit of the PR, and check it out in a detached state.
     Log.info(`Checking out PR #${prNumber} from ${fullHeadRef}`);
-    git.run(['fetch', '-q', headRefUrl, headRefName, '--deepen=500']);
+    git.run(['fetch', '-q', headRefUrl, '--deepen=500', '--', headRefName]);
     git.run(['checkout', '-q', '--detach', 'FETCH_HEAD']);
     // Fetch the PRs target branch and rebase onto it.
     Log.info(`Fetching ${fullBaseRef} to rebase #${prNumber} on`);
-    git.run(['fetch', '-q', baseRefUrl, baseRefName, '--deepen=500']);
+    git.run(['fetch', '-q', baseRefUrl, '--deepen=500', '--', baseRefName]);
 
     const commonAncestorSha = git.run(['merge-base', 'HEAD', 'FETCH_HEAD']).stdout.trim();
 


### PR DESCRIPTION
This PR fixes a command/argument injection vulnerability in the `ng-dev` tools when fetching branches.
By adding the `--` separator to `git fetch` calls, we ensure that branch names (which are user-controlled input) are not interpreted as command-line options.

This addresses the vulnerability where a branch name starting with `-` (e.g., `--upload-pack`) could trigger arbitrary command execution.