### PR TITLE
fix(rules_browsers): prevent wildcard expansion in dmg conversion

### DIFF
--- a/bazel/rules/rules_browsers/browsers/private/convert_dmg_to_zip.sh
+++ b/bazel/rules/rules_browsers/browsers/private/convert_dmg_to_zip.sh
@@ -25,7 +25,7 @@ VOLUME=$(hdiutil attach "${DMGFILE}" | tail -1 | awk '{print $3}')
 cp -r "${VOLUME}/"*.app tmp
 hdiutil detach "${VOLUME}" >/dev/null
 cd tmp
-zip -r "../${OUTFILE}" *
+zip -r "../${OUTFILE}" -- *
 cd ..
 rm -rf tmp
 rm "${DMGFILE}"


### PR DESCRIPTION
This PR mitigates an option injection vulnerability in `convert_dmg_to_zip.sh`.
The script was previously expanding `*` directly in `zip -r "../${OUTFILE}" *` which allowed files starting with `-` to be interpreted as options by `zip`.
This is fixed by adding `--` before the wildcard to signal the end of options.