### PR TITLE
fix(ng-dev): prevent current working directory executable injection on Windows

### DIFF
--- a/ng-dev/cli.ts
+++ b/ng-dev/cli.ts
@@ -27,6 +27,12 @@ import {Argv} from 'yargs';
 
 runParserWithCompletedFunctions((yargs: Argv) => {
   process.exitCode = 0;
+
+  // Ensure Windows CreateProcess does not search the current directory for bare executable names.
+  if (process.platform === 'win32') {
+    process.env['NoDefaultCurrentDirectoryInExePath'] = '1';
+  }
+
   return yargs
     .scriptName('ng-dev')
     .middleware([captureLogOutputForCommand, ngDevVersionMiddleware], true)


### PR DESCRIPTION
Sets `NoDefaultCurrentDirectoryInExePath=1` during CLI initialization on Windows to ensure `CreateProcess` does not include the current working directory in the search path when resolving bare executable names.

Fixes #3897