### PR TITLE
fix(ng-dev/caretaker): redact raw error objects from caretaker logs

### DIFF
--- a/ng-dev/caretaker/handoff/update-github-team.ts
+++ b/ng-dev/caretaker/handoff/update-github-team.ts
@@ -96,7 +96,11 @@ async function getGroupMembers(group: string) {
       })
       .then(({data}) => data.map((member) => member.login));
   } catch (e) {
-    Log.debug(e);
+    if (e instanceof Error) {
+      Log.debug(e.stack ?? e.message);
+    } else {
+      Log.debug(String(e));
+    }
     return [];
   }
 }

--- a/ng-dev/caretaker/handoff/verify-merge-mode.ts
+++ b/ng-dev/caretaker/handoff/verify-merge-mode.ts
@@ -34,10 +34,9 @@ export async function verifyMergeMode(expectedMode: MergeMode): Promise<boolean>
     } catch (err) {
       Log.info(`${red('✘')} Failed to update merge-mode`);
       if (err instanceof Error) {
-        Log.info(err.message);
-        Log.debug(err.stack);
+        Log.debug(err.stack ?? err.message);
       } else {
-        Log.info(err);
+        Log.debug(String(err));
       }
       return false;
     }

--- a/ng-dev/caretaker/merge-mode/release.ts
+++ b/ng-dev/caretaker/merge-mode/release.ts
@@ -20,13 +20,12 @@ export async function setMergeModeRelease(): Promise<boolean> {
   } catch (err) {
     Log.error('  ✘  Failed to setup of repository for release');
     if (err instanceof Error) {
-      Log.info(err.message);
-      Log.debug(err.stack);
-      return false;
+      Log.debug(err.stack ?? err.message);
+    } else {
+      Log.debug(String(err));
     }
-    Log.info(err);
+    return false;
   }
-  return false;
 }
 
 async function setRepoReleaserTeamToOnlyCurrentUser() {

--- a/ng-dev/caretaker/merge-mode/reset.ts
+++ b/ng-dev/caretaker/merge-mode/reset.ts
@@ -21,11 +21,10 @@ export async function resetMergeMode(): Promise<boolean> {
   } catch (err) {
     Log.info(`${red('✘')} Failed to reset the merge mode of the repository`);
     if (err instanceof Error) {
-      Log.info(err.message);
-      Log.debug(err.stack);
-      return false;
+      Log.debug(err.stack ?? err.message);
+    } else {
+      Log.debug(String(err));
     }
-    Log.info(err);
     return false;
   }
 }


### PR DESCRIPTION
Addresses ce4ab3d8. Redacts raw error objects in caretaker logs to prevent sensitive token leakage.