### PR TITLE
build(github-actions): pin external actions to SHAs in reusable-release

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Step 2: Checkout dev-infra dynamically at the same ref to get the custom actions
       - name: Checkout dev-infra
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: angular/dev-infra
           ref: ${{ steps.get-ref.outputs.ref }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Archive built packages
         if: steps.check-commit.outputs.is-release == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-packages
           path: dist/packages-dist/
@@ -121,7 +121,7 @@ jobs:
     steps:
       # Step 1: Checkout dev-infra dynamically at the same ref to get the custom actions
       - name: Checkout dev-infra
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: angular/dev-infra
           ref: ${{ needs.build.outputs.dev-infra-ref }}
@@ -134,7 +134,7 @@ jobs:
           clean: false
 
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-packages
           path: dist/packages-dist/


### PR DESCRIPTION
Migrates reusable-release.yml to use actions/checkout, actions/upload-artifact, and actions/download-artifact pinned to full length SHAs.