### PR TITLE
feat(renovate-presets): restrict bazel dependencies group to non-major updates

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -103,6 +103,7 @@
     {
       groupName: 'bazel dependencies',
       matchManagers: ['bazel', 'bazel-module'],
+      matchUpdateTypes: ['digest', 'patch', 'minor'],
       schedule: ['* 6-10 * * 4'], // 6:00 am to 10:00 am Every Thursday
     },
 


### PR DESCRIPTION
Include `matchUpdateTypes` for digest, patch, and minor updates in the bazel dependencies group configuration.