### PR TITLE
fix(ng-dev): breaking change in pnpm silent flag

### DIFF
--- a/ng-dev/release/publish/external-commands.ts
+++ b/ng-dev/release/publish/external-commands.ts
@@ -358,7 +358,7 @@ export abstract class ExternalCommands {
     spawnOptions: SpawnOptions = {},
   ): Promise<SpawnResult> {
     if (PnpmVersioning.isUsingPnpm(projectDir)) {
-      return ChildProcess.spawn('pnpm', ['-s', ...args], {
+      return ChildProcess.spawn('pnpm', ['--silent', ...args], {
         ...spawnOptions,
         cwd: projectDir,
       });


### PR DESCRIPTION
The `-s` flag is no longer valid in pnpm 12, we need to use `--silent`.