### PR TITLE
feat(renovate-presets): pin GitHub Actions to SHA digests and ignore next tag for angular/dev-infra

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -1,6 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['mergeConfidence:all-badges', 'group:monorepos'],
+  extends: ['mergeConfidence:all-badges', 'group:monorepos', 'helpers:pinGitHubActionDigests'],
   dependencyDashboard: true,
   rangeStrategy: 'replace',
   automerge: false,
@@ -136,10 +136,10 @@
       ],
     },
 
-    // @angular/benchpress is not released as 'next'
+    // @angular/benchpress, @angular/dev-infra and angular/dev-infra are not released as 'next'
     {
       followTag: null,
-      matchDepNames: ['@angular/benchpress'],
+      matchDepNames: ['@angular/benchpress', '@angular/dev-infra', 'angular/dev-infra'],
     },
 
     // Disable 'next' tag tracking on non-main branches


### PR DESCRIPTION
### Description
Extends the `helpers:pinGitHubActionDigests` Renovate preset in `default.json5` to automatically pin GitHub Actions to immutable commit SHAs with a trailing version comment (e.g. `@<sha> # <sha>` or `@<sha> # <tag>`).

Additionally, configures `followTag: null` for `angular/dev-infra` since action references from `angular/dev-infra` do not publish a `next` tag.

### Changes
- **`renovate-presets/default.json5`**:
  - Add `'helpers:pinGitHubActionDigests'` to `extends` array.
  - Add package rule with `followTag: null` for `angular/dev-infra`.