### PR TITLE
feat(renovate-presets): allow scheduled updates for package managers

### DIFF
--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -67,6 +67,14 @@
       dependencyDashboardApproval: true,
     },
 
+    // Allow auto updates on non-main branches for pnpm, npm and yarn.
+    // These are scheduled to run once every Thursday.
+    {
+      matchBaseBranches: ['!main'],
+      matchDepNames: ['pnpm', 'npm', 'yarn'],
+      schedule: ['* 6-10 * * 4'], // 6:00 am to 10:00 am Every Thursday
+    },
+
     // Esbuild packages should be kept in sync.
     {
       groupName: 'esbuild dependencies',
@@ -88,7 +96,7 @@
     // Group all non-major dependencies together for updates.
     {
       groupName: 'all non-major dependencies',
-      matchDepNames: ['*', '!node', '!pnpm', '!npm', '!yarn'],
+      matchDepNames: ['*', '!node'],
       matchUpdateTypes: ['digest', 'patch', 'minor'],
       matchManagers: ['npm'],
       matchBaseBranches: ['main'],

--- a/renovate-presets/default.json5
+++ b/renovate-presets/default.json5
@@ -81,6 +81,12 @@
       matchPackageNames: ['esbuild', 'esbuild-wasm'],
     },
 
+    // Sass packages should be kept in sync.
+    {
+      groupName: 'sass dependencies',
+      matchPackageNames: ['sass', 'sass-embedded'],
+    },
+
     // Jasmine packages should be kept in sync.
     {
       groupName: 'jasmine dependencies',


### PR DESCRIPTION
Enable scheduled automated updates for package managers (`pnpm`, `npm`, and `yarn`):
- Add a package rule to allow updates on non-main branches scheduled every Thursday between 6:00 am and 10:00 am.
- Include package managers in the `all non-major dependencies` update group on `main`.