### PR TITLE
fix(ng-dev/format): prevent formatter argument injection

### DIFF
--- a/ng-dev/format/formatters/base-formatter.ts
+++ b/ng-dev/format/formatters/base-formatter.ts
@@ -22,7 +22,7 @@ export type FormatterAction = 'check' | 'format';
 
 // The metadata needed for running one of the `FormatterAction`s on a file.
 interface FormatterActionMetadata {
-  commandFlags: string;
+  commandFlags: string[];
   callback: CallbackFunc;
 }
 
@@ -59,12 +59,12 @@ export abstract class Formatter {
    * Retrieve the command to execute the provided action, including both the binary
    * and command line flags.
    */
-  commandFor(action: FormatterAction) {
+  commandFor(action: FormatterAction): string[] {
     switch (action) {
       case 'check':
-        return `${this.binaryFilePath} ${this.actions.check.commandFlags}`;
+        return [this.binaryFilePath, ...this.actions.check.commandFlags];
       case 'format':
-        return `${this.binaryFilePath} ${this.actions.format.commandFlags}`;
+        return [this.binaryFilePath, ...this.actions.format.commandFlags];
       default:
         throw Error('Unknown action type');
     }

--- a/ng-dev/format/formatters/buildifier.ts
+++ b/ng-dev/format/formatters/buildifier.ts
@@ -24,7 +24,7 @@ export class Buildifier extends Formatter {
 
   override actions = {
     check: {
-      commandFlags: `${BAZEL_WARNING_FLAG} --lint=warn --mode=check --format=json`,
+      commandFlags: [BAZEL_WARNING_FLAG, '--lint=warn', '--mode=check', '--format=json'],
       callback: (_: string, code: number | NodeJS.Signals, stdout: string) => {
         // For cases where `stdout` is empty, we instead use an empty object to still allow parsing.
         stdout = stdout || '{}';
@@ -32,7 +32,7 @@ export class Buildifier extends Formatter {
       },
     },
     format: {
-      commandFlags: `${BAZEL_WARNING_FLAG} --lint=fix --mode=fix`,
+      commandFlags: [BAZEL_WARNING_FLAG, '--lint=fix', '--mode=fix'],
       callback: (file: string, code: number | NodeJS.Signals, _: string, stderr: string) => {
         if (code !== 0) {
           Log.error(`Error running buildifier on: ${file}`);

--- a/ng-dev/format/formatters/prettier.ts
+++ b/ng-dev/format/formatters/prettier.ts
@@ -45,13 +45,13 @@ export class Prettier extends Formatter {
 
   override actions = {
     check: {
-      commandFlags: `--config ${this.configPath} --check`,
+      commandFlags: ['--config', this.configPath, '--check'],
       callback: (_: string, code: number | NodeJS.Signals, stdout: string) => {
         return code !== 0;
       },
     },
     format: {
-      commandFlags: `--config ${this.configPath} --write`,
+      commandFlags: ['--config', this.configPath, '--write'],
       callback: (file: string, code: number | NodeJS.Signals, _: string, stderr: string) => {
         if (code !== 0) {
           Log.error(`Error running prettier on: ${file}`);

--- a/ng-dev/format/formatters/prettier.ts
+++ b/ng-dev/format/formatters/prettier.ts
@@ -45,13 +45,13 @@ export class Prettier extends Formatter {
 
   override actions = {
     check: {
-      commandFlags: ['--config', this.configPath, '--check'],
+      commandFlags: this.configPath ? ['--config', this.configPath, '--check'] : ['--check'],
       callback: (_: string, code: number | NodeJS.Signals, stdout: string) => {
         return code !== 0;
       },
     },
     format: {
-      commandFlags: ['--config', this.configPath, '--write'],
+      commandFlags: this.configPath ? ['--config', this.configPath, '--write'] : ['--write'],
       callback: (file: string, code: number | NodeJS.Signals, _: string, stderr: string) => {
         if (code !== 0) {
           Log.error(`Error running prettier on: ${file}`);

--- a/ng-dev/format/run-commands-parallel.ts
+++ b/ng-dev/format/run-commands-parallel.ts
@@ -98,7 +98,7 @@ export function runFormatterInParallel(allFiles: string[], action: FormatterActi
         throw new Error(`Security violation: symlink detected for file ${file}`);
       }
 
-      const [spawnCmd, ...spawnArgs] = [...formatter.commandFor(action).split(' '), '--', file];
+      const [spawnCmd, ...spawnArgs] = [...formatter.commandFor(action), '--', file];
 
       ChildProcess.spawn(spawnCmd, spawnArgs, {
         suppressErrorOnFailingExitCode: true,


### PR DESCRIPTION
This PR resolves a high severity argument injection vulnerability in formatters (`ng-dev/format/run-commands-parallel.ts`).

### Changes
- Refactored the `Formatter` definitions to specify `commandFlags` as `string[]` (array of arguments) instead of space-separated strings.
- Modified the execution logic in `run-commands-parallel.ts` to spawn formatter subprocesses directly with array arguments and inserted the `'--'` option terminator before appending the file path. This prevents argument injection in Prettier and Buildifier.

Vulnerability: 18d21598