### PR TITLE
fix(ng-dev/utils): secure yarn bin resolution and update tests

### DIFF
--- a/ng-dev/utils/resolve-yarn-bin.ts
+++ b/ng-dev/utils/resolve-yarn-bin.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import which from 'which';
 
 import {isNodeJSWrappedError} from './nodejs-errors.js';
+import {Prompt} from './prompt.js';
 import lockfile from '@yarnpkg/lockfile';
 import {parse as parseYaml} from 'yaml';
 import {ChildProcess} from './child-process.js';
@@ -52,7 +53,33 @@ export async function resolveYarnScriptForProject(projectDir: string): Promise<Y
 
   const yarnPathFromConfig = await getYarnPathFromConfigurationIfPresent(projectDir);
   if (yarnPathFromConfig !== null) {
-    info = {binary: 'node', args: [yarnPathFromConfig]};
+    const relativePath = path.relative(projectDir, yarnPathFromConfig);
+    const isLocal = !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+
+    let isTrusted = true;
+    if (isLocal) {
+      if (process.env['NG_DEV_TRUST_YARN_PATH'] === '1') {
+        isTrusted = true;
+      } else if (process.stdout.isTTY && process.stdin.isTTY) {
+        isTrusted = await Prompt.confirm({
+          message:
+            `The project configures a local Yarn path: ${yarnPathFromConfig}.\n` +
+            `Do you trust this path and want to use it?`,
+          default: false,
+        });
+      } else {
+        isTrusted = false;
+      }
+    }
+
+    if (isTrusted) {
+      info = {binary: 'node', args: [yarnPathFromConfig]};
+    } else {
+      Log.warn(
+        `Ignoring local Yarn path: ${yarnPathFromConfig} as it is not trusted.\n` +
+          `You can trust it by running with NG_DEV_TRUST_YARN_PATH=1 environment variable.`,
+      );
+    }
   }
 
   if (!info) {

--- a/ng-dev/utils/test/resolve-yarn-bin.spec.ts
+++ b/ng-dev/utils/test/resolve-yarn-bin.spec.ts
@@ -12,27 +12,50 @@ import * as path from 'path';
 import {ChildProcess} from '../child-process.js';
 import {resolveYarnScriptForProject} from '../resolve-yarn-bin.js';
 import {cleanTestTmpDir, testTmpDir} from '../testing/index.js';
+import {Prompt} from '../prompt.js';
+import {Log} from '../logging.js';
 
 describe('resolve yarn bin', () => {
+  let spawnSpy: jasmine.Spy;
+  let originalTrustEnv: string | undefined;
+
   beforeEach(() => {
     cleanTestTmpDir();
-  });
-
-  it('should respect yarn 1.x configuration files', async () => {
-    fs.writeFileSync(path.join(testTmpDir, '.yarnrc'), `yarn-path "./a/b/c"`);
-
-    expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
-      binary: 'node',
-      args: [path.resolve(testTmpDir, 'a/b/c')],
+    originalTrustEnv = process.env['NG_DEV_TRUST_YARN_PATH'];
+    spawnSpy = spyOn(ChildProcess, 'spawn').and.callFake(async (cmd, args) => {
+      return {stdout: '', stderr: '', status: 1} as any;
     });
   });
 
-  it('should respect yarn 2.x+ configuration files', async () => {
-    fs.writeFileSync(path.join(testTmpDir, '.yarnrc.yml'), `yarnPath: a/b/c`);
+  afterEach(() => {
+    if (originalTrustEnv === undefined) {
+      delete process.env['NG_DEV_TRUST_YARN_PATH'];
+    } else {
+      process.env['NG_DEV_TRUST_YARN_PATH'] = originalTrustEnv;
+    }
+  });
 
-    expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
-      binary: 'node',
-      args: [path.resolve(testTmpDir, 'a/b/c')],
+  describe('with trusted local yarn path (via env)', () => {
+    beforeEach(() => {
+      process.env['NG_DEV_TRUST_YARN_PATH'] = '1';
+    });
+
+    it('should respect yarn 1.x configuration files', async () => {
+      fs.writeFileSync(path.join(testTmpDir, '.yarnrc'), `yarn-path "./a/b/c"`);
+
+      expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
+        binary: 'node',
+        args: [path.resolve(testTmpDir, 'a/b/c')],
+      });
+    });
+
+    it('should respect yarn 2.x+ configuration files', async () => {
+      fs.writeFileSync(path.join(testTmpDir, '.yarnrc.yml'), `yarnPath: a/b/c`);
+
+      expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
+        binary: 'node',
+        args: [path.resolve(testTmpDir, 'a/b/c')],
+      });
     });
   });
 
@@ -50,7 +73,12 @@ describe('resolve yarn bin', () => {
       fs.writeFileSync(path.join(fakeNpmBinDir, 'yarn.bat'), '', {mode: 0o777});
 
       // The `npm bin --global` command should return the fake global directory.
-      spyOn(ChildProcess, 'spawn').and.resolveTo({stdout: fakeNpmBinDir, stderr: '', status: 0});
+      spawnSpy.and.callFake(async (cmd, args) => {
+        if (cmd === 'npm' && args?.[0] === 'bin') {
+          return {stdout: fakeNpmBinDir, stderr: '', status: 0} as any;
+        }
+        return {stdout: '', stderr: '', status: 1} as any;
+      });
     });
 
     it('should check if no config is found', async () => {
@@ -68,6 +96,90 @@ describe('resolve yarn bin', () => {
         binary: jasmine.stringContaining(fakeNpmBinDir),
         args: [],
       });
+    });
+  });
+
+  describe('local yarn path trust validation', () => {
+    let confirmSpy: jasmine.Spy;
+    let warnSpy: jasmine.Spy;
+    let originalStdoutIsTTY: any;
+    let originalStdinIsTTY: any;
+
+    beforeEach(() => {
+      confirmSpy = spyOn(Prompt, 'confirm');
+      warnSpy = spyOn(Log, 'warn');
+      originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+      originalStdinIsTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+    });
+
+    afterEach(() => {
+      if (originalStdoutIsTTY) {
+        Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY);
+      } else {
+        delete (process.stdout as any).isTTY;
+      }
+      if (originalStdinIsTTY) {
+        Object.defineProperty(process.stdin, 'isTTY', originalStdinIsTTY);
+      } else {
+        delete (process.stdin as any).isTTY;
+      }
+    });
+
+    function setTTY(val: boolean) {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: val,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: val,
+        configurable: true,
+        writable: true,
+      });
+    }
+
+    it('should ignore local yarn path and warn if untrusted (non-TTY, no env)', async () => {
+      setTTY(false);
+      fs.writeFileSync(path.join(testTmpDir, '.yarnrc.yml'), `yarnPath: a/b/c`);
+
+      const res = await resolveYarnScriptForProject(testTmpDir);
+      expect(res.binary).toEqual('yarn');
+      expect(warnSpy).toHaveBeenCalledWith(jasmine.stringContaining('Ignoring local Yarn path'));
+      expect(confirmSpy).not.toHaveBeenCalled();
+    });
+
+    it('should prompt and respect confirmation (trust = true)', async () => {
+      setTTY(true);
+      confirmSpy.and.resolveTo(true);
+      fs.writeFileSync(path.join(testTmpDir, '.yarnrc.yml'), `yarnPath: a/b/c`);
+
+      expect(await resolveYarnScriptForProject(testTmpDir)).toEqual({
+        binary: 'node',
+        args: [path.resolve(testTmpDir, 'a/b/c')],
+      });
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should prompt and respect confirmation (trust = false)', async () => {
+      setTTY(true);
+      confirmSpy.and.resolveTo(false);
+      fs.writeFileSync(path.join(testTmpDir, '.yarnrc.yml'), `yarnPath: a/b/c`);
+
+      const res = await resolveYarnScriptForProject(testTmpDir);
+      expect(res.binary).toEqual('yarn');
+      expect(confirmSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(jasmine.stringContaining('Ignoring local Yarn path'));
+    });
+
+    it('should prompt and respect confirmation when yarnPath is "."', async () => {
+      setTTY(true);
+      confirmSpy.and.resolveTo(false);
+      fs.writeFileSync(path.join(testTmpDir, '.yarnrc.yml'), `yarnPath: .`);
+
+      const res = await resolveYarnScriptForProject(testTmpDir);
+      expect(res.binary).toEqual('yarn');
+      expect(confirmSpy).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This PR resolves a high severity Remote Code Execution (RCE) vulnerability in Yarn binary resolution (`ng-dev/utils/resolve-yarn-bin.ts`).

### Changes
- Restricts execution of project-local `yarnPath` configurations. If `yarnPath` is inside the project directory, it is only executed if trusted (either via `NG_DEV_TRUST_YARN_PATH=1` environment variable or confirmed via an interactive prompt). Otherwise, it falls back to the system's global Yarn.
- Refactored tests in `ng-dev/utils/test/resolve-yarn-bin.spec.ts` to mock `ChildProcess.spawn` correctly using a shared spy, resolving pre-existing Bazel sandbox environment failures (missing `npm` command).
- Added new test cases for trusted, untrusted, and interactive yarn path resolution.

Vulnerability: bc48ee8d