### PR TITLE
fix(bazel/http-server): prevent directory traversal bypass in Http Server

### DIFF
--- a/bazel/http-server/server.mts
+++ b/bazel/http-server/server.mts
@@ -100,9 +100,13 @@ export class HttpServer {
     // Detect if the url escapes the server's root path
     for (const rootPath of this._rootPaths) {
       const resolvedRoot = path.resolve(rootPath);
-      const absoluteRootPath = resolvedRoot.endsWith(path.sep) ? resolvedRoot : resolvedRoot + path.sep;
+      const absoluteRootPath = resolvedRoot.endsWith(path.sep)
+        ? resolvedRoot
+        : resolvedRoot + path.sep;
       const resolvedJoined = path.resolve(path.posix.join(rootPath, getManifestPath(req.url)));
-      const absoluteJoinedPath = resolvedJoined.endsWith(path.sep) ? resolvedJoined : resolvedJoined + path.sep;
+      const absoluteJoinedPath = resolvedJoined.endsWith(path.sep)
+        ? resolvedJoined
+        : resolvedJoined + path.sep;
       if (!absoluteJoinedPath.startsWith(absoluteRootPath)) {
         res.statusCode = 500;
         res.end('Error: Detected directory traversal');

--- a/bazel/http-server/server.mts
+++ b/bazel/http-server/server.mts
@@ -99,8 +99,8 @@ export class HttpServer {
 
     // Detect if the url escapes the server's root path
     for (const rootPath of this._rootPaths) {
-      const absoluteRootPath = path.resolve(rootPath);
-      const absoluteJoinedPath = path.resolve(path.posix.join(rootPath, getManifestPath(req.url)));
+      const absoluteRootPath = path.resolve(rootPath) + path.sep;
+      const absoluteJoinedPath = path.resolve(path.posix.join(rootPath, getManifestPath(req.url))) + path.sep;
       if (!absoluteJoinedPath.startsWith(absoluteRootPath)) {
         res.statusCode = 500;
         res.end('Error: Detected directory traversal');

--- a/bazel/http-server/server.mts
+++ b/bazel/http-server/server.mts
@@ -99,8 +99,10 @@ export class HttpServer {
 
     // Detect if the url escapes the server's root path
     for (const rootPath of this._rootPaths) {
-      const absoluteRootPath = path.resolve(rootPath) + path.sep;
-      const absoluteJoinedPath = path.resolve(path.posix.join(rootPath, getManifestPath(req.url))) + path.sep;
+      const resolvedRoot = path.resolve(rootPath);
+      const absoluteRootPath = resolvedRoot.endsWith(path.sep) ? resolvedRoot : resolvedRoot + path.sep;
+      const resolvedJoined = path.resolve(path.posix.join(rootPath, getManifestPath(req.url)));
+      const absoluteJoinedPath = resolvedJoined.endsWith(path.sep) ? resolvedJoined : resolvedJoined + path.sep;
       if (!absoluteJoinedPath.startsWith(absoluteRootPath)) {
         res.statusCode = 500;
         res.end('Error: Detected directory traversal');


### PR DESCRIPTION
This PR resolves a directory traversal weakness in the HttpServer by appending path separators to root and joined paths before comparison. Vulnerability: 7ed5a82a