### PR TITLE
feat(renovate-presets): group esbuild and esbuild-wasm dependencies in renovate configuration

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -67,6 +67,12 @@
       dependencyDashboardApproval: true,
     },
 
+    // Esbuild packages should be kept in sync.
+    {
+      groupName: 'esbuild dependencies',
+      matchPackageNames: ['esbuild', 'esbuild-wasm'],
+    },
+
     // Jasmine packages should be kept in sync.
     {
       groupName: 'jasmine dependencies',


### PR DESCRIPTION

Always update this 2 packages together.