### PR TITLE
fix(bazel/api-golden): prevent path traversal in NPM package exports and golden file paths

### DIFF
--- a/bazel/api-golden/find_entry_points.ts
+++ b/bazel/api-golden/find_entry_points.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {dirname, join, relative} from 'path';
+import {dirname, isAbsolute, join, relative} from 'path';
 import {lstatSync, readFileSync, readdirSync} from 'fs';
 
 import {PackageJson} from './index_npm_packages.cjs';
@@ -32,9 +32,28 @@ export function findEntryPointsWithinNpmPackage(
   for (const [subpath, {types}] of Object.entries(packageJson.exports)) {
     // Wildcard types mappings are supported.
     if (types !== undefined && !types.includes('*')) {
+      if (isAbsolute(subpath) || subpath.split(/[/\\]/).includes('..')) {
+        throw new Error(`Invalid exports subpath: ${subpath}`);
+      }
+      if (isAbsolute(types) || types.split(/[/\\]/).includes('..')) {
+        throw new Error(`Invalid types entry point: ${types}`);
+      }
+
+      const resolvedSubpath = join(dirPath, subpath);
+      const relativeSubpath = relative(dirPath, resolvedSubpath);
+      if (relativeSubpath.startsWith('..') || isAbsolute(relativeSubpath)) {
+        throw new Error(`Subpath resolves outside package directory: ${subpath}`);
+      }
+
+      const resolvedTypesPath = join(dirPath, types);
+      const relativeTypes = relative(dirPath, resolvedTypesPath);
+      if (relativeTypes.startsWith('..') || isAbsolute(relativeTypes)) {
+        throw new Error(`Types entry point resolves outside package directory: ${types}`);
+      }
+
       entryPoints.push({
         subpath,
-        typesEntryPointPath: join(dirPath, types),
+        typesEntryPointPath: resolvedTypesPath,
       });
     }
   }

--- a/bazel/api-golden/index_npm_packages.cts
+++ b/bazel/api-golden/index_npm_packages.cts
@@ -66,6 +66,14 @@ async function main(
       goldenName = subpath;
     }
     const goldenFilePath = path.join(goldenDir, goldenName);
+
+    const relativeGoldenPath = path.relative(goldenDir, goldenFilePath);
+    if (relativeGoldenPath.startsWith('..') || path.isAbsolute(relativeGoldenPath)) {
+      throw new Error(
+        `Golden file path resolves outside of the golden directory: ${goldenFilePath}`,
+      );
+    }
+
     const moduleName = normalizePathToPosix(path.join(packageJson.name, subpath));
 
     // Run API extractor in child processes. This is because API extractor is very


### PR DESCRIPTION
This PR resolves a path traversal vulnerability in the API golden testing rules.

### Changes
- Validated that `subpath` and `types` in package exports do not contain `..` and resolve within the package directory in `find_entry_points.ts`.
- Validated that `goldenFilePath` resolves under the expected `goldenDir` in `index_npm_packages.cts`.
- Verified changes by running `bazel test //bazel/api-golden/test:all`.

Vulnerability: 2dde5483