### PR TITLE
fix(renovate-presets): remove wildcard from matchDepNames to fix renovate config error

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -62,7 +62,7 @@
     // Engines and packageManagers are excluded from this rule.
     {
       matchBaseBranches: ['!main'],
-      matchDepNames: ['*', '!node', '!pnpm', '!npm', '!yarn'],
+      matchDepNames: ['!node', '!pnpm', '!npm', '!yarn'],
       matchManagers: ['npm'],
       dependencyDashboardApproval: true,
     },
@@ -82,7 +82,7 @@
     // Group all non-major dependencies together for updates.
     {
       groupName: 'all non-major dependencies',
-      matchDepNames: ['*', '!node', '!pnpm', '!npm', '!yarn'],
+      matchDepNames: ['!node', '!pnpm', '!npm', '!yarn'],
       matchUpdateTypes: ['digest', 'patch', 'minor'],
       matchManagers: ['npm'],
       matchBaseBranches: ['main'],


### PR DESCRIPTION
Fixes #3847

In newer versions of Renovate, using a wildcard (`*`) alongside negated match patterns (`!node`, etc.) inside `matchDepNames` arrays causes a configuration validation error. Removing `*` resolves the preset loading failure.