### PR TITLE
fix(bazel/spec-bundling): sanitize ESM import paths using repr()

### DIFF
--- a/bazel/spec-bundling/spec-entrypoint.bzl
+++ b/bazel/spec-bundling/spec-entrypoint.bzl
@@ -32,7 +32,8 @@ def _create_entrypoint_file(base_package, spec_files, bootstrap_files):
     output = ""
     for file in bootstrap_files + spec_files:
         base_dir_segments = "/".join([".."] * len(base_package.split("/")))
-        output += """import "%s/%s";\n""" % (base_dir_segments, file.short_path)
+        path = "%s/%s" % (base_dir_segments, file.short_path)
+        output += "import %s;\n" % repr(path)
     return output
 
 def _spec_entrypoint_impl(ctx):


### PR DESCRIPTION
This PR resolves a code injection vulnerability in the spec entrypoint generator.

### Changes
- Wrapped ESM import paths in `repr()` to sanitize paths generated in `spec-entrypoint.bzl`.
- Verified changes by running `bazel test //bazel/spec-bundling/test/...`.

Vulnerability: 45417416