### PR TITLE
fix(apps/code-of-conduct): load provider icons over HTTPS

### DIFF
--- a/apps/code-of-conduct/app/account/account.component.html
+++ b/apps/code-of-conduct/app/account/account.component.html
@@ -26,11 +26,11 @@
     <ng-container cdkAccordionItem #providerPanel="cdkAccordionItem">
       <div *ngIf="providerPanel.expanded" class="provider-panel">
         <div class="provider-row">
-          <img class="provider-icon" src="http://google.com/favicon.ico" alt="google icon" />
+          <img class="provider-icon" src="https://google.com/favicon.ico" alt="google icon" />
           <span class="provider-email">{{ account.googleInfo?.email || 'Unknown' }}</span>
         </div>
         <div class="provider-row">
-          <img class="provider-icon" src="http://github.com/favicon.ico" alt="github icon" />
+          <img class="provider-icon" src="https://github.com/favicon.ico" alt="github icon" />
           <span class="provider-email">{{
             account.githubInfo?.email || 'Account Not Linked'
           }}</span>


### PR DESCRIPTION
This PR resolves an insecure resource loading (mixed content) weakness in the Code of Conduct app by updating Google and GitHub favicon URLs to use HTTPS. Vulnerability: ac29b80c