### PR TITLE
fix(bazel/rules_angular): emit rollup config through a single template substitution

### DIFF
--- a/bazel/rules/rules_angular/src/ng_package/angular_package_format.bzl
+++ b/bazel/rules/rules_angular/src/ng_package/angular_package_format.bzl
@@ -77,17 +77,22 @@ def _write_rollup_config(
     ctx.actions.expand_template(
         output = config,
         template = ctx.file._rollup_config_tmpl,
+        # Substitutions are applied sequentially over the accumulating template, so text inserted
+        # by one substitution is re-scanned by every later one. A single substitution carrying all
+        # values as one JSON object keeps rule inputs from being re-entered as placeholders.
         substitutions = {
-            "TMPL_banner_file": "\"%s\"" % ctx.file.license_banner.path if ctx.file.license_banner else "undefined",
-            "TMPL_module_mappings": str(mappings),
-            # TODO: Determine node_modules_root
-            "TMPL_node_modules_root": "node_modules",
-            "TMPL_metadata": json.encode(metadata_arg),
-            "TMPL_root_dir": root_dir,
-            "TMPL_workspace_name": ctx.workspace_name,
-            "TMPL_external": json.encode(externals),
-            "TMPL_side_effect_entrypoints": json.encode(side_effect_entry_points),
-            "TMPL_dts_mode": "true" if dts_mode else "false",
+            "TMPL_config": json.encode(struct(
+                bannerFile = ctx.file.license_banner.path if ctx.file.license_banner else None,
+                dtsMode = dts_mode,
+                entrypointMetadata = metadata_arg,
+                external = externals,
+                moduleMappings = mappings,
+                # TODO: Determine node_modules_root
+                nodeModulesRoot = "node_modules",
+                rootDir = root_dir,
+                sideEffectEntryPoints = side_effect_entry_points,
+                workspaceName = ctx.workspace_name,
+            )),
         },
     )
 

--- a/bazel/rules/rules_angular/src/ng_package/rollup/rollup.config.js
+++ b/bazel/rules/rules_angular/src/ng_package/rollup/rollup.config.js
@@ -60,15 +60,17 @@ function log_verbose(...m) {
   if (!!process.env['VERBOSE_LOGS']) console.error(`[${path.basename(__filename)}]`, ...m);
 }
 
-const workspaceName = 'TMPL_workspace_name';
-const rootDir = 'TMPL_root_dir';
-const bannerFile = TMPL_banner_file;
-const moduleMappings = TMPL_module_mappings;
-const nodeModulesRoot = 'TMPL_node_modules_root';
-const entrypointMetadata = JSON.parse(`TMPL_metadata`);
-const sideEffectEntryPoints = JSON.parse('TMPL_side_effect_entrypoints');
-const external = TMPL_external;
-const dtsMode = TMPL_dts_mode;
+const {
+  workspaceName,
+  rootDir,
+  bannerFile,
+  moduleMappings,
+  nodeModulesRoot,
+  entrypointMetadata,
+  sideEffectEntryPoints,
+  external,
+  dtsMode,
+} = TMPL_config;
 
 log_verbose(`running with
   cwd: ${process.cwd()}


### PR DESCRIPTION
`ctx.actions.expand_template` applies substitutions sequentially over the accumulating template, so text inserted by one substitution is re-scanned by every later one. An `externals` entry containing the literal placeholder name `TMPL_side_effect_entrypoints` therefore has a raw JSON array spliced into its string literal, injecting JavaScript into the generated rollup config. Full analysis and reproduction in #3958.

This collapses the nine substitutions into a single `TMPL_config` object, destructured in the template. With one substitution there is no later pass, so no inserted value can be re-entered as a placeholder.

Two incidental changes: `moduleMappings` moves from `str()` to `json.encode`, the correct encoding for a JavaScript literal; and `bannerFile` is now `null` rather than `undefined` when no banner is set, whose only use is the `if (bannerFile)` guard.

Verified: the reproduction in #3958 no longer executes, and `bazel test //...` in `bazel/rules/rules_angular` passes 9/9.

Fixes #3958.
