### PR TITLE
fix(ng-dev): redact sensitive tokens from error logs

### DIFF
--- a/ng-dev/caretaker/handoff/verify-merge-mode.ts
+++ b/ng-dev/caretaker/handoff/verify-merge-mode.ts
@@ -33,7 +33,12 @@ export async function verifyMergeMode(expectedMode: MergeMode): Promise<boolean>
       return true;
     } catch (err) {
       Log.info(`${red('✘')} Failed to update merge-mode`);
-      Log.info(err);
+      if (err instanceof Error) {
+        Log.info(err.message);
+        Log.debug(err.stack);
+      } else {
+        Log.info(err);
+      }
       return false;
     }
   }

--- a/ng-dev/pr/rebase/index.ts
+++ b/ng-dev/pr/rebase/index.ts
@@ -125,7 +125,12 @@ export async function rebasePr(prNumber: number, interactive: boolean = false): 
       return 0;
     }
   } catch (err) {
-    Log.error(err);
+    if (err instanceof Error) {
+      Log.error(err.message);
+      Log.debug(err.stack);
+    } else {
+      Log.error(err);
+    }
     git.checkout(previousBranchOrRevision, true);
     return 1;
   }


### PR DESCRIPTION
Addresses vulnerability 1b8d0a2c by refactoring catch blocks in verify-merge-mode.ts and pr/rebase/index.ts to avoid printing raw error objects to logs. Logs only err.message and err.stack (debug) if it is an instance of Error, preventing API tokens (like GitHub Auth headers inside Octokit request structures) from leaking to CI logs.

Vulnerability: 1b8d0a2c