### PR TITLE
feat(ng-dev/release): implement publish-ci command and tests

### DIFF
--- a/ng-dev/release/cli.ts
+++ b/ng-dev/release/cli.ts
@@ -12,6 +12,7 @@ import {ReleaseInfoCommandModule} from './info/cli.js';
 import {ReleaseNotesCommandModule} from './notes/cli.js';
 import {ReleasePrecheckCommandModule} from './precheck/cli.js';
 import {ReleasePublishCommandModule} from './publish/cli.js';
+import {ReleasePublishCiCommandModule} from './publish/cli-ci.js';
 import {ReleasePublishSnapshotsCommandModule} from './snapshot-publish/cli.js';
 import {BuildEnvStampCommand} from './stamping/cli.js';
 import {ReleaseNpmDistTagCommand} from './npm-dist-tag/cli.js';
@@ -23,6 +24,7 @@ export function buildReleaseParser(localYargs: Argv) {
     .strict()
     .demandCommand()
     .command(ReleasePublishCommandModule)
+    .command(ReleasePublishCiCommandModule)
     .command(ReleaseBuildCommandModule)
     .command(ReleaseInfoCommandModule)
     .command(ReleaseNpmDistTagCommand)

--- a/ng-dev/release/publish/cli-ci.ts
+++ b/ng-dev/release/publish/cli-ci.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright Google LLC
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Argv, Arguments, CommandModule} from 'yargs';
+
+import {assertValidGithubConfig, getConfig} from '../../utils/config.js';
+import {addGithubTokenOption} from '../../utils/git/github-yargs.js';
+import {assertValidReleaseConfig} from '../config/index.js';
+import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client.js';
+import {PublishCiTool} from './index-ci.js';
+import {green, Log} from '../../utils/logging.js';
+
+/** Command line options for the release publish-ci command. */
+export interface ReleasePublishCiOptions {
+  /** Path to the directory containing pre-built packages. */
+  builtPackagesDir: string;
+  /** The expected Git SHA of the release commit. */
+  expectedSha: string;
+  /** Run the publish command in dry-run mode. */
+  dryRun?: boolean;
+}
+
+function builder(argv: Argv): Argv<ReleasePublishCiOptions> {
+  return addGithubTokenOption(argv)
+    .option('built-packages-dir' as 'builtPackagesDir', {
+      type: 'string',
+      demandOption: true,
+      description: 'Path to the directory containing pre-built packages.',
+    })
+    .option('expected-sha' as 'expectedSha', {
+      type: 'string',
+      demandOption: true,
+      description: 'The expected Git SHA of the release commit.',
+    })
+    .option('dry-run' as 'dryRun', {
+      type: 'boolean',
+      default: false,
+      description:
+        'Run the publish command in dry-run mode, skipping tag/release creation and NPM publishing.',
+    });
+}
+
+async function handler(flags: Arguments<ReleasePublishCiOptions>) {
+  const git = await AuthenticatedGitClient.get();
+  const config = await getConfig();
+  assertValidReleaseConfig(config);
+  assertValidGithubConfig(config);
+
+  const tool = new PublishCiTool(config, git, git.baseDir, flags);
+
+  try {
+    await tool.run();
+    Log.info(green('Release CI publish completed successfully.'));
+  } catch (e) {
+    if (e instanceof Error) {
+      Log.error(`Release CI publish failed: ${e.message}`);
+      if (e.stack) {
+        Log.debug(e.stack);
+      }
+    } else {
+      Log.error(`Release CI publish failed with unknown error: ${e}`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+/** Yargs command module for the 'publish-ci' command. */
+export const ReleasePublishCiCommandModule: CommandModule<{}, ReleasePublishCiOptions> = {
+  builder,
+  handler,
+  command: 'publish-ci',
+  describe: 'Publish a release from CI.',
+};

--- a/ng-dev/release/publish/index-ci.ts
+++ b/ng-dev/release/publish/index-ci.ts
@@ -322,6 +322,7 @@ export class PublishCiTool {
     } else {
       const tempDir = mkdtempSync(join(tmpdir(), 'angular-publish-ci-'));
       const tempNpmrcPath = join(tempDir, '.npmrc');
+      const originalUserconfig = process.env['NPM_CONFIG_USERCONFIG'];
 
       try {
         const wombatNpmrcContent =
@@ -332,10 +333,17 @@ export class PublishCiTool {
         writeFileSync(tempNpmrcPath, wombatNpmrcContent);
         Log.info(green(`  ✓   Created temporary .npmrc for Wombat registry.`));
 
+        // Set the environment variable to point to the temporary config
+        process.env['NPM_CONFIG_USERCONFIG'] = tempNpmrcPath;
+
         // Publish packages
         for (const pkg of builtPackages) {
           Log.info(`Publishing "${pkg.name}"...`);
-          await NpmCommand.publish(pkg.outputPath, npmDistTag, undefined, tempNpmrcPath);
+          await NpmCommand.publish(
+            pkg.outputPath,
+            npmDistTag,
+            'https://wombat-dressing-room.appspot.com/',
+          );
           Log.info(green(`  ✓   Successfully published "${pkg.name}".`));
         }
 
@@ -346,14 +354,26 @@ export class PublishCiTool {
           }
           Log.info(`Deprecating "${pkg.name}"...`);
           const {version, message} = pkg.deprecated;
-          await NpmCommand.deprecate(pkg.name, version, message, undefined, tempNpmrcPath);
+          await NpmCommand.deprecate(
+            pkg.name,
+            version,
+            message,
+            'https://wombat-dressing-room.appspot.com/',
+          );
           Log.info(green(`  ✓   Successfully deprecated "${pkg.name}@${version}".`));
         }
       } finally {
+        // Guaranteed cleanup of files and environment
         try {
           rmSync(tempDir, {recursive: true, force: true});
         } catch (e) {
           Log.warn(`Warning: Failed to clean up temporary directory ${tempDir}: ${e}`);
+        } finally {
+          if (originalUserconfig !== undefined) {
+            process.env['NPM_CONFIG_USERCONFIG'] = originalUserconfig;
+          } else {
+            delete process.env['NPM_CONFIG_USERCONFIG'];
+          }
         }
       }
     }

--- a/ng-dev/release/publish/index-ci.ts
+++ b/ng-dev/release/publish/index-ci.ts
@@ -7,9 +7,19 @@
  */
 
 import {join} from 'path';
-import {readdirSync, statSync, readFileSync, existsSync, writeFileSync, rmSync} from 'fs';
+import {
+  readdirSync,
+  readFileSync,
+  existsSync,
+  writeFileSync,
+  rmSync,
+  mkdtempSync,
+  Dirent,
+} from 'fs';
+import {tmpdir} from 'os';
 import semver from 'semver';
-import {ReleaseConfig, BuiltPackage} from '../config/index.js';
+import {ReleaseConfig, BuiltPackage, BuiltPackageWithInfo} from '../config/index.js';
+import {analyzeAndExtendBuiltPackagesWithInfo} from './built-package-info.js';
 import {GithubConfig, NgDevConfig} from '../../utils/config.js';
 import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client.js';
 import {ReleaseNotes, workspaceRelativeChangelogPath} from '../notes/release-notes.js';
@@ -70,6 +80,11 @@ export class PublishCiTool {
       throw new Error(`No built packages found under directory ${this.options.builtPackagesDir}`);
     }
 
+    const builtPackagesWithInfo = await analyzeAndExtendBuiltPackagesWithInfo(
+      builtPackages,
+      this.config.release.npmPackages,
+    );
+
     const beforeStagingSha = this.getBeforeStagingSha();
 
     const newVersion = readPackageJsonAtRef(this.git, 'HEAD').version;
@@ -97,7 +112,7 @@ export class PublishCiTool {
 
     await this.createGithubReleaseAndTags(newVersion, newSemver, releaseNotes, npmDistTag);
 
-    await this.publishPackagesToNpm(builtPackages, npmDistTag);
+    await this.publishAndDeprecatePackages(builtPackagesWithInfo, npmDistTag);
   }
 
   /**
@@ -293,17 +308,20 @@ export class PublishCiTool {
    * @param builtPackages List of built packages to be published.
    * @param npmDistTag The NPM distribution tag (e.g. 'latest', 'next') to publish under.
    */
-  private async publishPackagesToNpm(builtPackages: BuiltPackage[], npmDistTag: NpmDistTag) {
+  private async publishAndDeprecatePackages(
+    builtPackages: BuiltPackageWithInfo[],
+    npmDistTag: NpmDistTag,
+  ) {
     if (this.options.dryRun) {
       for (const pkg of builtPackages) {
-        Log.info(`[Dry-Run] Would write .npmrc and publish package: ${pkg.name} to Wombat`);
+        Log.info(`[Dry-Run] Would publish package: ${pkg.name} to Wombat`);
+        if (pkg.deprecated) {
+          Log.info(`[Dry-Run] Would deprecate package: ${pkg.name}@${pkg.deprecated.version}`);
+        }
       }
     } else {
-      const npmrcPath = join(this.projectDir, '.npmrc');
-      let originalNpmrc: string | null = null;
-      if (existsSync(npmrcPath)) {
-        originalNpmrc = readFileSync(npmrcPath, 'utf8');
-      }
+      const tempDir = mkdtempSync(join(tmpdir(), 'angular-publish-ci-'));
+      const tempNpmrcPath = join(tempDir, '.npmrc');
 
       try {
         const wombatNpmrcContent =
@@ -311,23 +329,31 @@ export class PublishCiTool {
             `registry=https://wombat-dressing-room.appspot.com/`,
             `//wombat-dressing-room.appspot.com/:_authToken=\${WOMBOT_TOKEN}`,
           ].join('\n') + '\n';
-        writeFileSync(npmrcPath, wombatNpmrcContent);
-        Log.info(green(`  ✓   Configured .npmrc to use Wombat registry.`));
+        writeFileSync(tempNpmrcPath, wombatNpmrcContent);
+        Log.info(green(`  ✓   Created temporary .npmrc for Wombat registry.`));
 
+        // Publish packages
         for (const pkg of builtPackages) {
           Log.info(`Publishing "${pkg.name}"...`);
-          await NpmCommand.publish(
-            pkg.outputPath,
-            npmDistTag,
-            'https://wombat-dressing-room.appspot.com/',
-          );
+          await NpmCommand.publish(pkg.outputPath, npmDistTag, undefined, tempNpmrcPath);
           Log.info(green(`  ✓   Successfully published "${pkg.name}".`));
         }
+
+        // Deprecate packages if configured
+        for (const pkg of builtPackages) {
+          if (!pkg.deprecated) {
+            continue;
+          }
+          Log.info(`Deprecating "${pkg.name}"...`);
+          const {version, message} = pkg.deprecated;
+          await NpmCommand.deprecate(pkg.name, version, message, undefined, tempNpmrcPath);
+          Log.info(green(`  ✓   Successfully deprecated "${pkg.name}@${version}".`));
+        }
       } finally {
-        if (originalNpmrc !== null) {
-          writeFileSync(npmrcPath, originalNpmrc);
-        } else if (existsSync(npmrcPath)) {
-          rmSync(npmrcPath);
+        try {
+          rmSync(tempDir, {recursive: true, force: true});
+        } catch (e) {
+          Log.warn(`Warning: Failed to clean up temporary directory ${tempDir}: ${e}`);
         }
       }
     }
@@ -362,34 +388,34 @@ function findBuiltPackages(dir: string): BuiltPackage[] {
   }
   const packages: BuiltPackage[] = [];
   const walk = (currentDir: string) => {
-    let files: string[];
+    let entries: Dirent[];
     try {
-      files = readdirSync(currentDir);
+      entries = readdirSync(currentDir, {withFileTypes: true});
     } catch (e) {
       return;
     }
-    if (files.includes('package.json')) {
+    const hasPackageJson = entries.some((e) => e.isFile() && e.name === 'package.json');
+    if (hasPackageJson) {
       try {
         const pkgJson = JSON.parse(readFileSync(join(currentDir, 'package.json'), 'utf8'));
         if (pkgJson.name) {
-          packages.push({
-            name: pkgJson.name,
-            outputPath: currentDir,
-          });
+          if (!pkgJson.private) {
+            packages.push({
+              name: pkgJson.name,
+              outputPath: currentDir,
+            });
+          }
+          // Stop traversing deeper once we find a package boundary (even if private)
+          // to avoid looking into nested node_modules or sub-packages.
           return;
         }
       } catch (e) {
         // Ignore parsing errors
       }
     }
-    for (const file of files) {
-      const fullPath = join(currentDir, file);
-      try {
-        if (statSync(fullPath).isDirectory()) {
-          walk(fullPath);
-        }
-      } catch (e) {
-        // Ignore broken symlinks or unreadable files
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        walk(join(currentDir, entry.name));
       }
     }
   };

--- a/ng-dev/release/publish/index-ci.ts
+++ b/ng-dev/release/publish/index-ci.ts
@@ -1,0 +1,447 @@
+/**
+ * @license
+ * Copyright Google LLC
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {join} from 'path';
+import {readdirSync, statSync, readFileSync, existsSync, writeFileSync, rmSync} from 'fs';
+import semver from 'semver';
+import {ReleaseConfig, BuiltPackage} from '../config/index.js';
+import {GithubConfig, NgDevConfig} from '../../utils/config.js';
+import {AuthenticatedGitClient} from '../../utils/git/authenticated-git-client.js';
+import {ReleaseNotes, workspaceRelativeChangelogPath} from '../notes/release-notes.js';
+import {NpmCommand} from '../versioning/npm-command.js';
+import {getFileContentsUrl} from '../../utils/git/github-urls.js';
+import {isGithubApiError} from '../../utils/git/github.js';
+import {githubReleaseBodyLimit} from './constants.js';
+import {green, Log} from '../../utils/logging.js';
+import {fetchLongTermSupportBranchesFromNpm} from '../versioning/long-term-support.js';
+import {ActiveReleaseTrains} from '../versioning/active-release-trains.js';
+import {NpmDistTag} from '../versioning/npm-registry.js';
+
+/** Options for configuring the PublishCiTool. */
+export interface PublishCiToolOptions {
+  /** The directory containing the pre-built packages to be published. */
+  builtPackagesDir: string;
+  /** The expected Git SHA of the release commit to verify against HEAD. */
+  expectedSha: string;
+  /** Whether to run in dry-run mode (skips tags/releases creation and publishing). */
+  dryRun?: boolean;
+}
+
+/**
+ * Tool that runs in CI to automate the publishing of pre-built release packages.
+ *
+ * This tool is designed to run non-interactively in a CI environment after a release
+ * staging PR has been merged. It handles Git tagging (both global and monorepo packages),
+ * GitHub Release creation (with generated release notes), and publishing the packages to
+ * the NPM registry (Wombat proxy) using the provided WOMBOT_TOKEN.
+ */
+export class PublishCiTool {
+  constructor(
+    protected config: NgDevConfig<{release: ReleaseConfig; github: GithubConfig}>,
+    protected git: AuthenticatedGitClient,
+    protected projectDir: string,
+    protected options: PublishCiToolOptions,
+  ) {}
+
+  /**
+   * Executes the publish-ci process.
+   *
+   * Validates the environment, verifies the HEAD commit matches the expected SHA,
+   * resolves the pre-built packages, generates release notes by comparing versions,
+   * and performs the tagging, release creation, and NPM publishing.
+   *
+   * @throws {Error} If WOMBOT_TOKEN is missing (and not in dry-run), if HEAD SHA doesn't match
+   * expected SHA, if no built packages are found, or if any GitHub/NPM API operation fails.
+   */
+  async run() {
+    if (!this.options.dryRun && !process.env['WOMBOT_TOKEN']) {
+      throw new Error('WOMBOT_TOKEN environment variable is not defined.');
+    }
+
+    this.assertExpectedSha();
+
+    const builtPackages = findBuiltPackages(this.options.builtPackagesDir);
+    if (builtPackages.length === 0) {
+      throw new Error(`No built packages found under directory ${this.options.builtPackagesDir}`);
+    }
+
+    const beforeStagingSha = this.getBeforeStagingSha();
+
+    const newVersion = readPackageJsonAtRef(this.git, 'HEAD').version;
+    const versionAtBeforeStaging = readPackageJsonAtRef(this.git, beforeStagingSha).version;
+
+    const newSemver = semver.parse(newVersion);
+    if (!newSemver) {
+      throw new Error(`Failed to parse version ${newVersion} as semver.`);
+    }
+    const versionAtBeforeStagingSemver = semver.parse(versionAtBeforeStaging);
+    if (!versionAtBeforeStagingSemver) {
+      throw new Error(`Failed to parse version ${versionAtBeforeStaging} as semver.`);
+    }
+
+    const previousVersionTag = this.getPreviousVersionTag(newSemver, versionAtBeforeStagingSemver);
+
+    const releaseNotes = await ReleaseNotes.forRange(
+      this.git,
+      newSemver,
+      previousVersionTag,
+      beforeStagingSha,
+    );
+
+    const npmDistTag = await determineNpmDistTag(newSemver, this.config.release, this.git);
+
+    await this.createGithubReleaseAndTags(newVersion, newSemver, releaseNotes, npmDistTag);
+
+    await this.publishPackagesToNpm(builtPackages, npmDistTag);
+  }
+
+  /**
+   * Asserts that the current HEAD commit SHA matches the expected SHA passed in options.
+   * @throws {Error} If the HEAD SHA does not match the expected SHA.
+   */
+  private assertExpectedSha() {
+    const headSha = this.git.run(['rev-parse', 'HEAD']).stdout.trim();
+    if (headSha !== this.options.expectedSha) {
+      throw new Error(`Expected HEAD SHA to be ${this.options.expectedSha}, but got ${headSha}.`);
+    }
+  }
+
+  /**
+   * Resolves the SHA of the commit immediately prior to the release staging changes.
+   *
+   * Analyzes the parents of the current HEAD commit. If it is a merge commit (typically the
+   * merged staging PR), it identifies the parent of the staging commit. Otherwise, it defaults
+   * to the single parent of HEAD.
+   *
+   * @returns The SHA of the pre-staging commit.
+   * @throws {Error} If HEAD has no parents, or if the parent structure is unexpected.
+   */
+  private getBeforeStagingSha(): string {
+    const parentsOutput = this.git.run(['show', '--format=%P', '-s', 'HEAD']).stdout.trim();
+    const parents = parentsOutput ? parentsOutput.split(' ') : [];
+    if (parents.length >= 2) {
+      const stagingCommitSha = parents[1];
+      const stagingCommitParentsOutput = this.git
+        .run(['show', '--format=%P', '-s', stagingCommitSha])
+        .stdout.trim();
+      const stagingCommitParents = stagingCommitParentsOutput
+        ? stagingCommitParentsOutput.split(' ')
+        : [];
+      if (stagingCommitParents.length === 0) {
+        throw new Error(`Could not find parent for staging commit ${stagingCommitSha}`);
+      }
+      return stagingCommitParents[0];
+    } else if (parents.length === 1) {
+      return parents[0];
+    } else {
+      throw new Error('HEAD commit has no parents.');
+    }
+  }
+
+  /**
+   * Resolves the previous version Git tag to compare against for generating release notes.
+   *
+   * If the release is a transition from a pre-release (e.g. RC) to a stable version, it searches
+   * the repository tags for the highest stable version that is less than the new version.
+   * Otherwise, it defaults to the version tag associated with the pre-staging commit.
+   *
+   * @param newSemver The version currently being published.
+   * @param versionAtBeforeStagingSemver The version at the pre-staging commit.
+   * @returns The git tag name of the previous version (e.g. 'v1.2.3').
+   * @throws {Error} If a previous stable version tag cannot be resolved when transitioning to stable.
+   */
+  private getPreviousVersionTag(
+    newSemver: semver.SemVer,
+    versionAtBeforeStagingSemver: semver.SemVer,
+  ): string {
+    if (newSemver.prerelease.length === 0 && versionAtBeforeStagingSemver.prerelease.length > 0) {
+      this.git.run(['fetch', '--tags', this.git.getRepoGitUrl()]);
+      const tagsOutput = this.git.run(['tag', '-l', 'v*']).stdout.trim();
+      const tags = tagsOutput ? tagsOutput.split('\n').map((t) => t.trim()) : [];
+      let highestStableVersion: semver.SemVer | null = null;
+      for (const tag of tags) {
+        const versionStr = tag.startsWith('v') ? tag.slice(1) : tag;
+        const parsed = semver.parse(versionStr);
+        if (parsed && parsed.prerelease.length === 0) {
+          if (semver.lt(parsed, newSemver)) {
+            if (highestStableVersion === null || semver.gt(parsed, highestStableVersion)) {
+              highestStableVersion = parsed;
+            }
+          }
+        }
+      }
+      if (highestStableVersion === null) {
+        throw new Error(
+          `Could not find a previous stable version tag matching v* less than ${newSemver.format()}`,
+        );
+      }
+      return `v${highestStableVersion.format()}`;
+    }
+    return `v${versionAtBeforeStagingSemver.format()}`;
+  }
+
+  /**
+   * Creates the GitHub Release and Git tags for the version being published.
+   *
+   * Creates the global version tag (`vX.Y.Z`), the GitHub Release entry containing the
+   * release notes, and individual monorepo package tags (`@angular/core@X.Y.Z`) if configured.
+   * These operations are idempotent and will gracefully log warnings if a tag or release
+   * already exists.
+   *
+   * @param newVersion The version string to release.
+   * @param newSemver The parsed SemVer representation of the version.
+   * @param releaseNotes The generated release notes for this version range.
+   * @param npmDistTag The determined NPM distribution tag (used to flag latest releases on GitHub).
+   */
+  private async createGithubReleaseAndTags(
+    newVersion: string,
+    newSemver: semver.SemVer,
+    releaseNotes: ReleaseNotes,
+    npmDistTag: NpmDistTag,
+  ) {
+    const globalTagName = `v${newVersion}`;
+    if (this.options.dryRun) {
+      Log.info(`[Dry-Run] Would tag global tag: ${globalTagName}`);
+    } else {
+      try {
+        await this.git.github.git.createRef({
+          ...this.git.remoteParams,
+          ref: `refs/tags/${globalTagName}`,
+          sha: this.options.expectedSha,
+        });
+        Log.info(green(`  ✓   Tagged ${globalTagName} release upstream.`));
+      } catch (e) {
+        if (isGithubApiError(e) && e.status === 422) {
+          Log.warn(`Warning: Tag ${globalTagName} already exists, skipping tag creation.`);
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    let releaseBody = await releaseNotes.getGithubReleaseEntry();
+    if (releaseBody.length > githubReleaseBodyLimit) {
+      const baseUrl = getFileContentsUrl(this.git, globalTagName, workspaceRelativeChangelogPath);
+      const urlFragment = await releaseNotes.getUrlFragmentForRelease();
+      const releaseNotesUrl = `${baseUrl}#${urlFragment}`;
+      releaseBody =
+        `Release notes are too large to be captured here. ` +
+        `[View all changes here](${releaseNotesUrl}).`;
+    }
+
+    if (this.options.dryRun) {
+      Log.info(`[Dry-Run] Would create GitHub Release for tag: ${globalTagName}`);
+    } else {
+      try {
+        await this.git.github.repos.createRelease({
+          ...this.git.remoteParams,
+          name: globalTagName,
+          tag_name: globalTagName,
+          prerelease: newSemver.prerelease.length > 0,
+          make_latest: npmDistTag === 'latest' ? 'true' : 'false',
+          body: releaseBody,
+        });
+        Log.info(green(`  ✓   Created ${globalTagName} release in Github.`));
+      } catch (e) {
+        if (isGithubApiError(e) && e.status === 422) {
+          Log.warn(
+            `Warning: GitHub release for ${globalTagName} already exists, skipping release creation.`,
+          );
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    if (this.config.release.npmPackages.length > 1) {
+      for (const npmPkg of this.config.release.npmPackages) {
+        const monorepoTagName = `${npmPkg.name}@${newVersion}`;
+        if (this.options.dryRun) {
+          Log.info(`[Dry-Run] Would tag monorepo package: ${monorepoTagName}`);
+        } else {
+          try {
+            await this.git.github.git.createRef({
+              ...this.git.remoteParams,
+              ref: `refs/tags/${monorepoTagName}`,
+              sha: this.options.expectedSha,
+            });
+            Log.info(green(`  ✓   Tagged monorepo package release: ${monorepoTagName}`));
+          } catch (e) {
+            if (isGithubApiError(e) && e.status === 422) {
+              Log.warn(`Warning: Tag ${monorepoTagName} already exists, skipping tag creation.`);
+            } else {
+              throw e;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Publishes the pre-built packages to the NPM registry via Wombat Dressing Room.
+   *
+   * Temporarily configures the local `.npmrc` file to point to the Wombat registry and include
+   * the authenticated `WOMBOT_TOKEN`. After publishing all resolved packages, the original
+   * `.npmrc` is restored (or deleted if it did not exist before).
+   *
+   * @param builtPackages List of built packages to be published.
+   * @param npmDistTag The NPM distribution tag (e.g. 'latest', 'next') to publish under.
+   */
+  private async publishPackagesToNpm(builtPackages: BuiltPackage[], npmDistTag: NpmDistTag) {
+    if (this.options.dryRun) {
+      for (const pkg of builtPackages) {
+        Log.info(`[Dry-Run] Would write .npmrc and publish package: ${pkg.name} to Wombat`);
+      }
+    } else {
+      const npmrcPath = join(this.projectDir, '.npmrc');
+      let originalNpmrc: string | null = null;
+      if (existsSync(npmrcPath)) {
+        originalNpmrc = readFileSync(npmrcPath, 'utf8');
+      }
+
+      try {
+        const wombatNpmrcContent =
+          [
+            `registry=https://wombat-dressing-room.appspot.com/`,
+            `//wombat-dressing-room.appspot.com/:_authToken=\${WOMBOT_TOKEN}`,
+          ].join('\n') + '\n';
+        writeFileSync(npmrcPath, wombatNpmrcContent);
+        Log.info(green(`  ✓   Configured .npmrc to use Wombat registry.`));
+
+        for (const pkg of builtPackages) {
+          Log.info(`Publishing "${pkg.name}"...`);
+          await NpmCommand.publish(
+            pkg.outputPath,
+            npmDistTag,
+            'https://wombat-dressing-room.appspot.com/',
+          );
+          Log.info(green(`  ✓   Successfully published "${pkg.name}".`));
+        }
+      } finally {
+        if (originalNpmrc !== null) {
+          writeFileSync(npmrcPath, originalNpmrc);
+        } else if (existsSync(npmrcPath)) {
+          rmSync(npmrcPath);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Reads and parses the `package.json` file at a specified Git reference.
+ *
+ * @param git The authenticated Git client.
+ * @param ref The Git reference (e.g. branch name, SHA, tag) to read from.
+ * @returns The parsed JSON content of the `package.json` file.
+ */
+function readPackageJsonAtRef(git: AuthenticatedGitClient, ref: string): any {
+  const content = git.run(['show', `${ref}:package.json`]).stdout.trim();
+  return JSON.parse(content);
+}
+
+/**
+ * Recursively searches a directory to find all built packages.
+ *
+ * A directory is considered a built package if it contains a `package.json` file
+ * with a valid `name` property.
+ *
+ * @param dir The root directory to start the search from.
+ * @returns An array of `BuiltPackage` objects containing the name and output path.
+ * @throws {Error} If the specified directory does not exist.
+ */
+function findBuiltPackages(dir: string): BuiltPackage[] {
+  if (!existsSync(dir)) {
+    throw new Error(`The built packages directory does not exist: ${dir}`);
+  }
+  const packages: BuiltPackage[] = [];
+  const walk = (currentDir: string) => {
+    let files: string[];
+    try {
+      files = readdirSync(currentDir);
+    } catch (e) {
+      return;
+    }
+    if (files.includes('package.json')) {
+      try {
+        const pkgJson = JSON.parse(readFileSync(join(currentDir, 'package.json'), 'utf8'));
+        if (pkgJson.name) {
+          packages.push({
+            name: pkgJson.name,
+            outputPath: currentDir,
+          });
+          return;
+        }
+      } catch (e) {
+        // Ignore parsing errors
+      }
+    }
+    for (const file of files) {
+      const fullPath = join(currentDir, file);
+      try {
+        if (statSync(fullPath).isDirectory()) {
+          walk(fullPath);
+        }
+      } catch (e) {
+        // Ignore broken symlinks or unreadable files
+      }
+    }
+  };
+  walk(dir);
+  return packages;
+}
+
+/**
+ * Determines the NPM distribution tag (e.g. 'latest', 'next') for the version being published.
+ *
+ * Checks if the version falls under an active or inactive LTS branch, a pre-release train,
+ * or if it is a new major version that should be published as 'next' temporarily.
+ *
+ * @param newSemver The version being published.
+ * @param config The release configuration.
+ * @param git The authenticated Git client.
+ * @returns The determined NPM distribution tag.
+ */
+async function determineNpmDistTag(
+  newSemver: semver.SemVer,
+  config: ReleaseConfig,
+  git: AuthenticatedGitClient,
+): Promise<NpmDistTag> {
+  const {active: activeLts, inactive: inactiveLts} =
+    await fetchLongTermSupportBranchesFromNpm(config);
+  const ltsBranch = [...activeLts, ...inactiveLts].find((b) => b.version.major === newSemver.major);
+  if (ltsBranch) {
+    return ltsBranch.npmDistTag;
+  }
+
+  const repo = {
+    owner: git.remoteConfig.owner,
+    name: git.remoteConfig.name,
+    api: git.github,
+    nextBranchName: git.mainBranchName,
+  };
+  const activeTrains = await ActiveReleaseTrains.fetch(repo);
+
+  if (newSemver.prerelease.length > 0) {
+    if (
+      activeTrains.exceptionalMinor !== null &&
+      newSemver.major === activeTrains.exceptionalMinor.version.major &&
+      newSemver.minor === activeTrains.exceptionalMinor.version.minor
+    ) {
+      return 'do-not-use-exceptional-minor';
+    }
+    return 'next';
+  }
+
+  if (newSemver.major > activeTrains.latest.version.major) {
+    return 'next';
+  }
+
+  return 'latest';
+}

--- a/ng-dev/release/publish/index-ci.ts
+++ b/ng-dev/release/publish/index-ci.ts
@@ -339,11 +339,7 @@ export class PublishCiTool {
         // Publish packages
         for (const pkg of builtPackages) {
           Log.info(`Publishing "${pkg.name}"...`);
-          await NpmCommand.publish(
-            pkg.outputPath,
-            npmDistTag,
-            'https://wombat-dressing-room.appspot.com/',
-          );
+          await NpmCommand.publish(pkg.outputPath, npmDistTag, undefined);
           Log.info(green(`  ✓   Successfully published "${pkg.name}".`));
         }
 
@@ -354,12 +350,7 @@ export class PublishCiTool {
           }
           Log.info(`Deprecating "${pkg.name}"...`);
           const {version, message} = pkg.deprecated;
-          await NpmCommand.deprecate(
-            pkg.name,
-            version,
-            message,
-            'https://wombat-dressing-room.appspot.com/',
-          );
+          await NpmCommand.deprecate(pkg.name, version, message, undefined);
           Log.info(green(`  ✓   Successfully deprecated "${pkg.name}@${version}".`));
         }
       } finally {

--- a/ng-dev/release/publish/test/publish-ci.spec.ts
+++ b/ng-dev/release/publish/test/publish-ci.spec.ts
@@ -731,16 +731,8 @@ describe('PublishCiTool', () => {
 
       // Verify NpmCommand.publish was called for both packages with correct arguments
       expect(publishSpy).toHaveBeenCalledTimes(2);
-      expect(publishSpy.calls.argsFor(0)).toEqual([
-        pkg1Dir,
-        'latest',
-        'https://wombat-dressing-room.appspot.com/',
-      ]);
-      expect(publishSpy.calls.argsFor(1)).toEqual([
-        pkg2Dir,
-        'latest',
-        'https://wombat-dressing-room.appspot.com/',
-      ]);
+      expect(publishSpy.calls.argsFor(0)).toEqual([pkg1Dir, 'latest', undefined]);
+      expect(publishSpy.calls.argsFor(1)).toEqual([pkg2Dir, 'latest', undefined]);
     });
 
     it('should preserve original NPM_CONFIG_USERCONFIG and leave project .npmrc untouched', async () => {
@@ -887,16 +879,8 @@ describe('PublishCiTool', () => {
 
       // Verify publish was called for both
       expect(publishSpy).toHaveBeenCalledTimes(2);
-      expect(publishSpy.calls.argsFor(0)).toEqual([
-        pkg1Dir,
-        'latest',
-        'https://wombat-dressing-room.appspot.com/',
-      ]);
-      expect(publishSpy.calls.argsFor(1)).toEqual([
-        pkg2Dir,
-        'latest',
-        'https://wombat-dressing-room.appspot.com/',
-      ]);
+      expect(publishSpy.calls.argsFor(0)).toEqual([pkg1Dir, 'latest', undefined]);
+      expect(publishSpy.calls.argsFor(1)).toEqual([pkg2Dir, 'latest', undefined]);
 
       // Verify deprecate was called only for @angular/common
       expect(deprecateSpy).toHaveBeenCalledTimes(1);
@@ -904,7 +888,7 @@ describe('PublishCiTool', () => {
         '@angular/common',
         '>=9.0.0',
         'Use @angular/core instead',
-        'https://wombat-dressing-room.appspot.com/',
+        undefined,
       );
     });
   });

--- a/ng-dev/release/publish/test/publish-ci.spec.ts
+++ b/ng-dev/release/publish/test/publish-ci.spec.ts
@@ -648,7 +648,14 @@ describe('PublishCiTool', () => {
       process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
     });
 
-    it('should temporarily write wombat registry token to .npmrc and clean up afterwards', async () => {
+    it('should temporarily write wombat registry token to a temp .npmrc and clean up afterwards', async () => {
+      const testReleaseConfig = {
+        representativeNpmPackage: '@angular/core',
+        npmPackages: [{name: '@angular/core'}, {name: '@angular/common'}],
+        buildPackages: async () => [],
+      };
+      setConfig({github: githubConfig, release: testReleaseConfig});
+
       fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
       const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
 
@@ -667,14 +674,21 @@ describe('PublishCiTool', () => {
       );
 
       let npmrcContentDuringPublish: string | null = null;
-      publishSpy.and.callFake(async () => {
-        if (fs.existsSync(npmrcPath)) {
-          npmrcContentDuringPublish = fs.readFileSync(npmrcPath, 'utf8');
-        }
-      });
+      let tempNpmrcPath: string | undefined;
+
+      publishSpy.and.callFake(
+        async (pkgPath: string, tag: string, registry: string | undefined, userconfig?: string) => {
+          if (userconfig) {
+            tempNpmrcPath = userconfig;
+            if (fs.existsSync(userconfig)) {
+              npmrcContentDuringPublish = fs.readFileSync(userconfig, 'utf8');
+            }
+          }
+        },
+      );
 
       const tool = new PublishCiTool(
-        {github: githubConfig, release: releaseConfig} as any,
+        {github: githubConfig, release: testReleaseConfig} as any,
         gitClient,
         testTmpDir,
         {
@@ -683,37 +697,34 @@ describe('PublishCiTool', () => {
         },
       );
 
-      // Verify .npmrc does not exist initially
+      // Verify .npmrc does not exist in project dir initially
       expect(fs.existsSync(npmrcPath)).toBe(false);
 
       await expectAsync(tool.run()).toBeResolved();
 
-      // Verify it was correctly configured during publish
-      expect(npmrcContentDuringPublish).toContain(
+      // Verify temp npmrc was created and had correct content
+      expect(tempNpmrcPath).toBeDefined();
+      expect<string | null>(npmrcContentDuringPublish).toContain(
         'registry=https://wombat-dressing-room.appspot.com/',
       );
-      expect(npmrcContentDuringPublish).toContain(
+      expect<string | null>(npmrcContentDuringPublish).toContain(
         '//wombat-dressing-room.appspot.com/:_authToken=${WOMBOT_TOKEN}',
       );
 
-      // Verify that original npmrc is restored (since it did not exist, it should be deleted)
+      // Verify that the temp npmrc file and its directory are deleted
+      expect(fs.existsSync(tempNpmrcPath!)).toBe(false);
+      expect(fs.existsSync(path.dirname(tempNpmrcPath!))).toBe(false);
+
+      // Verify original npmrc was NOT created in project dir
       expect(fs.existsSync(npmrcPath)).toBe(false);
 
       // Verify NpmCommand.publish was called for both packages with correct arguments
       expect(publishSpy).toHaveBeenCalledTimes(2);
-      expect(publishSpy.calls.argsFor(0)).toEqual([
-        pkg1Dir,
-        'latest',
-        'https://wombat-dressing-room.appspot.com/',
-      ]);
-      expect(publishSpy.calls.argsFor(1)).toEqual([
-        pkg2Dir,
-        'latest',
-        'https://wombat-dressing-room.appspot.com/',
-      ]);
+      expect(publishSpy.calls.argsFor(0)).toEqual([pkg1Dir, 'latest', undefined, tempNpmrcPath]);
+      expect(publishSpy.calls.argsFor(1)).toEqual([pkg2Dir, 'latest', undefined, tempNpmrcPath]);
     });
 
-    it('should restore original .npmrc if it existed beforehand', async () => {
+    it('should leave original .npmrc untouched if it existed beforehand', async () => {
       fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
       const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
 
@@ -728,6 +739,13 @@ describe('PublishCiTool', () => {
       const originalNpmrcContent = 'registry=https://my-custom-registry.com/\n';
       fs.writeFileSync(npmrcPath, originalNpmrcContent);
 
+      let originalNpmrcContentDuringPublish: string | null = null;
+      publishSpy.and.callFake(async () => {
+        if (fs.existsSync(npmrcPath)) {
+          originalNpmrcContentDuringPublish = fs.readFileSync(npmrcPath, 'utf8');
+        }
+      });
+
       const tool = new PublishCiTool(
         {github: githubConfig, release: releaseConfig} as any,
         gitClient,
@@ -740,12 +758,15 @@ describe('PublishCiTool', () => {
 
       await expectAsync(tool.run()).toBeResolved();
 
-      // Verify that original npmrc is restored
+      // Verify that original npmrc was not modified during publish
+      expect<string | null>(originalNpmrcContentDuringPublish).toBe(originalNpmrcContent);
+
+      // Verify that original npmrc is still there unchanged
       expect(fs.existsSync(npmrcPath)).toBe(true);
       expect(fs.readFileSync(npmrcPath, 'utf8')).toBe(originalNpmrcContent);
     });
 
-    it('should restore .npmrc even if publishing fails', async () => {
+    it('should leave original .npmrc untouched even if publishing fails', async () => {
       fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
       const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
 
@@ -774,9 +795,71 @@ describe('PublishCiTool', () => {
 
       await expectAsync(tool.run()).toBeRejectedWithError('Npm publish error');
 
-      // Verify that original npmrc is restored
+      // Verify that original npmrc is still there unchanged
       expect(fs.existsSync(npmrcPath)).toBe(true);
       expect(fs.readFileSync(npmrcPath, 'utf8')).toBe(originalNpmrcContent);
+    });
+
+    it('should deprecate packages if configured', async () => {
+      const deprecateSpy = spyOn(NpmCommand, 'deprecate').and.resolveTo();
+
+      const deprecateReleaseConfig = {
+        representativeNpmPackage: '@angular/core',
+        npmPackages: [
+          {name: '@angular/core'},
+          {
+            name: '@angular/common',
+            deprecated: {
+              version: '>=9.0.0',
+              message: 'Use @angular/core instead',
+            },
+          },
+        ],
+        buildPackages: async () => [],
+      };
+      setConfig({github: githubConfig, release: deprecateReleaseConfig});
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.1.0'}));
+      sandbox.commit('v10.1.0 commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const pkg1Dir = path.join(builtPackagesDir, 'pkg1');
+      const pkg2Dir = path.join(builtPackagesDir, 'pkg2');
+      fs.mkdirSync(pkg1Dir, {recursive: true});
+      fs.mkdirSync(pkg2Dir, {recursive: true});
+      fs.writeFileSync(path.join(pkg1Dir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+      fs.writeFileSync(
+        path.join(pkg2Dir, 'package.json'),
+        JSON.stringify({name: '@angular/common'}),
+      );
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: deprecateReleaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      // Verify publish was called for both
+      expect(publishSpy).toHaveBeenCalledTimes(2);
+
+      // Verify deprecate was called only for @angular/common
+      expect(deprecateSpy).toHaveBeenCalledTimes(1);
+      expect(deprecateSpy).toHaveBeenCalledWith(
+        '@angular/common',
+        '>=9.0.0',
+        'Use @angular/core instead',
+        undefined,
+        jasmine.any(String),
+      );
     });
   });
 
@@ -831,7 +914,7 @@ describe('PublishCiTool', () => {
         '[Dry-Run] Would create GitHub Release for tag: v10.1.0',
       );
       expect(logInfoSpy).toHaveBeenCalledWith(
-        '[Dry-Run] Would write .npmrc and publish package: @angular/core to Wombat',
+        '[Dry-Run] Would publish package: @angular/core to Wombat',
       );
     });
 
@@ -890,10 +973,10 @@ describe('PublishCiTool', () => {
         '[Dry-Run] Would tag monorepo package: @angular/common@10.1.0',
       );
       expect(logInfoSpy).toHaveBeenCalledWith(
-        '[Dry-Run] Would write .npmrc and publish package: @angular/core to Wombat',
+        '[Dry-Run] Would publish package: @angular/core to Wombat',
       );
       expect(logInfoSpy).toHaveBeenCalledWith(
-        '[Dry-Run] Would write .npmrc and publish package: @angular/common to Wombat',
+        '[Dry-Run] Would publish package: @angular/common to Wombat',
       );
     });
   });

--- a/ng-dev/release/publish/test/publish-ci.spec.ts
+++ b/ng-dev/release/publish/test/publish-ci.spec.ts
@@ -1,0 +1,900 @@
+/**
+ * @license
+ * Copyright Google LLC
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {PublishCiTool} from '../index-ci.js';
+import {ReleaseConfig} from '../../config/index.js';
+import {GithubConfig, setConfig} from '../../../utils/config.js';
+import {
+  getMockGitClient,
+  installSandboxGitClient,
+  SandboxGitRepo,
+  testTmpDir,
+  runGitInTmpDir,
+} from '../../../utils/testing/index.js';
+import {prepareTempDirectory} from './test-utils/action-mocks.js';
+import {fakeNpmPackageQueryRequest} from './test-utils/test-utils.js';
+import {ReleaseNotes} from '../../notes/release-notes.js';
+import {NpmCommand} from '../../versioning/npm-command.js';
+import {ActiveReleaseTrains} from '../../versioning/active-release-trains.js';
+import {ReleaseTrain} from '../../versioning/release-trains.js';
+import semver from 'semver';
+import * as fs from 'fs';
+import * as path from 'path';
+import {Log} from '../../../utils/logging.js';
+
+class RequestError extends Error {
+  request = {};
+  constructor(
+    message: string,
+    public status: number,
+  ) {
+    super(message);
+    this.name = 'RequestError';
+  }
+}
+
+describe('PublishCiTool', () => {
+  let githubConfig: GithubConfig;
+  let releaseConfig: ReleaseConfig;
+  let gitClient: any;
+  let createRefSpy: jasmine.Spy;
+  let createReleaseSpy: jasmine.Spy;
+  let publishSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    prepareTempDirectory();
+    githubConfig = {
+      mergeMode: 'caretaker-only' as any,
+      owner: 'angular',
+      name: 'angular',
+      mainBranchName: 'main',
+    };
+    releaseConfig = {
+      representativeNpmPackage: '@angular/core',
+      npmPackages: [{name: '@angular/core'}],
+      buildPackages: async () => [],
+    };
+    setConfig({github: githubConfig, release: releaseConfig});
+    gitClient = getMockGitClient(githubConfig, true);
+    installSandboxGitClient(gitClient);
+
+    // Populate NPM package info cache to avoid real fetch calls
+    fakeNpmPackageQueryRequest('@angular/core', {});
+    fakeNpmPackageQueryRequest('@angular/common', {});
+
+    // Mock NpmCommand.publish
+    publishSpy = spyOn(NpmCommand, 'publish').and.resolveTo();
+
+    // Mock GitHub API calls using a plain mock object to avoid Proxy issues
+    createRefSpy = jasmine.createSpy('createRef').and.resolveTo({});
+    createReleaseSpy = jasmine.createSpy('createRelease').and.resolveTo({});
+    const mockGithub = {
+      git: {
+        createRef: createRefSpy,
+      },
+      repos: {
+        createRelease: createReleaseSpy,
+      },
+    };
+    Object.defineProperty(gitClient, 'github', {
+      value: mockGithub,
+      writable: true,
+      configurable: true,
+    });
+
+    // Mock ActiveReleaseTrains.fetch
+    spyOn(ActiveReleaseTrains, 'fetch').and.resolveTo(
+      new ActiveReleaseTrains({
+        exceptionalMinor: null,
+        releaseCandidate: null,
+        next: new ReleaseTrain('main', semver.parse('10.1.0-next.0')!),
+        latest: new ReleaseTrain('10.0.x', semver.parse('10.0.0')!),
+      }),
+    );
+  });
+
+  it('should verify HEAD SHA matches expectedSha', async () => {
+    // Write package.json v10.0.0
+    fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+    const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+    // Get the HEAD SHA of the sandbox repo
+    const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+    const toolWithMismatchedSha = new PublishCiTool(
+      {github: githubConfig, release: releaseConfig} as any,
+      gitClient,
+      testTmpDir,
+      {
+        builtPackagesDir: path.join(testTmpDir, 'dist'),
+        expectedSha: 'incorrect-sha-12345',
+        dryRun: true,
+      },
+    );
+
+    await expectAsync(toolWithMismatchedSha.run()).toBeRejectedWithError(
+      `Expected HEAD SHA to be incorrect-sha-12345, but got ${headSha}.`,
+    );
+
+    const toolWithCorrectSha = new PublishCiTool(
+      {github: githubConfig, release: releaseConfig} as any,
+      gitClient,
+      testTmpDir,
+      {
+        builtPackagesDir: path.join(testTmpDir, 'dist'),
+        expectedSha: headSha,
+      },
+    );
+
+    // Mock ReleaseNotes.forRange and other dependencies so it runs successfully
+    const releaseNotesSpy = spyOn(ReleaseNotes, 'forRange').and.resolveTo({
+      getGithubReleaseEntry: async () => 'release notes body',
+      getUrlFragmentForRelease: async () => 'url-frag',
+    } as any);
+
+    // Prepare dummy built package output
+    const builtPackagesDir = path.join(testTmpDir, 'dist');
+    const pkgDir = path.join(builtPackagesDir, 'pkg1');
+    fs.mkdirSync(pkgDir, {recursive: true});
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+
+    process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
+
+    await expectAsync(toolWithCorrectSha.run()).toBeResolved();
+  });
+
+  describe('fail-fast validation', () => {
+    let originalWombotToken: string | undefined;
+
+    beforeEach(() => {
+      originalWombotToken = process.env['WOMBOT_TOKEN'];
+      delete process.env['WOMBOT_TOKEN'];
+    });
+
+    afterEach(() => {
+      if (originalWombotToken !== undefined) {
+        process.env['WOMBOT_TOKEN'] = originalWombotToken;
+      } else {
+        delete process.env['WOMBOT_TOKEN'];
+      }
+    });
+
+    it('should throw if WOMBOT_TOKEN is missing (dryRun: false) and not call GitHub API', async () => {
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir: path.join(testTmpDir, 'dist'),
+          expectedSha: headSha,
+          dryRun: false,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeRejectedWithError(
+        'WOMBOT_TOKEN environment variable is not defined.',
+      );
+
+      expect(createRefSpy).not.toHaveBeenCalled();
+      expect(createReleaseSpy).not.toHaveBeenCalled();
+    });
+
+    it('should NOT throw if WOMBOT_TOKEN is missing when dryRun is true', async () => {
+      spyOn(ReleaseNotes, 'forRange').and.resolveTo({
+        getGithubReleaseEntry: async () => 'release notes body',
+        getUrlFragmentForRelease: async () => 'url-frag',
+      } as any);
+
+      const builtPackagesDir = path.join(testTmpDir, 'dist');
+      const pkgDir = path.join(builtPackagesDir, 'pkg1');
+      fs.mkdirSync(pkgDir, {recursive: true});
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir: builtPackagesDir,
+          expectedSha: headSha,
+          dryRun: true,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+    });
+
+    it('should throw if built packages directory does not exist and not call GitHub API', async () => {
+      process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const nonExistentDir = path.join(testTmpDir, 'non-existent-dist');
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir: nonExistentDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeRejectedWithError(
+        `The built packages directory does not exist: ${nonExistentDir}`,
+      );
+
+      expect(createRefSpy).not.toHaveBeenCalled();
+      expect(createReleaseSpy).not.toHaveBeenCalled();
+    });
+
+    it('should throw if no built packages are found and not call GitHub API', async () => {
+      process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const emptyDir = path.join(testTmpDir, 'empty-dist');
+      fs.mkdirSync(emptyDir, {recursive: true});
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir: emptyDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeRejectedWithError(
+        `No built packages found under directory ${emptyDir}`,
+      );
+
+      expect(createRefSpy).not.toHaveBeenCalled();
+      expect(createReleaseSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('git graph traversal (beforeStagingSha)', () => {
+    let releaseNotesSpy: jasmine.Spy;
+    let builtPackagesDir: string;
+
+    beforeEach(() => {
+      releaseNotesSpy = spyOn(ReleaseNotes, 'forRange').and.resolveTo({
+        getGithubReleaseEntry: async () => 'release notes body',
+        getUrlFragmentForRelease: async () => 'url-frag',
+      } as any);
+
+      builtPackagesDir = path.join(testTmpDir, 'dist');
+      const pkgDir = path.join(builtPackagesDir, 'pkg1');
+      fs.mkdirSync(pkgDir, {recursive: true});
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+
+      process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
+    });
+
+    it('should resolve beforeStagingSha for standard merge commit', async () => {
+      // 1. Initial commit (v10.0.0)
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+      const mainParentSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      // 2. Tag v10.0.0
+      sandbox.createTagForHead('v10.0.0');
+
+      // 3. Create branch `staging-branch`
+      sandbox.branchOff('staging-branch');
+
+      // 4. On `staging-branch`, make commit bumping version to 10.1.0-next.0 and update CHANGELOG.md
+      fs.writeFileSync(
+        path.join(testTmpDir, 'package.json'),
+        JSON.stringify({version: '10.1.0-next.0'}),
+      );
+      fs.writeFileSync(path.join(testTmpDir, 'CHANGELOG.md'), 'changelog contents');
+      sandbox.commit('release: bump version to 10.1.0-next.0');
+
+      // 5. Switch back to main branch
+      sandbox.switchToBranch('main');
+
+      // 6. Merge staging-branch into main with a merge commit
+      runGitInTmpDir(['merge', 'staging-branch', '--no-ff', '-m', 'Merge branch staging-branch']);
+      const mergeCommitSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: mergeCommitSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      // Assert that ReleaseNotes.forRange was called with beforeStagingSha as baseRef
+      expect(releaseNotesSpy).toHaveBeenCalledTimes(1);
+      const args = releaseNotesSpy.calls.mostRecent().args;
+      expect(args[1]).toEqual(semver.parse('10.1.0-next.0')!); // newVersion
+      expect(args[2]).toBe('v10.0.0'); // previousVersionTag
+      expect(args[3]).toBe(mainParentSha); // beforeStagingSha
+    });
+
+    it('should resolve beforeStagingSha for squash/rebase commit', async () => {
+      // 1. Initial commit (v10.0.0)
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+      const initialCommitSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      // 2. Create single commit bumping version to 10.1.0-next.0
+      fs.writeFileSync(
+        path.join(testTmpDir, 'package.json'),
+        JSON.stringify({version: '10.1.0-next.0'}),
+      );
+      sandbox.commit('release: bump version to 10.1.0-next.0');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      expect(releaseNotesSpy).toHaveBeenCalledTimes(1);
+      const args = releaseNotesSpy.calls.mostRecent().args;
+      expect(args[1]).toEqual(semver.parse('10.1.0-next.0')!); // newVersion
+      expect(args[2]).toBe('v10.0.0'); // previousVersionTag
+      expect(args[3]).toBe(initialCommitSha); // beforeStagingSha
+    });
+  });
+
+  describe('previousVersionTag resolution', () => {
+    let releaseNotesSpy: jasmine.Spy;
+    let builtPackagesDir: string;
+
+    beforeEach(() => {
+      releaseNotesSpy = spyOn(ReleaseNotes, 'forRange').and.resolveTo({
+        getGithubReleaseEntry: async () => 'release notes body',
+        getUrlFragmentForRelease: async () => 'url-frag',
+      } as any);
+
+      builtPackagesDir = path.join(testTmpDir, 'dist');
+      const pkgDir = path.join(builtPackagesDir, 'pkg1');
+      fs.mkdirSync(pkgDir, {recursive: true});
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+
+      process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
+    });
+
+    it('should resolve highest stable tag when transitioning from prerelease to stable', async () => {
+      // 1. Create tags v9.0.0, v10.0.0, v10.1.0-rc.0 pointing to different commits
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '9.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+      sandbox.createTagForHead('v9.0.0');
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      sandbox.commit('v10.0.0 commit');
+      sandbox.createTagForHead('v10.0.0');
+
+      fs.writeFileSync(
+        path.join(testTmpDir, 'package.json'),
+        JSON.stringify({version: '10.1.0-rc.0'}),
+      );
+      sandbox.commit('v10.1.0-rc.0 commit');
+      sandbox.createTagForHead('v10.1.0-rc.0');
+
+      // 2. Set version at HEAD to 10.1.0 (stable)
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.1.0'}));
+      sandbox.commit('v10.1.0 stable commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      expect(releaseNotesSpy).toHaveBeenCalledTimes(1);
+      const args = releaseNotesSpy.calls.mostRecent().args;
+      expect(args[2]).toBe('v10.0.0'); // previousVersionTag (should skip v10.1.0-rc.0 because it's prerelease)
+    });
+
+    it('should resolve previous prerelease tag when incrementing prerelease', async () => {
+      // 1. Set version at beforeStagingSha to 10.1.0-next.0
+      fs.writeFileSync(
+        path.join(testTmpDir, 'package.json'),
+        JSON.stringify({version: '10.1.0-next.0'}),
+      );
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+      // 2. Set version at HEAD to 10.1.0-next.1
+      fs.writeFileSync(
+        path.join(testTmpDir, 'package.json'),
+        JSON.stringify({version: '10.1.0-next.1'}),
+      );
+      sandbox.commit('v10.1.0-next.1 commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      expect(releaseNotesSpy).toHaveBeenCalledTimes(1);
+      const args = releaseNotesSpy.calls.mostRecent().args;
+      expect(args[2]).toBe('v10.1.0-next.0'); // previousVersionTag
+    });
+  });
+
+  describe('GitHub release and tag creation (idempotency)', () => {
+    let releaseNotesSpy: jasmine.Spy;
+    let builtPackagesDir: string;
+
+    beforeEach(() => {
+      releaseNotesSpy = spyOn(ReleaseNotes, 'forRange').and.resolveTo({
+        getGithubReleaseEntry: async () => 'release notes body',
+        getUrlFragmentForRelease: async () => 'url-frag',
+      } as any);
+
+      builtPackagesDir = path.join(testTmpDir, 'dist');
+      const pkgDir = path.join(builtPackagesDir, 'pkg1');
+      fs.mkdirSync(pkgDir, {recursive: true});
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+
+      process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
+    });
+
+    it('should create tags and releases with correct arguments', async () => {
+      fs.writeFileSync(
+        path.join(testTmpDir, 'package.json'),
+        JSON.stringify({version: '10.1.0-next.0'}),
+      );
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+      fs.writeFileSync(
+        path.join(testTmpDir, 'package.json'),
+        JSON.stringify({version: '10.1.0-next.1'}),
+      );
+      sandbox.commit('v10.1.0-next.1 commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      expect(createRefSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          ref: 'refs/tags/v10.1.0-next.1',
+          sha: headSha,
+        }),
+      );
+      expect(createReleaseSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({
+          name: 'v10.1.0-next.1',
+          tag_name: 'v10.1.0-next.1',
+          prerelease: true,
+          make_latest: 'false',
+          body: 'release notes body',
+        }),
+      );
+    });
+
+    it('should proceed to publish even if tag or release already exists', async () => {
+      fs.writeFileSync(
+        path.join(testTmpDir, 'package.json'),
+        JSON.stringify({version: '10.1.0-next.0'}),
+      );
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+      fs.writeFileSync(
+        path.join(testTmpDir, 'package.json'),
+        JSON.stringify({version: '10.1.0-next.1'}),
+      );
+      sandbox.commit('v10.1.0-next.1 commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      createRefSpy.and.rejectWith(new RequestError('Reference already exists', 422));
+      createReleaseSpy.and.rejectWith(new RequestError('Release already exists', 422));
+
+      const warnSpy = spyOn(Log, 'warn');
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching('Tag v10.1.0-next.1 already exists, skipping tag creation.'),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(
+          'GitHub release for v10.1.0-next.1 already exists, skipping release creation.',
+        ),
+      );
+      expect(publishSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('should create monorepo tags if there are multiple npm packages configured', async () => {
+    const monorepoReleaseConfig = {
+      representativeNpmPackage: '@angular/core',
+      npmPackages: [{name: '@angular/core'}, {name: '@angular/common'}],
+      buildPackages: async () => [],
+    };
+    setConfig({github: githubConfig, release: monorepoReleaseConfig});
+
+    fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+    const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+    fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.1.0'}));
+    sandbox.commit('v10.1.0 commit');
+    const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+    spyOn(ReleaseNotes, 'forRange').and.resolveTo({
+      getGithubReleaseEntry: async () => 'release notes body',
+      getUrlFragmentForRelease: async () => 'url-frag',
+    } as any);
+
+    const builtPackagesDir = path.join(testTmpDir, 'dist');
+    // We need to create mock directories for both packages so findBuiltPackages works
+    const pkg1Dir = path.join(builtPackagesDir, 'pkg1');
+    const pkg2Dir = path.join(builtPackagesDir, 'pkg2');
+    fs.mkdirSync(pkg1Dir, {recursive: true});
+    fs.mkdirSync(pkg2Dir, {recursive: true});
+    fs.writeFileSync(path.join(pkg1Dir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+    fs.writeFileSync(path.join(pkg2Dir, 'package.json'), JSON.stringify({name: '@angular/common'}));
+
+    process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
+
+    const tool = new PublishCiTool(
+      {github: githubConfig, release: monorepoReleaseConfig} as any,
+      gitClient,
+      testTmpDir,
+      {
+        builtPackagesDir,
+        expectedSha: headSha,
+      },
+    );
+
+    await expectAsync(tool.run()).toBeResolved();
+
+    expect(createRefSpy).toHaveBeenCalledTimes(3);
+    expect(createRefSpy.calls.argsFor(0)[0]).toEqual(
+      jasmine.objectContaining({
+        ref: 'refs/tags/v10.1.0',
+        sha: headSha,
+      }),
+    );
+    expect(createRefSpy.calls.argsFor(1)[0]).toEqual(
+      jasmine.objectContaining({
+        ref: 'refs/tags/@angular/core@10.1.0',
+        sha: headSha,
+      }),
+    );
+    expect(createRefSpy.calls.argsFor(2)[0]).toEqual(
+      jasmine.objectContaining({
+        ref: 'refs/tags/@angular/common@10.1.0',
+        sha: headSha,
+      }),
+    );
+  });
+
+  describe('NPM publishing & Wombat registry setup', () => {
+    let releaseNotesSpy: jasmine.Spy;
+    let builtPackagesDir: string;
+    let npmrcPath: string;
+
+    beforeEach(() => {
+      releaseNotesSpy = spyOn(ReleaseNotes, 'forRange').and.resolveTo({
+        getGithubReleaseEntry: async () => 'release notes body',
+        getUrlFragmentForRelease: async () => 'url-frag',
+      } as any);
+
+      builtPackagesDir = path.join(testTmpDir, 'dist');
+      npmrcPath = path.join(testTmpDir, '.npmrc');
+
+      process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
+    });
+
+    it('should temporarily write wombat registry token to .npmrc and clean up afterwards', async () => {
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.1.0'}));
+      sandbox.commit('v10.1.0 commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const pkg1Dir = path.join(builtPackagesDir, 'pkg1');
+      const pkg2Dir = path.join(builtPackagesDir, 'pkg2');
+      fs.mkdirSync(pkg1Dir, {recursive: true});
+      fs.mkdirSync(pkg2Dir, {recursive: true});
+      fs.writeFileSync(path.join(pkg1Dir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+      fs.writeFileSync(
+        path.join(pkg2Dir, 'package.json'),
+        JSON.stringify({name: '@angular/common'}),
+      );
+
+      let npmrcContentDuringPublish: string | null = null;
+      publishSpy.and.callFake(async () => {
+        if (fs.existsSync(npmrcPath)) {
+          npmrcContentDuringPublish = fs.readFileSync(npmrcPath, 'utf8');
+        }
+      });
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+        },
+      );
+
+      // Verify .npmrc does not exist initially
+      expect(fs.existsSync(npmrcPath)).toBe(false);
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      // Verify it was correctly configured during publish
+      expect(npmrcContentDuringPublish).toContain(
+        'registry=https://wombat-dressing-room.appspot.com/',
+      );
+      expect(npmrcContentDuringPublish).toContain(
+        '//wombat-dressing-room.appspot.com/:_authToken=${WOMBOT_TOKEN}',
+      );
+
+      // Verify that original npmrc is restored (since it did not exist, it should be deleted)
+      expect(fs.existsSync(npmrcPath)).toBe(false);
+
+      // Verify NpmCommand.publish was called for both packages with correct arguments
+      expect(publishSpy).toHaveBeenCalledTimes(2);
+      expect(publishSpy.calls.argsFor(0)).toEqual([
+        pkg1Dir,
+        'latest',
+        'https://wombat-dressing-room.appspot.com/',
+      ]);
+      expect(publishSpy.calls.argsFor(1)).toEqual([
+        pkg2Dir,
+        'latest',
+        'https://wombat-dressing-room.appspot.com/',
+      ]);
+    });
+
+    it('should restore original .npmrc if it existed beforehand', async () => {
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.1.0'}));
+      sandbox.commit('v10.1.0 commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const pkg1Dir = path.join(builtPackagesDir, 'pkg1');
+      fs.mkdirSync(pkg1Dir, {recursive: true});
+      fs.writeFileSync(path.join(pkg1Dir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+
+      const originalNpmrcContent = 'registry=https://my-custom-registry.com/\n';
+      fs.writeFileSync(npmrcPath, originalNpmrcContent);
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      // Verify that original npmrc is restored
+      expect(fs.existsSync(npmrcPath)).toBe(true);
+      expect(fs.readFileSync(npmrcPath, 'utf8')).toBe(originalNpmrcContent);
+    });
+
+    it('should restore .npmrc even if publishing fails', async () => {
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.1.0'}));
+      sandbox.commit('v10.1.0 commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const pkg1Dir = path.join(builtPackagesDir, 'pkg1');
+      fs.mkdirSync(pkg1Dir, {recursive: true});
+      fs.writeFileSync(path.join(pkg1Dir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+
+      const originalNpmrcContent = 'registry=https://my-custom-registry.com/\n';
+      fs.writeFileSync(npmrcPath, originalNpmrcContent);
+
+      publishSpy.and.rejectWith(new Error('Npm publish error'));
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeRejectedWithError('Npm publish error');
+
+      // Verify that original npmrc is restored
+      expect(fs.existsSync(npmrcPath)).toBe(true);
+      expect(fs.readFileSync(npmrcPath, 'utf8')).toBe(originalNpmrcContent);
+    });
+  });
+
+  describe('dry-run mode', () => {
+    let releaseNotesSpy: jasmine.Spy;
+    let builtPackagesDir: string;
+    let logInfoSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      releaseNotesSpy = spyOn(ReleaseNotes, 'forRange').and.resolveTo({
+        getGithubReleaseEntry: async () => 'release notes body',
+        getUrlFragmentForRelease: async () => 'url-frag',
+      } as any);
+
+      builtPackagesDir = path.join(testTmpDir, 'dist');
+      const pkgDir = path.join(builtPackagesDir, 'pkg1');
+      fs.mkdirSync(pkgDir, {recursive: true});
+      fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+
+      logInfoSpy = spyOn(Log, 'info');
+    });
+
+    it('should skip API calls and log dry-run actions', async () => {
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.1.0'}));
+      sandbox.commit('v10.1.0 commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: releaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+          dryRun: true,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      // Verify no external actions were performed
+      expect(createRefSpy).not.toHaveBeenCalled();
+      expect(createReleaseSpy).not.toHaveBeenCalled();
+      expect(publishSpy).not.toHaveBeenCalled();
+
+      // Verify dry-run logs
+      expect(logInfoSpy).toHaveBeenCalledWith('[Dry-Run] Would tag global tag: v10.1.0');
+      expect(logInfoSpy).toHaveBeenCalledWith(
+        '[Dry-Run] Would create GitHub Release for tag: v10.1.0',
+      );
+      expect(logInfoSpy).toHaveBeenCalledWith(
+        '[Dry-Run] Would write .npmrc and publish package: @angular/core to Wombat',
+      );
+    });
+
+    it('should skip monorepo tag creation and log dry-run actions', async () => {
+      const monorepoReleaseConfig = {
+        representativeNpmPackage: '@angular/core',
+        npmPackages: [{name: '@angular/core'}, {name: '@angular/common'}],
+        buildPackages: async () => [],
+      };
+      setConfig({github: githubConfig, release: monorepoReleaseConfig});
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
+      const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
+
+      fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.1.0'}));
+      sandbox.commit('v10.1.0 commit');
+      const headSha = gitClient.run(['rev-parse', 'HEAD']).stdout.trim();
+
+      const pkg1Dir = path.join(builtPackagesDir, 'pkg1');
+      const pkg2Dir = path.join(builtPackagesDir, 'pkg2');
+      fs.mkdirSync(pkg1Dir, {recursive: true});
+      fs.mkdirSync(pkg2Dir, {recursive: true});
+      fs.writeFileSync(path.join(pkg1Dir, 'package.json'), JSON.stringify({name: '@angular/core'}));
+      fs.writeFileSync(
+        path.join(pkg2Dir, 'package.json'),
+        JSON.stringify({name: '@angular/common'}),
+      );
+
+      const tool = new PublishCiTool(
+        {github: githubConfig, release: monorepoReleaseConfig} as any,
+        gitClient,
+        testTmpDir,
+        {
+          builtPackagesDir,
+          expectedSha: headSha,
+          dryRun: true,
+        },
+      );
+
+      await expectAsync(tool.run()).toBeResolved();
+
+      // Verify no external actions were performed
+      expect(createRefSpy).not.toHaveBeenCalled();
+      expect(createReleaseSpy).not.toHaveBeenCalled();
+      expect(publishSpy).not.toHaveBeenCalled();
+
+      // Verify dry-run logs
+      expect(logInfoSpy).toHaveBeenCalledWith('[Dry-Run] Would tag global tag: v10.1.0');
+      expect(logInfoSpy).toHaveBeenCalledWith(
+        '[Dry-Run] Would create GitHub Release for tag: v10.1.0',
+      );
+      expect(logInfoSpy).toHaveBeenCalledWith(
+        '[Dry-Run] Would tag monorepo package: @angular/core@10.1.0',
+      );
+      expect(logInfoSpy).toHaveBeenCalledWith(
+        '[Dry-Run] Would tag monorepo package: @angular/common@10.1.0',
+      );
+      expect(logInfoSpy).toHaveBeenCalledWith(
+        '[Dry-Run] Would write .npmrc and publish package: @angular/core to Wombat',
+      );
+      expect(logInfoSpy).toHaveBeenCalledWith(
+        '[Dry-Run] Would write .npmrc and publish package: @angular/common to Wombat',
+      );
+    });
+  });
+});

--- a/ng-dev/release/publish/test/publish-ci.spec.ts
+++ b/ng-dev/release/publish/test/publish-ci.spec.ts
@@ -635,6 +635,7 @@ describe('PublishCiTool', () => {
     let releaseNotesSpy: jasmine.Spy;
     let builtPackagesDir: string;
     let npmrcPath: string;
+    let originalNpmConfigUserconfig: string | undefined;
 
     beforeEach(() => {
       releaseNotesSpy = spyOn(ReleaseNotes, 'forRange').and.resolveTo({
@@ -646,6 +647,17 @@ describe('PublishCiTool', () => {
       npmrcPath = path.join(testTmpDir, '.npmrc');
 
       process.env['WOMBOT_TOKEN'] = 'mock-wombat-token';
+
+      originalNpmConfigUserconfig = process.env['NPM_CONFIG_USERCONFIG'];
+      delete process.env['NPM_CONFIG_USERCONFIG'];
+    });
+
+    afterEach(() => {
+      if (originalNpmConfigUserconfig !== undefined) {
+        process.env['NPM_CONFIG_USERCONFIG'] = originalNpmConfigUserconfig;
+      } else {
+        delete process.env['NPM_CONFIG_USERCONFIG'];
+      }
     });
 
     it('should temporarily write wombat registry token to a temp .npmrc and clean up afterwards', async () => {
@@ -675,17 +687,12 @@ describe('PublishCiTool', () => {
 
       let npmrcContentDuringPublish: string | null = null;
       let tempNpmrcPath: string | undefined;
-
-      publishSpy.and.callFake(
-        async (pkgPath: string, tag: string, registry: string | undefined, userconfig?: string) => {
-          if (userconfig) {
-            tempNpmrcPath = userconfig;
-            if (fs.existsSync(userconfig)) {
-              npmrcContentDuringPublish = fs.readFileSync(userconfig, 'utf8');
-            }
-          }
-        },
-      );
+      publishSpy.and.callFake(async () => {
+        tempNpmrcPath = process.env['NPM_CONFIG_USERCONFIG'];
+        if (tempNpmrcPath && fs.existsSync(tempNpmrcPath)) {
+          npmrcContentDuringPublish = fs.readFileSync(tempNpmrcPath, 'utf8');
+        }
+      });
 
       const tool = new PublishCiTool(
         {github: githubConfig, release: testReleaseConfig} as any,
@@ -697,8 +704,9 @@ describe('PublishCiTool', () => {
         },
       );
 
-      // Verify .npmrc does not exist in project dir initially
+      // Verify .npmrc does not exist initially in project dir
       expect(fs.existsSync(npmrcPath)).toBe(false);
+      expect(process.env['NPM_CONFIG_USERCONFIG']).toBeUndefined();
 
       await expectAsync(tool.run()).toBeResolved();
 
@@ -715,16 +723,27 @@ describe('PublishCiTool', () => {
       expect(fs.existsSync(tempNpmrcPath!)).toBe(false);
       expect(fs.existsSync(path.dirname(tempNpmrcPath!))).toBe(false);
 
-      // Verify original npmrc was NOT created in project dir
+      // Verify project .npmrc was NOT created
       expect(fs.existsSync(npmrcPath)).toBe(false);
+
+      // Verify env var was cleaned up
+      expect(process.env['NPM_CONFIG_USERCONFIG']).toBeUndefined();
 
       // Verify NpmCommand.publish was called for both packages with correct arguments
       expect(publishSpy).toHaveBeenCalledTimes(2);
-      expect(publishSpy.calls.argsFor(0)).toEqual([pkg1Dir, 'latest', undefined, tempNpmrcPath]);
-      expect(publishSpy.calls.argsFor(1)).toEqual([pkg2Dir, 'latest', undefined, tempNpmrcPath]);
+      expect(publishSpy.calls.argsFor(0)).toEqual([
+        pkg1Dir,
+        'latest',
+        'https://wombat-dressing-room.appspot.com/',
+      ]);
+      expect(publishSpy.calls.argsFor(1)).toEqual([
+        pkg2Dir,
+        'latest',
+        'https://wombat-dressing-room.appspot.com/',
+      ]);
     });
 
-    it('should leave original .npmrc untouched if it existed beforehand', async () => {
+    it('should preserve original NPM_CONFIG_USERCONFIG and leave project .npmrc untouched', async () => {
       fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
       const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
 
@@ -739,10 +758,15 @@ describe('PublishCiTool', () => {
       const originalNpmrcContent = 'registry=https://my-custom-registry.com/\n';
       fs.writeFileSync(npmrcPath, originalNpmrcContent);
 
-      let originalNpmrcContentDuringPublish: string | null = null;
+      const originalUserconfig = 'original-userconfig-path';
+      process.env['NPM_CONFIG_USERCONFIG'] = originalUserconfig;
+
+      let tempNpmrcPath: string | undefined;
+      let npmrcContentDuringPublish: string | null = null;
       publishSpy.and.callFake(async () => {
-        if (fs.existsSync(npmrcPath)) {
-          originalNpmrcContentDuringPublish = fs.readFileSync(npmrcPath, 'utf8');
+        tempNpmrcPath = process.env['NPM_CONFIG_USERCONFIG'];
+        if (tempNpmrcPath && fs.existsSync(tempNpmrcPath)) {
+          npmrcContentDuringPublish = fs.readFileSync(tempNpmrcPath, 'utf8');
         }
       });
 
@@ -758,15 +782,22 @@ describe('PublishCiTool', () => {
 
       await expectAsync(tool.run()).toBeResolved();
 
-      // Verify that original npmrc was not modified during publish
-      expect<string | null>(originalNpmrcContentDuringPublish).toBe(originalNpmrcContent);
+      // Verify that temp npmrc was used and configured correctly
+      expect(tempNpmrcPath).toBeDefined();
+      expect(tempNpmrcPath).not.toBe(originalUserconfig);
+      expect<string | null>(npmrcContentDuringPublish).toContain(
+        'registry=https://wombat-dressing-room.appspot.com/',
+      );
 
-      // Verify that original npmrc is still there unchanged
+      // Verify that original project .npmrc is completely untouched
       expect(fs.existsSync(npmrcPath)).toBe(true);
       expect(fs.readFileSync(npmrcPath, 'utf8')).toBe(originalNpmrcContent);
+
+      // Verify that original NPM_CONFIG_USERCONFIG is restored
+      expect(process.env['NPM_CONFIG_USERCONFIG']).toBe(originalUserconfig);
     });
 
-    it('should leave original .npmrc untouched even if publishing fails', async () => {
+    it('should restore NPM_CONFIG_USERCONFIG even if publishing fails', async () => {
       fs.writeFileSync(path.join(testTmpDir, 'package.json'), JSON.stringify({version: '10.0.0'}));
       const sandbox = SandboxGitRepo.withInitialCommit(githubConfig);
 
@@ -780,6 +811,9 @@ describe('PublishCiTool', () => {
 
       const originalNpmrcContent = 'registry=https://my-custom-registry.com/\n';
       fs.writeFileSync(npmrcPath, originalNpmrcContent);
+
+      const originalUserconfig = 'original-userconfig-path';
+      process.env['NPM_CONFIG_USERCONFIG'] = originalUserconfig;
 
       publishSpy.and.rejectWith(new Error('Npm publish error'));
 
@@ -795,9 +829,12 @@ describe('PublishCiTool', () => {
 
       await expectAsync(tool.run()).toBeRejectedWithError('Npm publish error');
 
-      // Verify that original npmrc is still there unchanged
+      // Verify that original project .npmrc is untouched
       expect(fs.existsSync(npmrcPath)).toBe(true);
       expect(fs.readFileSync(npmrcPath, 'utf8')).toBe(originalNpmrcContent);
+
+      // Verify that original NPM_CONFIG_USERCONFIG is restored
+      expect(process.env['NPM_CONFIG_USERCONFIG']).toBe(originalUserconfig);
     });
 
     it('should deprecate packages if configured', async () => {
@@ -850,6 +887,16 @@ describe('PublishCiTool', () => {
 
       // Verify publish was called for both
       expect(publishSpy).toHaveBeenCalledTimes(2);
+      expect(publishSpy.calls.argsFor(0)).toEqual([
+        pkg1Dir,
+        'latest',
+        'https://wombat-dressing-room.appspot.com/',
+      ]);
+      expect(publishSpy.calls.argsFor(1)).toEqual([
+        pkg2Dir,
+        'latest',
+        'https://wombat-dressing-room.appspot.com/',
+      ]);
 
       // Verify deprecate was called only for @angular/common
       expect(deprecateSpy).toHaveBeenCalledTimes(1);
@@ -857,8 +904,7 @@ describe('PublishCiTool', () => {
         '@angular/common',
         '>=9.0.0',
         'Use @angular/core instead',
-        undefined,
-        jasmine.any(String),
+        'https://wombat-dressing-room.appspot.com/',
       );
     });
   });

--- a/ng-dev/release/versioning/npm-command.ts
+++ b/ng-dev/release/versioning/npm-command.ts
@@ -18,19 +18,11 @@ export abstract class NpmCommand {
    * Runs NPM publish within a specified package directory.
    * @throws With the process log output if the publish failed.
    */
-  static async publish(
-    packagePath: string,
-    distTag: NpmDistTag,
-    registryUrl: string | undefined,
-    userconfig?: string,
-  ) {
+  static async publish(packagePath: string, distTag: NpmDistTag, registryUrl: string | undefined) {
     const args = ['publish', '--access', 'public', '--tag', distTag];
     // If a custom registry URL has been specified, add the `--registry` flag.
     if (registryUrl !== undefined) {
       args.push('--registry', registryUrl);
-    }
-    if (userconfig !== undefined) {
-      args.push('--userconfig', userconfig);
     }
     await ChildProcess.spawn('npm', args, {cwd: packagePath, mode: 'silent'});
   }
@@ -48,16 +40,12 @@ export abstract class NpmCommand {
     version: string,
     message: string,
     registryUrl: string | undefined,
-    userconfig?: string,
   ) {
     const args = ['deprecate', `${packageName}@${version}`, message];
 
     // If a custom registry URL has been specified, add the `--registry` flag.
     if (registryUrl !== undefined) {
       args.push('--registry', registryUrl);
-    }
-    if (userconfig !== undefined) {
-      args.push('--userconfig', userconfig);
     }
 
     try {

--- a/ng-dev/release/versioning/npm-command.ts
+++ b/ng-dev/release/versioning/npm-command.ts
@@ -18,11 +18,19 @@ export abstract class NpmCommand {
    * Runs NPM publish within a specified package directory.
    * @throws With the process log output if the publish failed.
    */
-  static async publish(packagePath: string, distTag: NpmDistTag, registryUrl: string | undefined) {
+  static async publish(
+    packagePath: string,
+    distTag: NpmDistTag,
+    registryUrl: string | undefined,
+    userconfig?: string,
+  ) {
     const args = ['publish', '--access', 'public', '--tag', distTag];
     // If a custom registry URL has been specified, add the `--registry` flag.
     if (registryUrl !== undefined) {
       args.push('--registry', registryUrl);
+    }
+    if (userconfig !== undefined) {
+      args.push('--userconfig', userconfig);
     }
     await ChildProcess.spawn('npm', args, {cwd: packagePath, mode: 'silent'});
   }
@@ -40,12 +48,16 @@ export abstract class NpmCommand {
     version: string,
     message: string,
     registryUrl: string | undefined,
+    userconfig?: string,
   ) {
     const args = ['deprecate', `${packageName}@${version}`, message];
 
     // If a custom registry URL has been specified, add the `--registry` flag.
     if (registryUrl !== undefined) {
       args.push('--registry', registryUrl);
+    }
+    if (userconfig !== undefined) {
+      args.push('--userconfig', userconfig);
     }
 
     try {


### PR DESCRIPTION
This PR implements the publish-ci command for CI-driven publishing, including monorepo-style tagging support and full unit tests. Stacked on top of the staging CLI changes.