### PR TITLE
build: update dependency ejs to v6

### DIFF
--- a/ng-dev/package.json
+++ b/ng-dev/package.json
@@ -47,7 +47,7 @@
     "cli-progress": "3.12.0",
     "conventional-commits-filter": "5.0.0",
     "conventional-commits-parser": "6.4.0",
-    "ejs": "5.0.2",
+    "ejs": "6.0.1",
     "encoding": "0.1.13",
     "fast-glob": "3.3.3",
     "firebase": "12.13.0",

--- a/ng-dev/release/notes/context.ts
+++ b/ng-dev/release/notes/context.ts
@@ -86,7 +86,7 @@ export class RenderContext {
    * the configuration. Commits are order in the same order within each groups commit list as they
    * appear in the provided list of commits.
    * */
-  asCommitGroups(commits: CategorizedCommit[]) {
+  asCommitGroups = (commits: CategorizedCommit[]) => {
     /** The discovered groups to organize into. */
     const groups = new Map<string, CategorizedCommit[]>();
 
@@ -122,23 +122,23 @@ export class RenderContext {
       }
     }
     return commitGroups;
-  }
+  };
 
   /** Whether the specified commit contains breaking changes. */
-  hasBreakingChanges(commit: CategorizedCommit) {
+  hasBreakingChanges = (commit: CategorizedCommit) => {
     return commit.breakingChanges.length !== 0;
-  }
+  };
 
   /** Whether the specified commit contains deprecations. */
-  hasDeprecations(commit: CategorizedCommit) {
+  hasDeprecations = (commit: CategorizedCommit) => {
     return commit.deprecations.length !== 0;
-  }
+  };
 
   /**
    * A filter function for filtering a list of commits to only include commits which
    * should appear in release notes.
    */
-  includeInReleaseNotes() {
+  includeInReleaseNotes = () => {
     return (commit: CategorizedCommit) => {
       if (this.hiddenScopes.includes(commit.scope)) {
         return false;
@@ -153,36 +153,36 @@ export class RenderContext {
 
       return typesToIncludeInReleaseNotes.includes(commit.type);
     };
-  }
+  };
 
   /**
    * A filter function for filtering a list of commits to only include commits which contain a
    * unique value for the provided field across all commits in the list.
    */
-  unique(field: keyof CategorizedCommit) {
+  unique = (field: keyof CategorizedCommit) => {
     const set = new Set<CategorizedCommit[typeof field]>();
     return (commit: CategorizedCommit) => {
       const include = !set.has(commit[field]);
       set.add(commit[field]);
       return include;
     };
-  }
+  };
 
   /**
    * Convert a commit object to a Markdown link.
    */
-  commitToLink(commit: CategorizedCommit): string {
+  commitToLink = (commit: CategorizedCommit): string => {
     const url = `https://github.com/${this.data.github.owner}/${this.data.github.name}/commit/${commit.hash}`;
     return `[${commit.shortHash}](${url})`;
-  }
+  };
 
   /**
    * Convert a pull request number to a Markdown link.
    */
-  pullRequestToLink(prNumber: number): string {
+  pullRequestToLink = (prNumber: number): string => {
     const url = `https://github.com/${this.data.github.owner}/${this.data.github.name}/pull/${prNumber}`;
     return `[#${prNumber}](${url})`;
-  }
+  };
 
   /**
    * Transform a given string by replacing any pull request references with their
@@ -192,21 +192,21 @@ export class RenderContext {
    * automatically in release note entries, issues and pull requests, but not for plain
    * markdown files (like the changelog file).
    */
-  convertPullRequestReferencesToLinks(content: string): string {
+  convertPullRequestReferencesToLinks = (content: string): string => {
     return content.replace(/#(\d+)/g, (_, g) => this.pullRequestToLink(Number(g)));
-  }
+  };
 
   /**
    * Bulletize a paragraph.
    */
-  bulletizeText(text: string): string {
+  bulletizeText = (text: string): string => {
     return '- ' + text.replace(/\n/g, '\n  ');
-  }
+  };
 
   /**
    * Convert a commit object to a Markdown linked badged.
    */
-  commitToBadge(commit: CategorizedCommit): string {
+  commitToBadge = (commit: CategorizedCommit): string => {
     let color = 'yellow';
     switch (commit.type) {
       case 'fix':
@@ -222,7 +222,7 @@ export class RenderContext {
     const url = `https://github.com/${this.data.github.owner}/${this.data.github.name}/commit/${commit.hash}`;
     const imgSrc = `https://img.shields.io/badge/${commit.shortHash}-${commit.type}-${color}`;
     return `[![${commit.type} - ${commit.shortHash}](${imgSrc})](${url})`;
-  }
+  };
 }
 
 /**

--- a/ng-dev/release/notes/release-notes.ts
+++ b/ng-dev/release/notes/release-notes.ts
@@ -100,16 +100,15 @@ export class ReleaseNotes {
    * Prompt the user for a title for the release, if the project's configuration is defined to use a
    * title.
    */
-  async promptForReleaseTitle() {
+  async promptForReleaseTitle(): Promise<string | false> {
     const notesConfig = await this._getNotesConfig();
 
-    if (this.title === undefined) {
-      if (notesConfig.useReleaseTitle) {
-        this.title = await Prompt.input({message: 'Please provide a title for the release:'});
-      } else {
-        this.title = false;
-      }
+    if (this.title === undefined && notesConfig.useReleaseTitle) {
+      this.title = await Prompt.input({message: 'Please provide a title for the release:'});
     }
+
+    this.title ??= false;
+
     return this.title;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -612,8 +612,8 @@ importers:
         specifier: 6.4.0
         version: 6.4.0
       ejs:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 6.0.1
+        version: 6.0.1
       encoding:
         specifier: 0.1.13
         version: 0.1.13
@@ -3307,8 +3307,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  ejs@5.0.2:
-    resolution: {integrity: sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==}
+  ejs@6.0.1:
+    resolution: {integrity: sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==}
     engines: {node: '>=0.12.18'}
     hasBin: true
 
@@ -8924,7 +8924,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  ejs@5.0.2: {}
+  ejs@6.0.1: {}
 
   electron-to-chromium@1.5.358: {}
 


### PR DESCRIPTION
See associated pull request for more information.

Closes #3704 as a pr takeover