### PR TITLE
fix: correct issue labeling action path

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: ./github-actions/issue-labeling
+      - uses: ./github-actions/labeling/issue
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
           google-generative-ai-key: ${{ secrets.GOOGLE_GENERATIVE_AI_KEY }}


### PR DESCRIPTION
Supersedes #3851.

## What changed
- update `.github/workflows/dev-infra.yml` to use the checked-in issue labeling action path

## Why
The `issues` job in the `DevInfra` workflow points at `./github-actions/issue-labeling`, but the local action actually lives at `./github-actions/labeling/issue`. That mismatch causes issue-triggered runs to fail before the labeling action starts.

## Validation
- confirmed `github-actions/labeling/issue/action.yml` exists in the repository
- inspected workflow run `29552379887`, which failed with: `Can't find 'action.yml' ... under '/home/runner/work/dev-infra/dev-infra/github-actions/issue-labeling'`
