### PR TITLE
ci: fix zizmor security analysis findings across workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,7 @@ name: 'CodeQL'
 
 on:
   push:
+  # zizmor: ignore[dangerous-triggers] - {Trigger is safe as workflow does not checkout untrusted code}
   pull_request_target:
   schedule:
     # Run every Sunday at 12:00

--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -1,6 +1,7 @@
 name: DevInfra
 
 on:
+  # zizmor: ignore[dangerous-triggers] - {Trigger is safe as workflow does not checkout untrusted code}
   pull_request_target:
     types: [opened, synchronize, reopened]
   issues:

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -33,10 +33,12 @@ jobs:
       # Step 1: Extract the ref of the running reusable workflow to use for checking out dev-infra actions.
       - name: Extract dev-infra ref
         id: get-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
         run: |
           # github.workflow_ref is of the form: "owner/repo/path/to/workflow.yml@ref"
           # Extract the ref (part after @)
-          REF=$(echo "${{ github.workflow_ref }}" | cut -d'@' -f2)
+          REF=$(echo "$WORKFLOW_REF" | cut -d'@' -f2)
           echo "ref=$REF" >> $GITHUB_OUTPUT
 
       # Checkout the calling repository first to ensure there is a .git directory at the root,

--- a/.github/workflows/rules_sass-compiler-updates.yml
+++ b/.github/workflows/rules_sass-compiler-updates.yml
@@ -6,8 +6,12 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch: # Allows you to trigger it manually.
 
+permissions: {}
+
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -38,6 +42,9 @@ jobs:
 
   create_pr:
     needs: build
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Zizmor reports security analysis findings on workflow triggers (`pull_request_target`), template expansions in `reusable-release.yml`, and missing permissions in `rules_sass-compiler-updates.yml`.

Issue Number: N/A

## What is the new behavior?

- Adds `# zizmor: ignore[dangerous-triggers] - {Trigger is safe as workflow does not checkout untrusted code}` to safe `pull_request_target` workflows (`codeql.yml` and `dev-infra.yml`).
- Resolves code injection via template expansion in `.github/workflows/reusable-release.yml` by using `$WORKFLOW_REF` environment variable.
- Defines explicit workflow and job permissions in `.github/workflows/rules_sass-compiler-updates.yml`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information