### PR TITLE
fix(ng-dev): release failing with latest pnpm version

### DIFF
--- a/ng-dev/utils/test/git-client.spec.ts
+++ b/ng-dev/utils/test/git-client.spec.ts
@@ -8,9 +8,8 @@
 import {GitClient} from '../git/git-client.js';
 import {AuthenticatedGitClient} from '../git/authenticated-git-client.js';
 import {Log} from '../logging.js';
-import {mockNgDevConfig} from '../testing/index.js';
+import {cleanTestTmpDir, mockNgDevConfig, testTmpDir} from '../testing/index.js';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 
 describe('GitClient validation', () => {
@@ -24,7 +23,7 @@ describe('GitClient validation', () => {
   };
 
   beforeEach(() => {
-    client = new GitClient(mockConfig as any, '/tmp');
+    client = new GitClient(mockConfig as any, testTmpDir);
   });
 
   describe('hasCommit', () => {
@@ -78,9 +77,12 @@ describe('GitClient sanitization', () => {
   let gitClient: GitClient;
   let logDebugSpy: jasmine.Spy;
   let stderrWriteSpy: jasmine.Spy;
-  const scriptPath = path.join(os.tmpdir(), 'mock-git-58c20eaf.sh');
+  let scriptPath: string;
 
   beforeEach(() => {
+    cleanTestTmpDir();
+    scriptPath = path.join(testTmpDir, 'mock-git.sh');
+
     // Write mock git script
     const scriptContent = `#!/bin/sh
 # shift 2 to get rid of -c credential.helper=
@@ -101,7 +103,7 @@ esac
     fs.writeFileSync(scriptPath, scriptContent);
     fs.chmodSync(scriptPath, 0o755);
 
-    gitClient = new GitClient(mockNgDevConfig, os.tmpdir());
+    gitClient = new GitClient(mockNgDevConfig, testTmpDir);
     (gitClient as any).gitBinPath = scriptPath; // Cast to any to override readonly
 
     logDebugSpy = spyOn(Log, 'debug');
@@ -148,7 +150,7 @@ esac
 
     it('should sanitize process error in logs if spawn fails', () => {
       // Force spawn failure by pointing to non-existent path
-      (gitClient as any).gitBinPath = path.join(os.tmpdir(), 'non-existent-path-58c20eaf');
+      (gitClient as any).gitBinPath = path.join(testTmpDir, 'non-existent-path');
       gitClient.runGraceful(['some-arg']);
 
       expect(logDebugSpy).toHaveBeenCalledWith('Process Error:', jasmine.stringMatching('ENOENT'));
@@ -165,7 +167,7 @@ esac
 describe('AuthenticatedGitClient sanitization', () => {
   class TestAuthenticatedGitClient extends AuthenticatedGitClient {
     constructor(token: string, config: any) {
-      super(token, 'user', config, os.tmpdir());
+      super(token, 'user', config, testTmpDir);
     }
   }
 

--- a/ng-dev/utils/test/version-check.spec.ts
+++ b/ng-dev/utils/test/version-check.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Copyright Google LLC
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import fs from 'fs';
+import path from 'path';
+import {cleanTestTmpDir, testTmpDir} from '../testing/index.js';
+import {Prompt} from '../prompt.js';
+import {GitClient} from '../git/git-client.js';
+import {extractNgDevVersionFromPnpmLock, verifyNgDevToolIsUpToDate} from '../version-check.js';
+
+describe('extractNgDevVersionFromPnpmLock', () => {
+  it('should extract ng-dev version from a single-document pnpm-lock.yaml', () => {
+    const lockfile = `
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    devDependencies:
+      '@angular/ng-dev':
+        specifier: ^18.0.0
+        version: 18.0.0
+
+packages:
+  '@angular/ng-dev@18.0.0':
+    resolution: {integrity: sha512-test==}
+    version: 18.0.0
+`;
+
+    expect(extractNgDevVersionFromPnpmLock(lockfile)).toBe('18.0.0');
+  });
+
+  it('should extract ng-dev version from a multi-document pnpm-lock.yaml', () => {
+    const lockfile = `
+---
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-test==}
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+
+importers:
+  .:
+    devDependencies:
+      '@angular/ng-dev':
+        specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#2fe8cf97ca7d7f1616c3f29e910dde3a7ac5b981
+        version: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/2fe8cf97ca7d7f1616c3f29e910dde3a7ac5b981(@modelcontextprotocol/sdk@1.30.0(supports-color@11.0.0))
+
+packages:
+  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/2fe8cf97ca7d7f1616c3f29e910dde3a7ac5b981':
+    resolution: {gitHosted: true}
+    version: 0.0.0-183403ae13b785698eaf13c819dda55b9fed430b
+`;
+
+    expect(extractNgDevVersionFromPnpmLock(lockfile)).toBe(
+      '0.0.0-183403ae13b785698eaf13c819dda55b9fed430b',
+    );
+  });
+
+  it('should extract ng-dev version when listed in dependencies', () => {
+    const lockfile = `
+---
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+---
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      '@angular/ng-dev':
+        specifier: 19.0.0
+        version: 19.0.0
+
+packages:
+  '@angular/ng-dev@19.0.0':
+    version: 19.0.0
+`;
+
+    expect(extractNgDevVersionFromPnpmLock(lockfile)).toBe('19.0.0');
+  });
+
+  it('should extract ng-dev version when depEntry is a string (older lockfile format)', () => {
+    const lockfile = `
+lockfileVersion: '5.4'
+
+importers:
+  .:
+    dependencies:
+      '@angular/ng-dev': 17.0.0
+
+packages:
+  '@angular/ng-dev@17.0.0':
+    version: 17.0.0
+`;
+
+    expect(extractNgDevVersionFromPnpmLock(lockfile)).toBe('17.0.0');
+  });
+
+  it('should handle depEntry object with missing version gracefully without throwing', () => {
+    const lockfile = `
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      '@angular/ng-dev':
+        specifier: ^18.0.0
+`;
+
+    expect(extractNgDevVersionFromPnpmLock(lockfile)).toBeNull();
+  });
+
+  it('should return null if ng-dev is not present in lockfile', () => {
+    const lockfile = `
+lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      tslib:
+        specifier: ^2.0.0
+        version: 2.5.0
+`;
+
+    expect(extractNgDevVersionFromPnpmLock(lockfile)).toBeNull();
+  });
+
+  it('should throw an error for invalid YAML syntax', () => {
+    const lockfile = `
+invalid: yaml: :
+`;
+
+    expect(() => extractNgDevVersionFromPnpmLock(lockfile)).toThrow();
+  });
+});
+
+describe('verifyNgDevToolIsUpToDate', () => {
+  let gitClientMock: any;
+
+  beforeEach(() => {
+    cleanTestTmpDir();
+    fs.writeFileSync(
+      path.join(testTmpDir, 'package.json'),
+      JSON.stringify({name: 'test-project', version: '1.0.0'}),
+    );
+
+    gitClientMock = {
+      remoteConfig: {name: 'repo', owner: 'owner', mainBranchName: 'main'},
+      github: {
+        repos: {
+          getContent: jasmine.createSpy('getContent'),
+        },
+      },
+    };
+    spyOn(GitClient, 'get').and.returnValue(Promise.resolve(gitClientMock as any));
+  });
+
+  it('should prompt user to continue when extracting version fails and return true if confirmed', async () => {
+    gitClientMock.github.repos.getContent.and.rejectWith(new Error('Network error'));
+    spyOn(Prompt, 'confirm').and.returnValue(Promise.resolve(true));
+
+    const result = await verifyNgDevToolIsUpToDate(testTmpDir);
+
+    expect(Prompt.confirm).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        message: 'Do you want to continue anyway?',
+        default: false,
+      }),
+    );
+    expect(result).toBeTrue();
+  });
+
+  it('should return false when extracting version fails and user declines prompt', async () => {
+    gitClientMock.github.repos.getContent.and.rejectWith(new Error('Network error'));
+    spyOn(Prompt, 'confirm').and.returnValue(Promise.resolve(false));
+
+    const result = await verifyNgDevToolIsUpToDate(testTmpDir);
+
+    expect(Prompt.confirm).toHaveBeenCalled();
+    expect(result).toBeFalse();
+  });
+});

--- a/ng-dev/utils/version-check.ts
+++ b/ng-dev/utils/version-check.ts
@@ -8,12 +8,13 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
-import {parse as parseYaml} from 'yaml';
+import {parseAllDocuments} from 'yaml';
 import {workspaceRelativePackageJsonPath} from './constants.js';
 import {Log} from './logging.js';
 import {tryGetPackageId} from '@pnpm/dependency-path';
 import {determineRepoBaseDirFromCwd} from './repo-directory.js';
 import {GitClient} from './git/git-client.js';
+import {Prompt} from './prompt.js';
 
 /**
  * The currently executing version of ng-dev
@@ -55,7 +56,15 @@ export async function verifyNgDevToolIsUpToDate(workspacePath: string): Promise<
 
   Log.debug('Checking ng-dev version in lockfile and in the running script:');
   Log.debug(`  Local: ${localVersion}`);
-  Log.debug(`  Expected: ${expectedVersion}`);
+  Log.debug(`  Expected: ${expectedVersion ?? 'unknown'}`);
+
+  if (expectedVersion === null) {
+    Log.warn('  ⚠   Could not extract the expected `ng-dev` version from `pnpm-lock.yaml`.');
+    return await Prompt.confirm({
+      message: 'Do you want to continue anyway?',
+      default: false,
+    });
+  }
 
   if (localVersion !== expectedVersion) {
     Log.warn('  ⚠   Your locally installed version of the `ng-dev` tool is outdated and not');
@@ -68,7 +77,7 @@ export async function verifyNgDevToolIsUpToDate(workspacePath: string): Promise<
 }
 
 /** Retrieves the pnpm lock file from upstream on the primary branch and extracts the version. */
-async function getExpectedVersionFromPnpmLockUpstream(): Promise<string> {
+async function getExpectedVersionFromPnpmLockUpstream(): Promise<string | null> {
   const git = await GitClient.get();
   try {
     const {data} = await git.github.repos.getContent({
@@ -84,19 +93,58 @@ async function getExpectedVersionFromPnpmLockUpstream(): Promise<string> {
         `A non-single file of content was retrieved from Github when the pnpm-lock.yaml file was requested`,
       );
     }
-    const lockFile = parseYaml(
-      Buffer.from(data.content, data.encoding as BufferEncoding).toString('utf-8'),
-    );
-    const importers = lockFile['importers']['.'];
-    const depEntry =
-      importers.dependencies?.['@angular/ng-dev'] ??
-      importers.devDependencies?.['@angular/ng-dev'] ??
-      importers.optionalDependencies?.['@angular/ng-dev'];
-    const packageId = tryGetPackageId(depEntry.version);
+    const content = Buffer.from(data.content, data.encoding as BufferEncoding).toString('utf-8');
+    const expectedVersion = extractNgDevVersionFromPnpmLock(content);
+    if (expectedVersion === null) {
+      throw Error('Could not find @angular/ng-dev entry in pnpm-lock.yaml');
+    }
 
-    return lockFile['packages'][`@angular/ng-dev@${packageId}`].version;
+    return expectedVersion;
   } catch (e) {
     Log.debug('Could not find expected ng-dev version from `pnpm-lock.yaml` file:', e);
-    return 'unknown';
+    return null;
   }
+}
+
+/**
+ * Extracts the expected `@angular/ng-dev` version from the content of a `pnpm-lock.yaml` file.
+ * Supports both single-document and multi-document YAML formats.
+ */
+export function extractNgDevVersionFromPnpmLock(content: string): string | null {
+  const documents = parseAllDocuments(content);
+  for (const doc of documents) {
+    if (doc.errors.length > 0) {
+      throw doc.errors[0];
+    }
+  }
+
+  const lockFiles = documents.map((doc) => doc.toJS());
+
+  for (const lockFile of lockFiles) {
+    const importers = lockFile?.['importers']?.['.'];
+    const depEntry =
+      importers?.dependencies?.['@angular/ng-dev'] ??
+      importers?.devDependencies?.['@angular/ng-dev'] ??
+      importers?.optionalDependencies?.['@angular/ng-dev'];
+    if (!depEntry) {
+      continue;
+    }
+    const depEntryVersion =
+      typeof depEntry === 'object' && depEntry !== null ? depEntry.version : depEntry;
+    if (typeof depEntryVersion !== 'string' || !depEntryVersion) {
+      continue;
+    }
+    const packageId = tryGetPackageId(depEntryVersion as any) ?? depEntryVersion;
+
+    for (const file of lockFiles) {
+      const version =
+        file?.['packages']?.[`@angular/ng-dev@${packageId}`]?.version ??
+        file?.['packages']?.[`@angular/ng-dev@${depEntryVersion}`]?.version;
+      if (version) {
+        return version;
+      }
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
The latest version of pnpm prepends a section to the lockfile that breaks our parser which in turn prevents the release from running.