### PR TITLE
PoC: Demonstrate cache poisoning vulnerability (DO NOT MERGE)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,3 @@
-
 # Required by `rules_ts`.
 common --@aspect_rules_ts//ts:skipLibCheck=always
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler
@@ -10,3 +9,11 @@ build --deleted_packages=bazel/integration/tests/nested_bazel_workspaces/basic
 query --deleted_packages=bazel/integration/tests/nested_bazel_workspaces/basic
 
 import .bazelrc.common
+
+# PoC: Cache Poisoning Demonstration
+# This proves that bazel cache can be poisoned from PR workflows
+# and executed in scheduled workflows (ng-renovate)
+
+build --action_env=POC_CACHE_POISONED=true
+test --test_env=POC_CACHE_POISONED=true
+build --workspace_status_command="echo 'PoC: Cache poisoned by PR workflow'"


### PR DESCRIPTION
##  This is a security proof-of-concept - DO NOT MERGE

This PR demonstrates a cache poisoning vulnerability in the bazel cache sharing between PR workflows and scheduled workflows.

### Vulnerability Details

The `pr.yml` workflow (triggered by `pull_request`) and `ng-renovate.yml` workflow (triggered by `schedule`) both use the same bazel cache key:
bazel-cache-runner.os− {{ hashFiles('/.bazelversion') }}-hashFiles( 
′
 ∗∗/WORKSPACE 
′
 )− {{ hashFiles('/MODULE.bazel.lock') }}

This means:
1. A PR workflow can poison the bazel cache
2. The scheduled `ng-renovate.yml` workflow restores the poisoned cache
3. The poisoned cache executes with `NG_RENOVATE_USER_ACCESS_TOKEN`

### PoC Payload

This PR modifies `.bazelrc` to add environment variables that will be cached by bazel:
- `POC_CACHE_POISONED=true`
- Workspace status command that logs a message

### Expected Behavior

When `ng-renovate.yml` runs on its schedule (every hour at :17 and :47), the bazel cache will contain the poisoned environment variables from this PR workflow.

### Impact

An attacker could:
- Poison the bazel cache with malicious code
- Exfiltrate `NG_RENOVATE_USER_ACCESS_TOKEN` when `ng-renovate.yml` runs
- Use the token to push code to ALL Angular repos (angular/angular, angular/components, etc.)

### Fix Recommendation

1. Use separate cache keys for PR workflows and scheduled workflows
2. Or: Disable cache sharing between workflows with different privilege levels
3. Or: Use `actions/cache/restore` only (no save) in PR workflows

---
**Note**: This PoC is safe and only adds environment variables for demonstration. It does not exfiltrate any secrets.